### PR TITLE
Don't use `-a` flag for go build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,5 +84,3 @@ jobs:
           target: ${{ matrix.image.target }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            GO_BUILD_FLAGS=-a


### PR DESCRIPTION
## Issue

- [ ] [Solution Arsenal xx](https://github.com/opendefensecloud/solution-arsenal/issues/xx)
- [ ] Internal
- [x] Chore
- [ ] Hotfix

## Description

Currently re-building the controller images can take up to multiple minutes per image. This is mostly because we pass the `-a` go build arg, which forces packages to be rebuilt that are already up to date.

We should only use `-a` for production images in order to keep local development nice and fast.

## Checklist
- [ ] PR required dependency updates 
- [ ] I've added tests that cover the changes
- [ ] I've updated the documentation to reflect the new behavior

## Additional Authors

<!-- Mention additional authors or teams here using @username syntax -->

## Logs

`make dev-cluster-rebuild` before this change:

```console
$ time make dev-cluster-rebuild
make APISERVER_IMG=localhost/local/solar-apiserver:dev.20260225084940 docker-build-apiserver
docker build --target apiserver -t localhost/local/solar-apiserver:dev.20260225084940 .
[+] Building 127.3s (20/20) FINISHED                                                     docker:default
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 2.60kB                                                             0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                  0.3s
 => [internal] load metadata for docker.io/library/golang:1.26                                     0.2s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [builder  1/11] FROM docker.io/library/golang:1.26@sha256:9edf71320ef8a791c4c33ec79f90496d641  0.0s
 => => resolve docker.io/library/golang:1.26@sha256:9edf71320ef8a791c4c33ec79f90496d641f306a91fb1  0.0s
 => CACHED [apiserver 1/3] FROM gcr.io/distroless/static:nonroot@sha256:01e550fdb7ab79ee7be5ff440  0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 15.31kB                                                               0.0s
 => CACHED [builder  2/11] WORKDIR /workspace                                                      0.0s
 => CACHED [builder  3/11] RUN go env -w GOMODCACHE=/root/.cache/go-build                          0.0s
 => CACHED [builder  4/11] COPY go.mod go.mod                                                      0.0s
 => CACHED [builder  5/11] COPY go.sum go.sum                                                      0.0s
 => CACHED [builder  6/11] RUN --mount=type=cache,target=/root/.cache/go-build go mod download     0.0s
 => CACHED [builder  7/11] COPY api/ api/                                                          0.0s
 => CACHED [builder  8/11] COPY client-go/ client-go/                                              0.0s
 => CACHED [builder  9/11] COPY cmd/ cmd/                                                          0.0s
 => CACHED [builder 10/11] COPY pkg/ pkg/                                                          0.0s
 => CACHED [builder 11/11] RUN mkdir bin                                                           0.0s
 => [apiserver-builder 1/1] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=typ  126.7s
 => [apiserver 2/3] COPY --from=apiserver-builder /workspace/bin/solar-apiserver .                 0.1s
 => exporting to image                                                                             0.2s
 => => exporting layers                                                                            0.2s
 => => writing image sha256:5e6ef7474797b434ab59614ac17703d4c58f883001c6240467fa881a85736201       0.0s
 => => naming to localhost/local/solar-apiserver:dev.20260225084940                                0.0s
make MANAGER_IMG=localhost/local/solar-controller-manager:dev.20260225084940 docker-build-manager

...

real	10m8,279s
user	0m3,249s
sys	0m2,499s
```

And after the change

```console
$ time make dev-cluster-rebuild
make APISERVER_IMG=localhost/local/solar-apiserver:dev.20260225090421 docker-build-apiserver
docker build --target apiserver -t localhost/local/solar-apiserver:dev.20260225090421 .
[+] Building 3.6s (21/21) FINISHED                                                       docker:default
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 2.68kB                                                             0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                  0.3s
 => [internal] load metadata for docker.io/library/golang:1.26                                     0.6s
 => [auth] library/golang:pull token for registry-1.docker.io                                      0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [builder  1/11] FROM docker.io/library/golang:1.26@sha256:9edf71320ef8a791c4c33ec79f90496d641  0.0s
 => => resolve docker.io/library/golang:1.26@sha256:9edf71320ef8a791c4c33ec79f90496d641f306a91fb1  0.0s
 => [apiserver 1/3] FROM gcr.io/distroless/static:nonroot@sha256:01e550fdb7ab79ee7be5ff440a563a58  0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 15.31kB                                                               0.0s
 => CACHED [builder  2/11] WORKDIR /workspace                                                      0.0s
 => CACHED [builder  3/11] RUN go env -w GOMODCACHE=/root/.cache/go-build                          0.0s
 => CACHED [builder  4/11] COPY go.mod go.mod                                                      0.0s
 => CACHED [builder  5/11] COPY go.sum go.sum                                                      0.0s
 => CACHED [builder  6/11] RUN --mount=type=cache,target=/root/.cache/go-build go mod download     0.0s
 => CACHED [builder  7/11] COPY api/ api/                                                          0.0s
 => CACHED [builder  8/11] COPY client-go/ client-go/                                              0.0s
 => CACHED [builder  9/11] COPY cmd/ cmd/                                                          0.0s
 => CACHED [builder 10/11] COPY pkg/ pkg/                                                          0.0s
 => CACHED [builder 11/11] RUN mkdir bin                                                           0.0s
 => [apiserver-builder 1/1] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=  2.9s
 => CACHED [apiserver 2/3] COPY --from=apiserver-builder /workspace/bin/solar-apiserver .          0.0s
 => exporting to image                                                                             0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:5e6ef7474797b434ab59614ac17703d4c58f883001c6240467fa881a85736201       0.0s
 => => naming to localhost/local/solar-apiserver:dev.20260225090421                                0.0s

...

real	0m13,948s
user	0m1,355s
sys	0m0,589s

```