### PR TITLE
Support custom CA bundle in discovery

### DIFF
--- a/api/solar/discovery_types.go
+++ b/api/solar/discovery_types.go
@@ -44,6 +44,10 @@ type Registry struct {
 	// +optional
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 
+	// CAConfigMapRef contains CA bundle for registry connections (e.g., trust-manager's root-bundle). Key is expected to be "trust-bundle.pem".
+	// +optional
+	CAConfigMapRef corev1.LocalObjectReference `json:"caConfigMapRef"`
+
 	// PlainHTTP defines whether the registry should be accessed via plain HTTP instead of HTTPS.
 	// +optional
 	PlainHTTP bool `json:"plainHTTP,omitempty"`

--- a/api/solar/v1alpha1/discovery_types.go
+++ b/api/solar/v1alpha1/discovery_types.go
@@ -44,6 +44,10 @@ type Registry struct {
 	// +optional
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 
+	// CAConfigMapRef contains CA bundle for registry connections (e.g., trust-manager's root-bundle). Key is expected to be "trust-bundle.pem".
+	// +optional
+	CAConfigMapRef corev1.LocalObjectReference `json:"caConfigMapRef"`
+
 	// PlainHTTP defines whether the registry should be accessed via plain HTTP instead of HTTPS.
 	// +optional
 	PlainHTTP bool `json:"plainHTTP,omitempty"`

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1145,6 +1145,7 @@ func Convert_solar_PushResult_To_v1alpha1_PushResult(in *solar.PushResult, out *
 func autoConvert_v1alpha1_Registry_To_solar_Registry(in *Registry, out *solar.Registry, s conversion.Scope) error {
 	out.RegistryURL = in.RegistryURL
 	out.SecretRef = in.SecretRef
+	out.CAConfigMapRef = in.CAConfigMapRef
 	out.PlainHTTP = in.PlainHTTP
 	return nil
 }
@@ -1157,6 +1158,7 @@ func Convert_v1alpha1_Registry_To_solar_Registry(in *Registry, out *solar.Regist
 func autoConvert_solar_Registry_To_v1alpha1_Registry(in *solar.Registry, out *Registry, s conversion.Scope) error {
 	out.RegistryURL = in.RegistryURL
 	out.SecretRef = in.SecretRef
+	out.CAConfigMapRef = in.CAConfigMapRef
 	out.PlainHTTP = in.PlainHTTP
 	return nil
 }

--- a/api/solar/v1alpha1/zz_generated.deepcopy.go
+++ b/api/solar/v1alpha1/zz_generated.deepcopy.go
@@ -656,6 +656,7 @@ func (in *PushResult) DeepCopy() *PushResult {
 func (in *Registry) DeepCopyInto(out *Registry) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.CAConfigMapRef = in.CAConfigMapRef
 	return
 }
 

--- a/api/solar/zz_generated.deepcopy.go
+++ b/api/solar/zz_generated.deepcopy.go
@@ -656,6 +656,7 @@ func (in *PushResult) DeepCopy() *PushResult {
 func (in *Registry) DeepCopyInto(out *Registry) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.CAConfigMapRef = in.CAConfigMapRef
 	return
 }
 

--- a/client-go/applyconfigurations/solar/v1alpha1/registry.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/registry.go
@@ -18,6 +18,8 @@ type RegistryApplyConfiguration struct {
 	RegistryURL *string `json:"registryURL,omitempty"`
 	// SecretRef specifies the secret containing the relevant credentials for the registry that should be used during discovery.
 	SecretRef *v1.LocalObjectReference `json:"secretRef,omitempty"`
+	// CAConfigMapRef contains CA bundle for registry connections (e.g., trust-manager's root-bundle). Key is expected to be "trust-bundle.pem".
+	CAConfigMapRef *v1.LocalObjectReference `json:"caConfigMapRef,omitempty"`
 	// PlainHTTP defines whether the registry should be accessed via plain HTTP instead of HTTPS.
 	PlainHTTP *bool `json:"plainHTTP,omitempty"`
 }
@@ -41,6 +43,14 @@ func (b *RegistryApplyConfiguration) WithRegistryURL(value string) *RegistryAppl
 // If called multiple times, the SecretRef field is set to the value of the last call.
 func (b *RegistryApplyConfiguration) WithSecretRef(value v1.LocalObjectReference) *RegistryApplyConfiguration {
 	b.SecretRef = &value
+	return b
+}
+
+// WithCAConfigMapRef sets the CAConfigMapRef field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CAConfigMapRef field is set to the value of the last call.
+func (b *RegistryApplyConfiguration) WithCAConfigMapRef(value v1.LocalObjectReference) *RegistryApplyConfiguration {
+	b.CAConfigMapRef = &value
 	return b
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1416,6 +1416,13 @@ func schema_solar_api_solar_v1alpha1_Registry(ref common.ReferenceCallback) comm
 							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
 						},
 					},
+					"caConfigMapRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CAConfigMapRef contains CA bundle for registry connections (e.g., trust-manager's root-bundle). Key is expected to be \"trust-bundle.pem\".",
+							Default:     map[string]interface{}{},
+							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
+						},
+					},
 					"plainHTTP": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PlainHTTP defines whether the registry should be accessed via plain HTTP instead of HTTPS.",

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -435,6 +435,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `registryURL` _string_ | RegistryURL defines the URL which is used to connect to the registry. |  |  |
 | `secretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | SecretRef specifies the secret containing the relevant credentials for the registry that should be used during discovery. |  |  |
+| `caConfigMapRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | CAConfigMapRef contains CA bundle for registry connections (e.g., trust-manager's root-bundle). Key is expected to be "trust-bundle.pem". |  |  |
 | `plainHTTP` _boolean_ | PlainHTTP defines whether the registry should be accessed via plain HTTP instead of HTTPS. |  |  |
 
 

--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -401,26 +401,6 @@ func (r *DiscoveryReconciler) createWorkerResources(ctx context.Context, res *so
 		ObjectMeta: objectMeta(res),
 		Spec: corev1.PodSpec{
 			ServiceAccountName: workerSA.Name,
-			Containers: []corev1.Container{
-				{
-					Name:    "worker",
-					Image:   r.WorkerImage,
-					Command: []string{r.WorkerCommand},
-					Args:    args,
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "config",
-							ReadOnly:  true,
-							MountPath: "/etc/worker"},
-					},
-					Ports: []corev1.ContainerPort{
-						{
-							Name:          "webhook",
-							ContainerPort: 8080,
-						},
-					},
-				},
-			},
 			Volumes: []corev1.Volume{
 				{
 					Name: "config",
@@ -433,6 +413,56 @@ func (r *DiscoveryReconciler) createWorkerResources(ctx context.Context, res *so
 			},
 		},
 	}
+
+	container := corev1.Container{
+
+		Name:    "worker",
+		Image:   r.WorkerImage,
+		Command: []string{r.WorkerCommand},
+		Args:    args,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "config",
+				ReadOnly:  true,
+				MountPath: "/etc/worker"},
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "webhook",
+				ContainerPort: 8080,
+			},
+		},
+	}
+
+	if cmName := res.Spec.Registry.CAConfigMapRef.Name; cmName != "" {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+			Name: "ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: cmName,
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "trust-bundle.pem",
+							Path: "ca-bundle.pem",
+						},
+					},
+				},
+			},
+		})
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      "ca-bundle",
+			MountPath: "/etc/ssl/certs",
+			ReadOnly:  true,
+		})
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/ssl/certs/ca-bundle.pem",
+		})
+	}
+
+	pod.Spec.Containers = []corev1.Container{container}
 
 	// Set owner references
 	if err := controllerutil.SetControllerReference(res, pod, r.Scheme); err != nil {

--- a/pkg/controller/discovery_controller_test.go
+++ b/pkg/controller/discovery_controller_test.go
@@ -64,6 +64,14 @@ var _ = Describe("DiscoveryController", Ordered, func() {
 
 	Context("when reconciling Discoveries", func() {
 		It("should create required resources for a discovery resource", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root-bundle",
+				},
+				Data: map[string]string{
+					"trust-bundle.pem": "certs-data",
+				},
+			}
 			d := &solarv1alpha1.Discovery{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-discovery",
@@ -72,6 +80,9 @@ var _ = Describe("DiscoveryController", Ordered, func() {
 				Spec: solarv1alpha1.DiscoverySpec{
 					Registry: solarv1alpha1.Registry{
 						RegistryURL: registryURL,
+						CAConfigMapRef: corev1.LocalObjectReference{
+							Name: cm.Name,
+						},
 					},
 				},
 			}
@@ -94,6 +105,21 @@ var _ = Describe("DiscoveryController", Ordered, func() {
 			}).Should(Succeed())
 			Expect(pod).NotTo(BeNil())
 			Expect(pod.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", discoveryPrefixed(d.Name)))
+
+			Expect(pod.Spec.Volumes).To(HaveLen(2))
+			Expect(pod.Spec.Volumes[0].Name).To(Equal("config"))
+			Expect(pod.Spec.Volumes[1].Name).To(Equal("ca-bundle"))
+			Expect(pod.Spec.Volumes[1].ConfigMap.Name).To(Equal("root-bundle"))
+
+			container := pod.Spec.Containers[0]
+			Expect(container.VolumeMounts).To(HaveLen(2))
+			Expect(container.VolumeMounts[0].Name).To(Equal("config"))
+			Expect(container.VolumeMounts[1].Name).To(Equal("ca-bundle"))
+
+			Expect(container.Env).To(ContainElement(corev1.EnvVar{
+				Name:  "SSL_CERT_FILE",
+				Value: "/etc/ssl/certs/ca-bundle.pem",
+			}))
 
 			// Check for service
 			svc := &corev1.Service{}


### PR DESCRIPTION
Similar to https://github.com/opendefensecloud/solution-arsenal/pull/252 which adds support for custom CA bundle to the render task worker.

Closes https://github.com/opendefensecloud/solution-arsenal/issues/254.