### PR TITLE
Replace deprecated GetEventRecorderFor

### DIFF
--- a/cmd/solar-controller-manager/main.go
+++ b/cmd/solar-controller-manager/main.go
@@ -187,11 +187,9 @@ func main() {
 
 	// Register controllers
 	if err := (&controller.DiscoveryReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		// FIXME: GetEventRecorderFor is deprecated, see issue solar#123
-		// nolint:staticcheck
-		Recorder:      mgr.GetEventRecorderFor("discovery-controller"),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorder("discovery-controller"),
 		WorkerImage:   workerImage,
 		WorkerCommand: workerCommand,
 	}).SetupWithManager(mgr); err != nil {
@@ -199,11 +197,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.TargetReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		// FIXME: GetEventRecorderFor is deprecated, see issue solar#123
-		// nolint:staticcheck
-		Recorder: mgr.GetEventRecorderFor("target-controller"),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorder("target-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "target")
 		os.Exit(1)

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +39,7 @@ const (
 var (
 	k8sClient    client.Client
 	testEnv      *envtest.Environment
-	fakeRecorder *record.FakeRecorder
+	fakeRecorder *events.FakeRecorder
 )
 
 func TestController(t *testing.T) {
@@ -80,7 +80,7 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(cancel)
 
 	// log all events to GinkgoWriter
-	fakeRecorder = record.NewFakeRecorder(1)
+	fakeRecorder = events.NewFakeRecorder(1)
 	go func() {
 		for event := range fakeRecorder.Events {
 			logf.Log.Info(fmt.Sprintf("Event: %s", event))


### PR DESCRIPTION
The `GetEventRecorderFor` function was deprecated in the latest K8s update. Per the documentation:

```
// Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
```

I have replaced `GetEventRecorderFor` with `GetEventRecorder`. The latter returns an `EventRecorder` object from a different package, which has a slightly different signature for `Eventf`. I have adjusted the `Eventf` calls, passing a second resource object where applicable or `nil` and a new action string (alongside to reason).

Closes https://github.com/opendefensecloud/solution-arsenal/issues/123.