### PR TITLE
Stop sending discovery event processing errors to error chan

### DIFF
--- a/pkg/discovery/runner.go
+++ b/pkg/discovery/runner.go
@@ -5,6 +5,7 @@ package discovery
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"time"
 
@@ -25,7 +26,8 @@ type RunnerOption[InputEvent any, OutputEvent any] func(r *Runner[InputEvent, Ou
 // WithLogger sets the logger for the Runner.
 func WithLogger[InputEvent any, OutputEvent any](l logr.Logger) RunnerOption[InputEvent, OutputEvent] {
 	return func(r *Runner[InputEvent, OutputEvent]) {
-		r.logger = l
+		pt := reflect.TypeOf(r.Processor).String()
+		r.logger = l.WithValues("processor", pt)
 	}
 }
 
@@ -124,14 +126,14 @@ func (r *Runner[InputEvent, OutputEvent]) processEvent(ctx context.Context, ev I
 
 	if r.rateLimiter != nil {
 		if err := r.rateLimiter.Wait(ctx); err != nil {
-			r.handleError(err, "rate limiter wait failed")
+			r.logger.Error(err, "rate limiter wait failed")
 			return
 		}
 	}
 
 	outputEvents, err := r.Processor.Process(ctx, ev)
 	if err != nil {
-		r.handleError(err, "failed to process event", "event", ev)
+		r.logger.Error(err, "failed to process event", "event", ev)
 		return
 	}
 
@@ -148,14 +150,6 @@ func (r *Runner[InputEvent, OutputEvent]) processEvent(ctx context.Context, ev I
 		r.logger.V(1).Info("publishing output event", "outputEvent", outputEv)
 		Publish(&r.logger, r.outputChan, outputEv)
 	}
-}
-
-func (r *Runner[InputEvent, OutputEvent]) handleError(err error, msg string, keysAndValues ...any) {
-	Publish(&r.logger, r.errChan, ErrorEvent{
-		Error:     err,
-		Timestamp: time.Now().UTC(),
-	})
-	r.logger.Error(err, msg, keysAndValues...)
 }
 
 func (r *Runner[InputEvent, OutputEvent]) Logger() logr.Logger {


### PR DESCRIPTION
The errors are now only logged. Currently, the error chan is supposed to be used for non-recoverable errors.

Closes https://github.com/opendefensecloud/solution-arsenal/issues/224.