### PR TITLE
Add missing return statement in Reconcile method of DiscoveryReconciler

### DIFF
--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -81,6 +81,7 @@ func (r *DiscoveryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrlResult, errLogAndWrap(log, err, "failed to remove finalizer")
 			}
 		}
+		return ctrlResult, nil
 	}
 
 	// Add finalizer if not present and not deleting


### PR DESCRIPTION
Include a return statement to ensure proper handling of the reconciliation result in the DiscoveryReconciler.