### PR TITLE
Pass namespace of the discovery resource to the worker

### DIFF
--- a/pkg/controller/discovery_controller.go
+++ b/pkg/controller/discovery_controller.go
@@ -400,7 +400,7 @@ func (r *DiscoveryReconciler) createWorkerResources(ctx context.Context, res *so
 
 	// Create pod
 	var args = r.WorkerArgs
-	args = append(args, "--config", "/etc/worker/config.yaml")
+	args = append(args, "--config", "/etc/worker/config.yaml", "--namespace", res.Namespace)
 	pod := &corev1.Pod{
 		ObjectMeta: objectMeta(res),
 		Spec: corev1.PodSpec{

--- a/pkg/controller/discovery_controller_test.go
+++ b/pkg/controller/discovery_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -112,6 +113,7 @@ var _ = Describe("DiscoveryController", Ordered, func() {
 			Expect(pod.Spec.Volumes[1].ConfigMap.Name).To(Equal("root-bundle"))
 
 			container := pod.Spec.Containers[0]
+			Expect(strings.Join(container.Args, " ")).To(ContainSubstring("--namespace " + ns.Name))
 			Expect(container.VolumeMounts).To(HaveLen(2))
 			Expect(container.VolumeMounts[0].Name).To(Equal("config"))
 			Expect(container.VolumeMounts[1].Name).To(Equal("ca-bundle"))


### PR DESCRIPTION
Relates to https://github.com/opendefensecloud/solution-arsenal/issues/99.

The discovery resource needs to live in the same namespace as the worker right now. It creates resources (Component and ComponentVersion) in the discovery resource's namespace.

If no namespace is passed to the discovery worker, the `default` one is used.