### PR TITLE
fix: Add missing prefix wrapper

### DIFF
--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -255,7 +255,7 @@ func (r *DiscoveryReconciler) createWorkerResources(ctx context.Context, res *so
 					Name: "config",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: res.Name,
+							SecretName: discoveryPrefixed(res.Name),
 						},
 					},
 				},


### PR DESCRIPTION
Wrapper was used while creating secret but not on the volume mount.