### PR TITLE
Add component spec to WriteAPIResourceEvents

### DIFF
--- a/pkg/discovery/handler/handler_test.go
+++ b/pkg/discovery/handler/handler_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"ocm.software/ocm/api/ocm/compdesc"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -166,6 +168,11 @@ var _ = Describe("Handler", Ordered, func() {
 			}
 
 			expected := &discovery.WriteAPIResourceEvent{
+				ComponentSpec: compdesc.ComponentSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ocm.software/toi/demo/helmdemo",
+					},
+				},
 				HelmDiscovery: discovery.HelmDiscovery{
 					Name:    "echoserver",
 					Version: "0.1.0",

--- a/pkg/discovery/handler/helm.go
+++ b/pkg/discovery/handler/helm.go
@@ -31,8 +31,9 @@ func init() {
 
 func (h *helmHandler) Process(ctx ocm.Context, ev *discovery.ComponentVersionEvent, comp ocm.ComponentVersionAccess) (*discovery.WriteAPIResourceEvent, error) {
 	result := &discovery.WriteAPIResourceEvent{
-		Source:    *ev,
-		Timestamp: time.Now().UTC(),
+		Source:        *ev,
+		ComponentSpec: comp.GetDescriptor().ComponentSpec,
+		Timestamp:     time.Now().UTC(),
 	}
 
 	// Check if the component has a Helm resource. If not, return an error.


### PR DESCRIPTION
Closes https://github.com/opendefensecloud/solution-arsenal/issues/275.

We missed to add the Component spec to the WriteAPIResourceEvents in the helm handler so that the APIWriter complained about missing data.