### PR TITLE
Test e2e that profiles are added to hydrated targets

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,7 +20,8 @@ const namespace = "solar-system"
 
 var _ = Describe("solar", Ordered, func() {
 	var controllerPodName string
-	// dir, _ := getProjectDir()
+	dir, err := getProjectDir()
+	Expect(err).NotTo(HaveOccurred())
 
 	// Before running the tests, set up the environment by creating the namespace,
 	// enforce the restricted security policy to the namespace, installing CRDs,
@@ -39,8 +40,6 @@ var _ = Describe("solar", Ordered, func() {
 		// Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
 		By("deploying apiserver and controller-manager")
-		dir, err := getProjectDir()
-		Expect(err).NotTo(HaveOccurred())
 		cmd = exec.Command(helmBinary, "upgrade", "--install",
 			"--namespace", namespace, "solar", filepath.Join(dir, "charts", "solar"),
 			"--set", "fullnameOverride=solar",
@@ -142,10 +141,26 @@ var _ = Describe("solar", Ordered, func() {
 			Eventually(verifyAPIServicesAvailable).Should(Succeed())
 		})
 
-		It("should create catalog item", func() {
-			// cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", filepath.Join(dir, "examples", "catalogitem.yaml"))
-			// _, err := run(cmd)
-			// Expect(err).NotTo(HaveOccurred())
+		It("should create targets", func() {
+			Expect(applyResource("default", filepath.Join(dir, "test", "fixtures", "e2e", "target.yaml"))).To(Succeed())
+		})
+
+		It("should create profiles in hydrated target", func() {
+			Expect(applyResource("default", filepath.Join(dir, "test", "fixtures", "e2e", "profile.yaml"))).To(Succeed())
+
+			// Verify that the profile has been added to the hydrated target
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "-n", "default", "hydratedtarget", "cluster-1", "-o", "jsonpath='{.spec.profiles.*}'")
+				output, err := run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("production"))
+			}).Should(Succeed())
 		})
 	})
 })
+
+func applyResource(namespace, file string) error {
+	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", file)
+	_, err := run(cmd)
+	return err
+}

--- a/test/fixtures/e2e/profile.yaml
+++ b/test/fixtures/e2e/profile.yaml
@@ -1,0 +1,8 @@
+apiVersion: solar.opendefense.cloud/v1alpha1
+kind: Profile
+metadata:
+  name: production
+spec:
+  targetSelector:
+    matchLabels:
+      env: prod

--- a/test/fixtures/e2e/target.yaml
+++ b/test/fixtures/e2e/target.yaml
@@ -1,0 +1,7 @@
+apiVersion: solar.opendefense.cloud/v1alpha1
+kind: Target
+metadata:
+  name: cluster-1
+  labels:
+    env: prod
+spec:


### PR DESCRIPTION
The e2e test suite is intended to create `It` specs that depend on each other. I stuck with that approach. When adding more tests their `It` specs should be integrated as needed (and not just appended) or existing `It` specs extended. (Unless we change the overall approach.)

I also stuck with the current approach using `exec.Command` for simplicity for now. 

Closes https://github.com/opendefensecloud/solution-arsenal/issues/171.