### PR TITLE
Add permissions for profiles in target controller

### DIFF
--- a/charts/solar/files/role.yaml
+++ b/charts/solar/files/role.yaml
@@ -92,3 +92,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - profiles
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -41,6 +41,7 @@ type TargetReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets/finalizers,verbs=update
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=hydratedtargets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile moves the current state of the cluster closer to the desired state


### PR DESCRIPTION
Target controller now watches profiles and adds them to hydrated targets.

Relates to https://github.com/opendefensecloud/solution-arsenal/issues/171.