### PR TITLE
Add service resource access to discovery controller

### DIFF
--- a/charts/solar/files/role.yaml
+++ b/charts/solar/files/role.yaml
@@ -16,6 +16,7 @@ rules:
   resources:
   - pods
   - secrets
+  - services
   verbs:
   - create
   - delete

--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -43,6 +43,7 @@ type DiscoveryReconciler struct {
 // +kubebuilder:rbac:groups=solar.opendefense.cloud,resources=discoveries/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile moves the current state of the cluster closer to the desired state


### PR DESCRIPTION
Enhance the discovery controller by adding service resource access permissions, allowing for create, delete, and management operations on services.