### PR TITLE
Add recommended fix to ensure compatibility between devenv v1 and v2

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1773767086,
-        "narHash": "sha256-3eKyl4LXswf6P17/u59x8oQXDgCfYX+UX0uh7YHFwJc=",
+        "lastModified": 1773847701,
+        "narHash": "sha256-YMTzpYi185/RKxO1OGgNXw9UJg3QNtDCRMm+u0t6o1Y=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a5e5a7f8b1c9a7f33f9d82192b692768b39ec710",
+        "rev": "2292690433c416137643ff49dec0f0ec7e085e4a",
         "type": "github"
       },
       "original": {
@@ -199,7 +199,10 @@
         "git-hooks": "git-hooks",
         "go-overlay": "go-overlay",
         "gomod": "gomod",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     },
     "systems": {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,6 +6,8 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
+  pre-commit-hooks:
+    follows: git-hooks
   go-overlay:
     url: github:purpleclay/go-overlay
     inputs:


### PR DESCRIPTION
<https://devenv.sh/guides/migrating-to-2.0/#git-hooks-input-is-now-optional>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment configuration to support pre-commit hooks alongside existing git-hooks configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->