### PR TITLE
Revert "Add CPU architecture to matrix operator (#265)"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,6 @@ on:
 jobs:
   buildAndPush:
     strategy:
-      max-parallel: 4
       matrix:
         image:
           - name: solar-controller-manager
@@ -32,9 +31,6 @@ jobs:
             target: renderer
           - name: solar-discovery-worker
             target: discovery-worker
-        platform:
-          - linux/amd64
-          - linux/arm64
     permissions:
       contents: read
       packages: write
@@ -61,11 +57,10 @@ jobs:
             type=sha
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
-      - name: Set up QEMU for ARM64
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
-        if: ${{ matrix.platform == 'linux/arm64' }}
       - name: Set up Docker Buildx
         timeout-minutes: 5
         uses: docker/setup-buildx-action@v4
@@ -78,11 +73,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        timeout-minutes: 15
+        timeout-minutes: 20
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This reverts #265.

Multiarch images need to be built in a single build-push action. Otherwise one architecture might be missing from the manifest, since it gets overwritten.

Fixes #261 