### PR TITLE
Use registry creds in discovery for OCM repos

### DIFF
--- a/pkg/discovery/handler/handler.go
+++ b/pkg/discovery/handler/handler.go
@@ -98,9 +98,19 @@ func (rs *Handler) Process(ctx context.Context, ev discovery.ComponentVersionEve
 		return nil, fmt.Errorf("invalid registry: %s", ev.Source.Registry)
 	}
 
+	var octx ocm.Context
+	var err error
+	if registry.Credentials != nil {
+		octx, err = discovery.FromContextWithCreds(ctx, registry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OCM context with creds: %w", err)
+		}
+	} else {
+		octx = ocm.FromContext(ctx)
+	}
+
 	// Create repository for the component
 	baseURL := fmt.Sprintf("%s/%s", registry.GetURL(), ev.Namespace)
-	octx := ocm.FromContext(ctx)
 	repo, err := octx.RepositoryForSpec(ocireg.NewRepositorySpec(baseURL))
 	if err != nil {
 		rs.Logger().Error(err, "failed to create repo spec", "registry", ev.Source.Registry, "repository", ev.Source.Repository)
@@ -155,6 +165,8 @@ func (rs *Handler) Process(ctx context.Context, ev discovery.ComponentVersionEve
 		return nil, fmt.Errorf("no handler found for component version event: %v", ev)
 	}
 
+	rs.Logger().Info("info", "compVersion", compVersion)
+
 	// Process component with determined handler type.
 	h, err := rs.getHandler(handlerType)
 	if err != nil {
@@ -163,7 +175,7 @@ func (rs *Handler) Process(ctx context.Context, ev discovery.ComponentVersionEve
 	}
 
 	// Process component with determined handler. If processing fails, log and publish error.
-	resEvent, err := h.Process(ctx, &ev, compVersion)
+	resEvent, err := h.Process(octx, &ev, compVersion)
 	if err != nil {
 		rs.Logger().Error(err, "failed to process component with handler", "handler", handlerType)
 		return nil, fmt.Errorf("failed to process component with handler %q: %w", handlerType, err)

--- a/pkg/discovery/handler/handler_test.go
+++ b/pkg/discovery/handler/handler_test.go
@@ -66,10 +66,13 @@ var _ = Describe("Handler", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		handler.Stop()
+		close(inputChan)
+		close(outputChan)
+		close(errChan)
+	})
 
-		// Don't close eventsChan here since tests may still be reading from it
-		// Only close it if needed in specific test
+	AfterAll(func() {
+		testServer.Close()
 	})
 
 	Describe("Start and Stop", func() {
@@ -88,13 +91,68 @@ var _ = Describe("Handler", Ordered, func() {
 	})
 
 	Describe("ProcessEvent", func() {
-		It("should process events without error", func() {
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+
 			handler = NewHandler(registryProvider, inputChan, outputChan, errChan, opts...)
+			Expect(handler.Start(ctx)).NotTo(HaveOccurred())
+		})
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+		AfterEach(func() {
+			handler.Stop()
+			cancel()
+		})
 
-			Expect(handler.Start(ctx)).To(Succeed())
+		It("should process events without error", func() {
+			inputChan <- discovery.ComponentVersionEvent{
+				Source: discovery.RepositoryEvent{
+					Registry:   testRegistry.Name,
+					Repository: "test/component-descriptors/ocm.software/toi/demo/helmdemo",
+					Version:    "0.12.0",
+					Type:       discovery.EventCreated,
+				},
+				Namespace: "test",
+				Component: "ocm.software/toi/demo/helmdemo",
+			}
+
+			expected := &discovery.WriteAPIResourceEvent{
+				HelmDiscovery: discovery.HelmDiscovery{
+					Name:    "echoserver",
+					Version: "0.1.0",
+				},
+			}
+			Eventually(outputChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
+		})
+
+		It("should support basic auth", func() {
+			regWAuth := registry.New().WithAuth("", "")
+			testServerWAuth := httptest.NewServer(regWAuth.HandleFunc())
+
+			testServerUrlWAuth, err := url.Parse(testServerWAuth.URL)
+			Expect(err).NotTo(HaveOccurred())
+
+			testRegistryWAuth := &discovery.Registry{
+				Name:      "test-registry-wAuth",
+				Hostname:  testServerUrlWAuth.Host,
+				PlainHTTP: true,
+				Credentials: &discovery.RegistryCredentials{
+					Username: "usr",
+					Password: "psswrd",
+				},
+			}
+
+			Expect(registryProvider.Register(testRegistryWAuth)).To(Succeed())
+
+			_, err = test.Run(exec.Command(
+				"./bin/ocm", "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/helmdemo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+			))
+			Expect(err).NotTo(HaveOccurred())
 
 			inputChan <- discovery.ComponentVersionEvent{
 				Source: discovery.RepositoryEvent{
@@ -107,15 +165,14 @@ var _ = Describe("Handler", Ordered, func() {
 				Component: "ocm.software/toi/demo/helmdemo",
 			}
 
-			select {
-			case err := <-errChan:
-				Fail("unexpected error event: " + err.Error.Error())
-			case output := <-outputChan:
-				Expect(output.HelmDiscovery.Name).To(Equal("echoserver"))
-				Expect(output.HelmDiscovery.Version).To(Equal("0.1.0"))
-			case <-time.After(2 * time.Second):
-				Fail("timeout waiting for output event")
+			expected := &discovery.WriteAPIResourceEvent{
+				HelmDiscovery: discovery.HelmDiscovery{
+					Name:    "echoserver",
+					Version: "0.1.0",
+				},
 			}
+			Eventually(outputChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
 		})
 	})
 })

--- a/pkg/discovery/handler/helm.go
+++ b/pkg/discovery/handler/helm.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -30,7 +29,7 @@ func init() {
 	})
 }
 
-func (h *helmHandler) Process(ctx context.Context, ev *discovery.ComponentVersionEvent, comp ocm.ComponentVersionAccess) (*discovery.WriteAPIResourceEvent, error) {
+func (h *helmHandler) Process(ctx ocm.Context, ev *discovery.ComponentVersionEvent, comp ocm.ComponentVersionAccess) (*discovery.WriteAPIResourceEvent, error) {
 	result := &discovery.WriteAPIResourceEvent{
 		Source:    *ev,
 		Timestamp: time.Now().UTC(),
@@ -41,7 +40,7 @@ func (h *helmHandler) Process(ctx context.Context, ev *discovery.ComponentVersio
 		if res.Meta().Type == string(HelmResource) {
 			mfs := memoryfs.New()
 
-			effPath, err := download.DownloadResource(comp.GetContext(), res, res.Meta().Name, download.WithFileSystem(mfs))
+			effPath, err := download.DownloadResource(ctx, res, res.Meta().Name, download.WithFileSystem(mfs))
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to download helm resource %s", res.Meta().Name)
 			}

--- a/pkg/discovery/handler/types.go
+++ b/pkg/discovery/handler/types.go
@@ -4,8 +4,6 @@
 package handler
 
 import (
-	"context"
-
 	"ocm.software/ocm/api/ocm"
 
 	"go.opendefense.cloud/solar/pkg/discovery"
@@ -31,5 +29,5 @@ const (
 )
 
 type ComponentHandler interface {
-	Process(ctx context.Context, ev *discovery.ComponentVersionEvent, comp ocm.ComponentVersionAccess) (*discovery.WriteAPIResourceEvent, error)
+	Process(ctx ocm.Context, ev *discovery.ComponentVersionEvent, comp ocm.ComponentVersionAccess) (*discovery.WriteAPIResourceEvent, error)
 }

--- a/pkg/discovery/helpers.go
+++ b/pkg/discovery/helpers.go
@@ -4,10 +4,16 @@
 package discovery
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
+	"net"
 	"regexp"
 	"strings"
+
+	"ocm.software/ocm/api/credentials"
+	"ocm.software/ocm/api/oci/extensions/repositories/ocireg"
+	"ocm.software/ocm/api/ocm"
 )
 
 var (
@@ -70,4 +76,24 @@ func SanitizeWithHash(input string) string {
 // ComponentVersionName generates a name for a ComponentVersion
 func ComponentVersionName(comp string, version string) string {
 	return SanitizeName(fmt.Sprintf("%s-%s", comp, version))
+}
+
+func FromContextWithCreds(ctx context.Context, registry *Registry) (ocm.Context, error) {
+	octx := ocm.FromContext(ctx)
+	host, port, err := net.SplitHostPort(registry.Hostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port for registry %s: %s", registry.Hostname, err)
+	}
+	id := credentials.ConsumerIdentity{
+		credentials.ATTR_TYPE: ocireg.Type,
+		"hostname":            host,
+		"port":                port,
+	}
+	creds := credentials.NewCredentials(map[string]string{
+		credentials.ATTR_USERNAME: registry.Credentials.Username,
+		credentials.ATTR_PASSWORD: registry.Credentials.Password,
+	})
+	octx.CredentialsContext().SetCredentialsForConsumer(id, creds)
+
+	return octx, nil
 }

--- a/pkg/discovery/qualifier/qualifier.go
+++ b/pkg/discovery/qualifier/qualifier.go
@@ -78,9 +78,18 @@ func (rs *Qualifier) Process(ctx context.Context, ev discovery.RepositoryEvent) 
 		return nil, fmt.Errorf("invalid registry: %s", ev.Registry)
 	}
 
+	var octx ocm.Context
+	if registry.Credentials != nil {
+		octx, err = discovery.FromContextWithCreds(ctx, registry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OCM context with creds: %w", err)
+		}
+	} else {
+		octx = ocm.FromContext(ctx)
+	}
+
 	// Create repository for the component
 	baseURL := fmt.Sprintf("%s/%s", registry.GetURL(), ns)
-	octx := ocm.FromContext(ctx)
 	repo, err := octx.RepositoryForSpec(ocireg.NewRepositorySpec(baseURL))
 	if err != nil {
 		rs.Logger().Error(err, "failed to create repo spec", "registry", ev.Registry, "repository", ev.Repository)

--- a/pkg/discovery/qualifier/qualifier_test.go
+++ b/pkg/discovery/qualifier/qualifier_test.go
@@ -62,21 +62,19 @@ var _ = Describe("Qualifier", Ordered, func() {
 	})
 
 	BeforeEach(func() {
-		registryProvider = discovery.NewRegistryProvider()
-		if err := registryProvider.Register(testRegistry); err != nil {
-			panic(err)
-		}
-
 		inputEventsChan = make(chan discovery.RepositoryEvent, 100)
 		outputEventsChan = make(chan discovery.ComponentVersionEvent, 100)
 		errChan = make(chan discovery.ErrorEvent, 100)
 	})
 
 	AfterEach(func() {
-		qualifier.Stop()
+		close(inputEventsChan)
+		close(outputEventsChan)
+		close(errChan)
+	})
 
-		// Don't close eventsChan here since tests may still be reading from it
-		// Only close it if needed in specific test
+	AfterAll(func() {
+		testServer.Close()
 	})
 
 	Describe("Start and Stop", Label("qualifier"), func() {
@@ -95,16 +93,23 @@ var _ = Describe("Qualifier", Ordered, func() {
 	})
 
 	Describe("Qualifier discovering ocm components", Label("qualifier"), func() {
-		It("should process events", func() {
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+		BeforeEach(func() {
+			ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+
 			qualifier = NewQualifier(registryProvider, "default", inputEventsChan, outputEventsChan, errChan, qualifierOptions...)
+			Expect(qualifier.Start(ctx)).To(Succeed())
+		})
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+		AfterEach(func() {
+			qualifier.Stop()
+			cancel()
+		})
 
-			err := qualifier.Start(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			defer qualifier.Stop()
-
+		It("should process events", func() {
 			// Send event
 			inputEventsChan <- discovery.RepositoryEvent{
 				Registry:   testRegistry.Name,
@@ -120,16 +125,51 @@ var _ = Describe("Qualifier", Ordered, func() {
 				Version:    "0.12.0",
 			}
 
-			select {
-			case errEvent := <-errChan:
-				Expect(errEvent.Error).To(HaveOccurred())
-				Expect(errEvent.Error.Error()).To(ContainSubstring("invalid repository format"))
-			case ev := <-outputEventsChan:
-				Expect(ev.Component).To(Equal("ocm.software/toi/demo/helmdemo"))
-				Expect(ev.Source.Version).To(Equal("0.12.0"))
-			case <-time.After(5 * time.Second):
-				Fail("timeout waiting for event")
+			expected := &discovery.ComponentVersionEvent{
+				Component: "ocm.software/toi/demo/helmdemo",
+				Source:    discovery.RepositoryEvent{Version: "0.12.0"},
 			}
+			Eventually(outputEventsChan).Should(Receive(expected))
+			Eventually(outputEventsChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
+		})
+
+		It("should support basic auth", func() {
+			regWAuth := registry.New().WithAuth("usr", "psswrd")
+			testServerWAuth := httptest.NewServer(regWAuth.HandleFunc())
+			defer testServerWAuth.Close()
+
+			testServerWAuthUrl, err := url.Parse(testServerWAuth.URL)
+			Expect(err).NotTo(HaveOccurred())
+
+			testRegistryWAuth := &discovery.Registry{
+				Name:      "test-registry-wAuth",
+				Hostname:  testServerWAuthUrl.Host,
+				PlainHTTP: true,
+				Credentials: &discovery.RegistryCredentials{
+					Username: "usr",
+					Password: "psswrd",
+				},
+			}
+
+			Expect(registryProvider.Register(testRegistryWAuth)).To(Succeed())
+
+			_, err = test.Run(exec.Command(
+				"./bin/ocm", "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/helmdemo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Send event that requires requesting the registry to verify basic auth support
+			inputEventsChan <- discovery.RepositoryEvent{
+				Registry:   testRegistry.Name,
+				Repository: "test/component-descriptors/ocm.software/toi/demo/helmdemo",
+			}
+			expected := &discovery.ComponentVersionEvent{
+				Component: "ocm.software/toi/demo/helmdemo",
+				Source:    discovery.RepositoryEvent{Version: "0.12.0"},
+			}
+			Eventually(outputEventsChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
 		})
 
 	})

--- a/test/fixtures/units/ocm-config.yaml
+++ b/test/fixtures/units/ocm-config.yaml
@@ -1,0 +1,14 @@
+type: generic.config.ocm.software/v1
+configurations:
+  - type: credentials.config.ocm.software
+    consumers:
+      - identity:
+          type: OCIRegistry
+          scheme: http
+          hostname: 127.0.0.1
+        credentials:
+          - type: Credentials
+            properties:
+              username: usr
+              password: psswrd
+              


### PR DESCRIPTION
Closes https://github.com/opendefensecloud/solution-arsenal/issues/268.

When registry credentials are declared in the Discovery resource, they are now used to request OCM repos within the discovery pipeline.