### PR TITLE
feat 112: added helm chart signing on release to ci

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # Needed to create an OIDC token for keyless signing
     # Condition: Run on tag push, published release, OR PR with 'ok-to-helm' label
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
@@ -40,6 +41,16 @@ jobs:
         uses: azure/setup-helm@v4
         with:
           version: 'v4.0.1'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Login to GHCR # required for cosign
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         run: |
@@ -93,8 +104,11 @@ jobs:
 
               # Push to OCI registry
               PACKAGE=$(ls ${CHART_NAME}-*.tgz)
-              helm push "${PACKAGE}" oci://ghcr.io/${{ github.repository_owner }}/charts
-
+              helm push "${PACKAGE}" oci://ghcr.io/${{ github.repository_owner }}/charts &> push-metadata.txt
               echo "✓ Published ${PACKAGE} to ghcr.io/${{ github.repository_owner }}/charts"
+              CHART_DIGEST=$(awk '/Digest: /{print $2}' push-metadata.txt)
+              echo "CHART_DIGEST=${CHART_DIGEST}" | tee -a $GITHUB_ENV
+
+              cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME}@${CHART_DIGEST}"
             fi
           done


### PR DESCRIPTION
## Issue
Closes [Sign helm chart on release](https://github.com/opendefensecloud/solution-arsenal/issues/112)

## Description
This PR implements automated signing for our Helm charts within the CI pipeline. Every artifact pushed to GHCR is now cryptographically signed using Cosign.

How it was tested:
Opened PR, added "ok-to-helm" Label
output of the runner:
<img width="1017" height="187" alt="grafik" src="https://github.com/user-attachments/assets/5bd9395d-0de3-4671-afea-eddd700c3e60" />
Ran cosign tree and verify
<img width="1257" height="329" alt="grafik" src="https://github.com/user-attachments/assets/5d7b2ff7-8130-449d-8ffa-5afa83a3e1e6" />
