### PR TITLE
Fix: DiscoveryReconciler does not remove secrets

### DIFF
--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -66,9 +66,9 @@ func (r *DiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.V(1).Info("Discovery is being deleted")
 		r.Recorder.Event(res, corev1.EventTypeWarning, "Deleting", "Discovery is being deleted, cleaning up worker")
 
-		// Cleanup worker, if exists
-		if err := r.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: res.Namespace, Name: res.Name}}); err != nil && !apierrors.IsNotFound(err) {
-			return ctrlResult, errLogAndWrap(log, err, "pod deletion failed")
+		// Cleanup worker resources, if exists
+		if err := r.deleteWorkerResources(ctx, res); err != nil {
+			return ctrlResult, errLogAndWrap(log, err, "failed to clean up worker resources")
 		}
 
 		// Remove finalizer
@@ -104,7 +104,7 @@ func (r *DiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// No pod yet, create it.
 	if pod == nil || pod.Name == "" {
-		if err := r.createPod(ctx, res); err != nil {
+		if err := r.createWorkerResources(ctx, res); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to create pod")
 		}
 		return ctrlResult, nil
@@ -114,15 +114,11 @@ func (r *DiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if res.Status.PodGeneration != res.GetGeneration() {
 		// Recreate pod, configuration mismatch
 		r.Recorder.Eventf(res, corev1.EventTypeNormal, "Reconcile", "Configuration changed. Replacing pod.")
-		if err := r.ClientSet.CoreV1().Secrets(res.Namespace).Delete(ctx, discoveryPrefixed(res.Name), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			r.Recorder.Eventf(res, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete secret", err)
-			return ctrlResult, errLogAndWrap(log, err, "secret deletion failed")
+		if err := r.deleteWorkerResources(ctx, res); err != nil {
+			return ctrlResult, errLogAndWrap(log, err, "failed to clean up worker resources")
 		}
-		if err := r.ClientSet.CoreV1().Pods(res.Namespace).Delete(ctx, discoveryPrefixed(res.Name), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			r.Recorder.Eventf(res, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete pod", err)
-			return ctrlResult, errLogAndWrap(log, err, "pod deletion failed")
-		}
-		if err := r.createPod(ctx, res); err != nil {
+
+		if err := r.createWorkerResources(ctx, res); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to create pod")
 		}
 		return ctrlResult, nil
@@ -130,13 +126,27 @@ func (r *DiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.V(1).Info("Configuration hasn't changed", "podGen", res.Status.PodGeneration, "gen", res.GetGeneration())
 	}
 
-	// TODO: Check pods health
-
 	return ctrlResult, nil
 }
 
-// createPod creates a new pod for the given discovery resource
-func (r *DiscoveryReconciler) createPod(ctx context.Context, res *solarv1alpha1.Discovery) error {
+// deleteWorkerResources deletes the resources of the worker pod
+func (r *DiscoveryReconciler) deleteWorkerResources(ctx context.Context, res *solarv1alpha1.Discovery) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if err := r.ClientSet.CoreV1().Secrets(res.Namespace).Delete(ctx, discoveryPrefixed(res.Name), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		r.Recorder.Eventf(res, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete secret", err)
+		return errLogAndWrap(log, err, "secret deletion failed")
+	}
+	if err := r.ClientSet.CoreV1().Pods(res.Namespace).Delete(ctx, discoveryPrefixed(res.Name), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		r.Recorder.Eventf(res, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete pod", err)
+		return errLogAndWrap(log, err, "pod deletion failed")
+	}
+
+	return nil
+}
+
+// createWorkerResources creates the necessary resources for the worker pod
+func (r *DiscoveryReconciler) createWorkerResources(ctx context.Context, res *solarv1alpha1.Discovery) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Create secret
@@ -223,6 +233,11 @@ func (r *DiscoveryReconciler) createPod(ctx context.Context, res *solarv1alpha1.
 	return nil
 }
 
+// discoveryPrefixed returns the name of the discovery prefixed resource
+func discoveryPrefixed(discoveryName string) string {
+	return fmt.Sprintf("discovery-%s", discoveryName)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *DiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -230,8 +245,4 @@ func (r *DiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.Secret{}).
 		Complete(r)
-}
-
-func discoveryPrefixed(discoveryName string) string {
-	return fmt.Sprintf("discovery-%s", discoveryName)
 }


### PR DESCRIPTION
Refactor the DiscoveryReconciler to utilize dedicated methods for managing worker resources, enhancing code clarity and maintainability. This change streamlines the cleanup and creation processes for worker-related resources.

Closes #91.