### PR TITLE
Fix error handling in zot webhook handler

### DIFF
--- a/pkg/discovery/webhook/zot/zot.go
+++ b/pkg/discovery/webhook/zot/zot.go
@@ -4,7 +4,7 @@
 package zot
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -42,49 +42,36 @@ func NewHandler(registry *discovery.Registry, out chan<- discovery.RepositoryEve
 }
 
 type ZotEventData struct {
-	Name      string   `json:"name"`
-	Reference string   `json:"reference"`
-	Digest    string   `json:"digest"`
-	Manifest  Manifest `json:"manifest"`
-	MediaType string   `json:"mediaType"`
-}
-
-type Manifest struct {
-	SchemaVersion int    `json:"schemaVersion"`
-	MediaType     string `json:"mediaType,omitempty"`
-	Config        Config `json:"config"`
-}
-
-type Config struct {
-	MediaType string  `json:"mediaType,omitempty"`
-	Size      int     `json:"size,omitempty"`
-	Digest    string  `json:"digest,omitempty"`
-	Layers    []Layer `json:"layers,omitempty"`
-}
-
-type Layer struct {
-	MediaType string `json:"mediaType,omitempty"`
-	Size      int    `json:"size,omitempty"`
-	Digest    string `json:"digest,omitempty"`
+	Name      string `json:"name"`
+	Reference string `json:"reference"`
+	Digest    string `json:"digest"`
+	Manifest  string `json:"manifest"`
+	MediaType string `json:"mediaType"`
 }
 
 func (wh *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := logr.FromContextOrDiscard(r.Context())
-	logger.Info(fmt.Sprintf("this is zot handling request to %s", r.URL.Path))
+	logger.Info("handling request", "path", r.URL.Path)
 
 	cloudEvent, err := cloudevents.NewEventFromHTTPRequest(r)
 	if err != nil {
-		msg := fmt.Sprintf("failed to parse CloudEvent from request: %v", err)
-		http.Error(w, msg, http.StatusBadRequest)
-		logger.Info(msg)
+		logger.Error(err, "failed to parse CloudEvent from request")
+		http.Error(w, "invalid cloud event", http.StatusBadRequest)
 
 		return
 	}
 
 	var data ZotEventData
 	if err := json.Unmarshal(cloudEvent.Data(), &data); err != nil {
-		msg := fmt.Sprintf("failed to parse CloudEvent.Data from request: %v", err)
-		http.Error(w, msg, http.StatusBadRequest)
+		logger.Error(err, "failed to parse Zot data from CloudEvent request")
+		http.Error(w, "invalid data payload", http.StatusBadRequest)
+
+		return
+	}
+
+	if data.Name == "" || data.Reference == "" {
+		logger.Error(errors.New("missing fields"), "fields in Zot data from CloudEvent missing", "data", data)
+		http.Error(w, "invalid data payload", http.StatusBadRequest)
 
 		return
 	}
@@ -104,16 +91,20 @@ func (wh *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case ZotEventTypeImageDeleted:
 		repoEvent.Type = discovery.EventDeleted
 	default:
-		logger.Info(fmt.Sprintf("unknown event type '%s'", cloudEvent.Type()))
+		logger.Info("unknown event type, ignoring", "type", cloudEvent.Type())
+		w.WriteHeader(http.StatusNoContent)
+
 		return
 	}
 
-	wh.channel <- repoEvent
-
-	w.WriteHeader(http.StatusOK)
-
-	if err := json.NewEncoder(w).Encode(cloudEvent); err != nil {
-		msg := fmt.Sprintf("failed to encode event: %v", err)
-		logger.Info(msg)
+	select {
+	case wh.channel <- repoEvent:
+		w.WriteHeader(http.StatusAccepted)
+	case <-r.Context().Done():
+		logger.Error(r.Context().Err(), "request context cancelled")
+		http.Error(w, "timeout", http.StatusServiceUnavailable)
+	default:
+		logger.Error(nil, "event channel full, dropping event")
+		http.Error(w, "server busy", http.StatusServiceUnavailable)
 	}
 }

--- a/pkg/discovery/webhook/zot/zot_test.go
+++ b/pkg/discovery/webhook/zot/zot_test.go
@@ -100,15 +100,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 				Name:      "test/myapp",
 				Reference: "v1.0",
 				Digest:    "sha256:abc123def456",
-				Manifest: Manifest{
-					SchemaVersion: 2,
-					MediaType:     "application/vnd.docker.distribution.manifest.v2+json",
-					Config: Config{
-						MediaType: "application/vnd.docker.container.image.v1+json",
-						Size:      1024,
-						Digest:    "sha256:def456",
-					},
-				},
+				Manifest:  "{}",
 			}
 
 			// Create CloudEvent
@@ -130,7 +122,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 				bytes.NewReader(body),
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 			_ = resp.Body.Close()
 
 			// Verify that the webhook event was received and processed
@@ -175,7 +167,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 				bytes.NewReader(body),
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 			_ = resp.Body.Close()
 
 			// Verify event received
@@ -196,8 +188,8 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 			}
 
 			eventData := ZotEventData{
-				Name:   "test/obsolete",
-				Digest: "sha256:old123",
+				Name:      "test/obsolete",
+				Reference: "0.1",
 			}
 
 			event := cloudevents.NewEvent()
@@ -216,7 +208,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 				bytes.NewReader(body),
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
 			_ = resp.Body.Close()
 
 			// Verify event received
@@ -229,6 +221,46 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 			Expect(repositoryEvent.Repository).To(Equal("test/obsolete"))
 			Expect(repositoryEvent.Type).To(Equal(discovery.EventDeleted))
 		})
+
+		It("should handle invalid CloudEvent payload gracefully", func() {
+			resp, err := http.Post(
+				fmt.Sprintf("http://127.0.0.1:%d/webhook/zot", webhookPort),
+				"application/cloudevents+json",
+				bytes.NewReader([]byte("bad request")),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			_ = resp.Body.Close()
+		})
+
+		It("should handle invalid Zot data payload gracefully", func() {
+			invalidEventData := struct {
+				Name   int
+				Digest string
+			}{
+				Name:   11,
+				Digest: "sha256:xyz789",
+			}
+
+			event := cloudevents.NewEvent()
+			event.SetSource("https://zot-registry/")
+			event.SetType(ZotEventTypeRepositoryCreated)
+			event.SetID("test-event-983")
+			event.SetTime(time.Now())
+			_ = event.SetData(cloudevents.ApplicationJSON, invalidEventData)
+
+			body, err := json.Marshal(event)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(
+				fmt.Sprintf("http://127.0.0.1:%d/webhook/zot", webhookPort),
+				"application/cloudevents+json",
+				bytes.NewReader(body),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			_ = resp.Body.Close()
+		})
 	})
 
 	Describe("Webhook handler registration", func() {
@@ -238,15 +270,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 				Name:      "test-repo",
 				Reference: "test-tag",
 				Digest:    "sha256:abc123",
-				Manifest: Manifest{
-					SchemaVersion: 2,
-					MediaType:     "application/vnd.docker.distribution.manifest.v2+json",
-					Config: Config{
-						MediaType: "application/vnd.docker.container.image.v1+json",
-						Size:      1024,
-						Digest:    "sha256:def456",
-					},
-				},
+				Manifest:  "{}",
 			}
 
 			eventDataJSON, err := json.Marshal(eventData)
@@ -272,7 +296,7 @@ var _ = Describe("Zot Webhook Handler", Ordered, func() {
 			webhookRouter.ServeHTTP(w, req)
 
 			// Handler should process the event successfully (200 OK)
-			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Code).To(Equal(http.StatusAccepted))
 		})
 
 		It("should handle unknown webhook paths", func() {


### PR DESCRIPTION
* Fixes the Zot Data struct to match what Zot actually sends.
* Improves HTTP status codes.
* Adds missing error logging.
* Prevents the handler from being stuck when the event channel is full.


Closes https://github.com/opendefensecloud/solution-arsenal/issues/233.