### PR TITLE
Add api writer to discovery

### DIFF
--- a/pkg/discovery/pipeline/pipeline.go
+++ b/pkg/discovery/pipeline/pipeline.go
@@ -153,25 +153,25 @@ func WithScanner(s scanner.Scanner) Option {
 	}
 }
 
-func WithQualifierProcessor[InputEvent any, OutputEvent any](proc discovery.Processor[discovery.RepositoryEvent, discovery.ComponentVersionEvent]) Option {
+func WithQualifierProcessor(proc discovery.Processor[discovery.RepositoryEvent, discovery.ComponentVersionEvent]) Option {
 	return func(p *Pipeline) {
 		p.qualifier.Runner.Processor = proc
 	}
 }
 
-func WithFilterProcessor[InputEvent any, OutputEvent any](proc discovery.Processor[discovery.ComponentVersionEvent, discovery.ComponentVersionEvent]) Option {
+func WithFilterProcessor(proc discovery.Processor[discovery.ComponentVersionEvent, discovery.ComponentVersionEvent]) Option {
 	return func(p *Pipeline) {
 		p.filter.Runner.Processor = proc
 	}
 }
 
-func WithHandlerProcessor[InputEvent any, OutputEvent any](proc discovery.Processor[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent]) Option {
+func WithHandlerProcessor(proc discovery.Processor[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent]) Option {
 	return func(p *Pipeline) {
 		p.handler.Runner.Processor = proc
 	}
 }
 
-func WithWriterProcessor[InputEvent any, OutputEvent any](proc discovery.Processor[discovery.WriteAPIResourceEvent, any]) Option {
+func WithWriterProcessor(proc discovery.Processor[discovery.WriteAPIResourceEvent, any]) Option {
 	return func(p *Pipeline) {
 		p.writer.Runner.Processor = proc
 	}

--- a/pkg/discovery/pipeline/pipeline_test.go
+++ b/pkg/discovery/pipeline/pipeline_test.go
@@ -194,10 +194,10 @@ var _ = Describe("Pipeline", Ordered, func() {
 
 			p, err := NewPipeline("default", regProv, "127.0.0.1:0", errChan, log,
 				WithScanner(scanner),
-				WithQualifierProcessor[discovery.RepositoryEvent, discovery.ComponentVersionEvent](qualifier),
-				WithFilterProcessor[discovery.ComponentVersionEvent, discovery.ComponentVersionEvent](filter),
-				WithHandlerProcessor[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent](handler),
-				WithWriterProcessor[discovery.WriteAPIResourceEvent, any](writer),
+				WithQualifierProcessor(qualifier),
+				WithFilterProcessor(filter),
+				WithHandlerProcessor(handler),
+				WithWriterProcessor(writer),
 			)
 			Expect(err).NotTo(HaveOccurred())
 			err = p.Start(ctx)


### PR DESCRIPTION
Integrates the APIWriter into the discovery pipeline. Closes #193.

Minor adjustment for proper error handling during pipeline start included which also addresses 4. of #189.