### PR TITLE
feat: add TargetNamespace to Release

### DIFF
--- a/api/solar/release_rest.go
+++ b/api/solar/release_rest.go
@@ -13,10 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ resource.Object = &Release{}
-var _ resource.ObjectWithStatusSubResource = &Release{}
-var _ rest.PrepareForUpdater = &Release{}
-var _ rest.PrepareForCreater = &Release{}
+var (
+	_ resource.Object                      = &Release{}
+	_ resource.ObjectWithStatusSubResource = &Release{}
+	_ rest.PrepareForUpdater               = &Release{}
+	_ rest.PrepareForCreater               = &Release{}
+)
 
 func (o *Release) GetObjectMeta() *metav1.ObjectMeta {
 	return &o.ObjectMeta

--- a/api/solar/release_types.go
+++ b/api/solar/release_types.go
@@ -15,6 +15,8 @@ type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
+	// TargetNamespace is the namespace the ComponentVersion gets dpeloyed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/renderer_types.go
+++ b/api/solar/renderer_types.go
@@ -47,6 +47,8 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
+	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`
 }

--- a/api/solar/renderer_types.go
+++ b/api/solar/renderer_types.go
@@ -47,7 +47,7 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
-	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	// TargetNamespace is the namespace the Component gets deployed to.
 	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`

--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -15,6 +15,8 @@ type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
+	// TargetNamespace is the namespace the ComponentVersion gets dpeloyed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/v1alpha1/renderer_types.go
+++ b/api/solar/v1alpha1/renderer_types.go
@@ -47,6 +47,8 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
+	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`
 }

--- a/api/solar/v1alpha1/renderer_types.go
+++ b/api/solar/v1alpha1/renderer_types.go
@@ -47,7 +47,7 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
-	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	// TargetNamespace is the namespace the Component gets deployed to.
 	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1277,6 +1277,7 @@ func autoConvert_v1alpha1_ReleaseConfig_To_solar_ReleaseConfig(in *ReleaseConfig
 	if err := Convert_v1alpha1_ReleaseInput_To_solar_ReleaseInput(&in.Input, &out.Input, s); err != nil {
 		return err
 	}
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	return nil
 }
@@ -1293,6 +1294,7 @@ func autoConvert_solar_ReleaseConfig_To_v1alpha1_ReleaseConfig(in *solar.Release
 	if err := Convert_solar_ReleaseInput_To_v1alpha1_ReleaseInput(&in.Input, &out.Input, s); err != nil {
 		return err
 	}
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	return nil
 }
@@ -1358,6 +1360,7 @@ func Convert_solar_ReleaseList_To_v1alpha1_ReleaseList(in *solar.ReleaseList, ou
 
 func autoConvert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *solar.ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil
@@ -1370,6 +1373,7 @@ func Convert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *sol
 
 func autoConvert_solar_ReleaseSpec_To_v1alpha1_ReleaseSpec(in *solar.ReleaseSpec, out *ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil

--- a/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
@@ -18,7 +18,7 @@ type ReleaseConfigApplyConfiguration struct {
 	Chart *ChartConfigApplyConfiguration `json:"chart,omitempty"`
 	// Input is the input of the release.
 	Input *ReleaseInputApplyConfiguration `json:"input,omitempty"`
-	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	// TargetNamespace is the namespace the Component gets deployed to.
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values are additional values to be rendered into the release chart.
 	Values *runtime.RawExtension `json:"values,omitempty"`

--- a/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
@@ -18,6 +18,8 @@ type ReleaseConfigApplyConfiguration struct {
 	Chart *ChartConfigApplyConfiguration `json:"chart,omitempty"`
 	// Input is the input of the release.
 	Input *ReleaseInputApplyConfiguration `json:"input,omitempty"`
+	// TargetNamespace is the namespace the Component gets dpeloyed to.
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values are additional values to be rendered into the release chart.
 	Values *runtime.RawExtension `json:"values,omitempty"`
 }
@@ -41,6 +43,14 @@ func (b *ReleaseConfigApplyConfiguration) WithChart(value *ChartConfigApplyConfi
 // If called multiple times, the Input field is set to the value of the last call.
 func (b *ReleaseConfigApplyConfiguration) WithInput(value *ReleaseInputApplyConfiguration) *ReleaseConfigApplyConfiguration {
 	b.Input = value
+	return b
+}
+
+// WithTargetNamespace sets the TargetNamespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TargetNamespace field is set to the value of the last call.
+func (b *ReleaseConfigApplyConfiguration) WithTargetNamespace(value string) *ReleaseConfigApplyConfiguration {
+	b.TargetNamespace = &value
 	return b
 }
 

--- a/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
@@ -19,6 +19,8 @@ type ReleaseSpecApplyConfiguration struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef *v1.LocalObjectReference `json:"componentVersionRef,omitempty"`
+	// TargetNamespace is the namespace the ComponentVersion gets dpeloyed to.
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	Values *runtime.RawExtension `json:"values,omitempty"`
@@ -40,6 +42,14 @@ func ReleaseSpec() *ReleaseSpecApplyConfiguration {
 // If called multiple times, the ComponentVersionRef field is set to the value of the last call.
 func (b *ReleaseSpecApplyConfiguration) WithComponentVersionRef(value v1.LocalObjectReference) *ReleaseSpecApplyConfiguration {
 	b.ComponentVersionRef = &value
+	return b
+}
+
+// WithTargetNamespace sets the TargetNamespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TargetNamespace field is set to the value of the last call.
+func (b *ReleaseSpecApplyConfiguration) WithTargetNamespace(value string) *ReleaseSpecApplyConfiguration {
+	b.TargetNamespace = &value
 	return b
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1609,6 +1609,14 @@ func schema_solar_api_solar_v1alpha1_ReleaseConfig(ref common.ReferenceCallback)
 							Ref:         ref(v1alpha1.ReleaseInput{}.OpenAPIModelName()),
 						},
 					},
+					"targetNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetNamespace is the namespace the Component gets dpeloyed to.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Values are additional values to be rendered into the release chart.",
@@ -1616,7 +1624,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseConfig(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"chart", "input", "values"},
+				Required: []string{"chart", "input", "targetNamespace", "values"},
 			},
 		},
 		Dependencies: []string{
@@ -1732,6 +1740,14 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
 						},
 					},
+					"targetNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetNamespace is the namespace the ComponentVersion gets dpeloyed to.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Values contains deployment-specific values or configuration for the release. These values override defaults from the component version and are used during deployment.",
@@ -1746,7 +1762,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"componentVersionRef"},
+				Required: []string{"componentVersionRef", "targetNamespace"},
 			},
 		},
 		Dependencies: []string{

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1611,7 +1611,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseConfig(ref common.ReferenceCallback)
 					},
 					"targetNamespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TargetNamespace is the namespace the Component gets dpeloyed to.",
+							Description: "TargetNamespace is the namespace the Component gets deployed to.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -490,6 +490,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `chart` _[ChartConfig](#chartconfig)_ | Chart is the ChartConfig for the rendered chart. |  |  |
 | `input` _[ReleaseInput](#releaseinput)_ | Input is the input of the release. |  |  |
+| `targetNamespace` _string_ | TargetNamespace is the namespace the Component gets dpeloyed to. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values are additional values to be rendered into the release chart. |  |  |
 
 
@@ -528,6 +529,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `componentVersionRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ComponentVersionRef is a reference to the ComponentVersion to be released.<br />It points to the specific version of a component that this release is based on. |  |  |
+| `targetNamespace` _string_ | TargetNamespace is the namespace the ComponentVersion gets dpeloyed to. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values contains deployment-specific values or configuration for the release.<br />These values override defaults from the component version and are used during deployment. |  |  |
 | `failedJobTTL` _integer_ | failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.<br />After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete<br />the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.<br />If not set, defaults to 3600 (1 hour). |  |  |
 

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -490,7 +490,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `chart` _[ChartConfig](#chartconfig)_ | Chart is the ChartConfig for the rendered chart. |  |  |
 | `input` _[ReleaseInput](#releaseinput)_ | Input is the input of the release. |  |  |
-| `targetNamespace` _string_ | TargetNamespace is the namespace the Component gets dpeloyed to. |  |  |
+| `targetNamespace` _string_ | TargetNamespace is the namespace the Component gets deployed to. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values are additional values to be rendered into the release chart. |  |  |
 
 

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -5,7 +5,10 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,6 +108,157 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrlResult, nil
+}
+
+func (r *ReleaseReconciler) updateStatusConditionsFromRenderTask(ctx context.Context, res *solarv1alpha1.Release, rt *solarv1alpha1.RenderTask) (changed bool) {
+	if rt == nil || res == nil {
+		return false
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	if apimeta.IsStatusConditionTrue(rt.Status.Conditions, ConditionTypeJobFailed) {
+		changed = apimeta.SetStatusCondition(&res.Status.Conditions, metav1.Condition{
+			Type:               ConditionTypeTaskFailed,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: res.Generation,
+			Reason:             "TaskFailed",
+			Message:            "RenderTask failed",
+		})
+
+		log.V(1).Info("RenderTask failed", "name", rt.Name)
+		r.Recorder.Eventf(res, rt, corev1.EventTypeWarning, "TaskFailed", "RunTask", "RenderTask failed")
+
+		return changed
+	}
+
+	if apimeta.IsStatusConditionTrue(rt.Status.Conditions, ConditionTypeJobSucceeded) {
+		changed = apimeta.SetStatusCondition(&res.Status.Conditions, metav1.Condition{
+			Type:               ConditionTypeTaskCompleted,
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: res.Generation,
+			Reason:             "TaskCompleted",
+			Message:            "RenderTask completed",
+		})
+
+		if res.Status.ChartURL != rt.Status.ChartURL {
+			res.Status.ChartURL = rt.Status.ChartURL
+			changed = true
+		}
+
+		log.V(1).Info("RenderTask succeeded", "name", rt.Name)
+		r.Recorder.Eventf(res, rt, corev1.EventTypeWarning, "TaskCompleted", "RunTask", "RenderTask completed successfully")
+
+		return changed
+	}
+
+	log.V(1).Info("RenderTask has no final condtions yet", "name", rt.Name)
+
+	return false
+}
+
+func (r *ReleaseReconciler) createRenderTask(ctx context.Context, res *solarv1alpha1.Release) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Check if we need to cleanup an old task
+	if res.Status.RenderTaskRef != nil && res.Status.RenderTaskRef.Name != "" {
+		if err := r.deleteRenderTask(ctx, res); err != nil {
+			return errLogAndWrap(log, err, "failed to cleanup old task")
+		}
+	}
+
+	spec, err := r.computeRenderTaskSpec(ctx, res)
+	if err != nil {
+		return err
+	}
+	rt := &solarv1alpha1.RenderTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: renderTaskName(res),
+		},
+		Spec: spec,
+	}
+	rt.Spec.OwnerName = res.Name
+	rt.Spec.OwnerNamespace = res.Namespace
+	rt.Spec.OwnerKind = "Release"
+
+	if err := r.Create(ctx, rt); err != nil {
+		r.Recorder.Eventf(res, nil, corev1.EventTypeWarning, "CreationFailed", "Create", "Failed to create RenderTask", err)
+		return errLogAndWrap(log, err, "failed to create RenderTask")
+	}
+
+	// Set Reference in Status
+	res.Status.RenderTaskRef = &corev1.ObjectReference{
+		APIVersion: solarv1alpha1.SchemeGroupVersion.String(),
+		Kind:       "RenderTask",
+		Name:       rt.Name,
+	}
+
+	if err := r.Status().Update(ctx, res); err != nil {
+		return errLogAndWrap(log, err, "failed to update status")
+	}
+
+	return nil
+}
+
+func (r *ReleaseReconciler) deleteRenderTask(ctx context.Context, res *solarv1alpha1.Release) error {
+	if res.Status.RenderTaskRef == nil {
+		return nil
+	}
+
+	rt := &solarv1alpha1.RenderTask{}
+	if err := r.Get(ctx, client.ObjectKey{Name: res.Status.RenderTaskRef.Name}, rt); client.IgnoreNotFound(err) != nil {
+		return err
+	} else if err == nil {
+		return r.Delete(ctx, rt, client.PropagationPolicy(metav1.DeletePropagationBackground))
+	}
+
+	return nil
+}
+
+func (r *ReleaseReconciler) computeRenderTaskSpec(ctx context.Context, res *solarv1alpha1.Release) (solarv1alpha1.RenderTaskSpec, error) {
+	spec := solarv1alpha1.RenderTaskSpec{}
+
+	cvRef := types.NamespacedName{
+		Name:      res.Spec.ComponentVersionRef.Name,
+		Namespace: res.Namespace,
+	}
+
+	cv := &solarv1alpha1.ComponentVersion{}
+	if err := r.Get(ctx, cvRef, cv); err != nil {
+		return spec, err
+	}
+
+	chartName := fmt.Sprintf("release-%s", res.Name)
+	repo, err := url.JoinPath(res.Namespace, chartName)
+	if err != nil {
+		return spec, err
+	}
+
+	tag := fmt.Sprintf("v0.0.%d", res.GetGeneration())
+
+	spec.RendererConfig = solarv1alpha1.RendererConfig{
+		Type: solarv1alpha1.RendererConfigTypeRelease,
+		ReleaseConfig: solarv1alpha1.ReleaseConfig{
+			Chart: solarv1alpha1.ChartConfig{
+				Name:        chartName,
+				Description: fmt.Sprintf("Release of %s", res.Spec.ComponentVersionRef.Name),
+				Version:     tag,
+				AppVersion:  tag,
+			},
+			Input: solarv1alpha1.ReleaseInput{
+				Component:  solarv1alpha1.ReleaseComponent{Name: cv.Spec.ComponentRef.Name},
+				Resources:  cv.Spec.Resources,
+				Entrypoint: cv.Spec.Entrypoint,
+			},
+			TargetNamespace: res.Spec.TargetNamespace,
+			Values:          res.Spec.Values,
+		},
+	}
+	spec.Repository = repo
+	spec.Tag = tag
+	spec.FailedJobTTL = res.Spec.FailedJobTTL
+
+	return spec, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -4,6 +4,9 @@
 package controller
 
 import (
+	"fmt"
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +31,7 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 					ComponentVersionRef: corev1.LocalObjectReference{
 						Name: "my-component-v1",
 					},
+					TargetNamespace: "my-namespace",
 					Values: runtime.RawExtension{
 						Raw: []byte(`{"key": "value"}`),
 					},
@@ -66,6 +70,71 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 
 			release := validRelease("test-release-resolved", ns)
 			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			// Verify the Release was created
+			createdRelease := &solarv1alpha1.Release{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: "test-release", Namespace: ns.Name}, createdRelease)
+			}).Should(Succeed())
+
+			// Verify finalizer was added after a reconciliation cycle
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-release", Namespace: ns.Name}, createdRelease)
+				if err != nil {
+					return false
+				}
+
+				return len(createdRelease.Finalizers) > 0 && slices.Contains(createdRelease.Finalizers, releaseFinalizer)
+			}, eventuallyTimeout).Should(BeTrue(), "finalizer should be added by reconciler")
+
+			task := &solarv1alpha1.RenderTask{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-test-release-0", ns.Name)}, task)
+			}, eventuallyTimeout).Should(Succeed())
+
+			Expect(task.Spec.RendererConfig.Type).To(Equal(solarv1alpha1.RendererConfigTypeRelease))
+			Expect(task.Spec.RendererConfig.ReleaseConfig.Chart.Name).To(Equal("release-test-release"))
+			Expect(task.Spec.RendererConfig.ReleaseConfig.Chart.Version).To(Equal("v0.0.0"))
+			Expect(task.Spec.Repository).To(Equal(fmt.Sprintf("%s/release-test-release", ns.Name)))
+			Expect(task.Spec.RendererConfig.ReleaseConfig.TargetNamespace).To(Equal("my-namespace"))
+			Expect(task.Spec.Tag).To(Equal("v0.0.0"))
+		})
+
+		It("should propagate FailedJobTTL from Release to RenderTask", func() {
+			ttl := int32(3600)
+			release := validRelease("test-release-ttl", ns)
+			release.Spec.FailedJobTTL = &ttl
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			task := &solarv1alpha1.RenderTask{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-test-release-ttl-0", ns.Name)}, task)
+			}, eventuallyTimeout).Should(Succeed())
+
+			Expect(task.Spec.FailedJobTTL).ToNot(BeNil())
+			Expect(*task.Spec.FailedJobTTL).To(Equal(int32(3600)))
+		})
+	})
+
+	Describe("Release RenderTask completion", func() {
+		It("should represent completion when RenderTask completes successfully", func() {
+			// Create a Release
+			release := validRelease("test-release-success", ns)
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			task := &solarv1alpha1.RenderTask{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: fmt.Sprintf("%s-test-release-success-0", ns.Name)}, task)
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Manipulate Task to be Successful
+			Expect(apimeta.SetStatusCondition(&task.Status.Conditions, metav1.Condition{
+				Type:               ConditionTypeJobSucceeded,
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: task.Generation,
+				Reason:             ConditionTypeJobSucceeded,
+			})).To(BeTrue())
+			Expect(k8sClient.Status().Update(ctx, task)).To(Succeed())
 
 			updatedRelease := &solarv1alpha1.Release{}
 			Eventually(func() bool {

--- a/pkg/renderer/render_release_test.go
+++ b/pkg/renderer/render_release_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -288,6 +289,43 @@ var _ = Describe("RenderRelease", func() {
 			Expect(contentStr).To(ContainSubstring("replicaCount: 3"))
 			Expect(contentStr).To(ContainSubstring("repository: example.com/image"))
 			Expect(contentStr).To(ContainSubstring("tag: '{{ .resources.resource1.tag }}'"))
+		})
+
+		It("should render templates/release.yaml with custom targetnamespace", func() {
+			config := solarv1alpha1.ReleaseConfig{
+				Chart: solarv1alpha1.ChartConfig{
+					Name:        "test-release",
+					Description: "Test Release Chart",
+					Version:     "1.0.0",
+					AppVersion:  "1.0.0",
+				},
+				Input: solarv1alpha1.ReleaseInput{
+					Component: solarv1alpha1.ReleaseComponent{
+						Name: "test-component",
+					},
+					Resources: map[string]solarv1alpha1.ResourceAccess{},
+				},
+				Values:          runtime.RawExtension{},
+				TargetNamespace: "my-namespace",
+			}
+
+			result, err = RenderRelease(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			releasePath := filepath.Join(result.Dir, "templates", "release.yaml")
+			content, err := os.ReadFile(releasePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			for manifest := range strings.SplitSeq(string(content), "---") {
+				if !strings.Contains(manifest, "kind: HelmRelease") {
+					continue
+				}
+				lines := strings.Split(manifest, "\n")
+				Expect(lines).To(ContainElements(
+					Equal("spec:"),
+					Equal("  targetNamespace: my-namespace"),
+				))
+			}
 		})
 
 		It("should create files with proper directory structure", func() {

--- a/pkg/renderer/render_release_test.go
+++ b/pkg/renderer/render_release_test.go
@@ -316,16 +316,19 @@ var _ = Describe("RenderRelease", func() {
 			content, err := os.ReadFile(releasePath)
 			Expect(err).NotTo(HaveOccurred())
 
+			helmreleases := 0
 			for manifest := range strings.SplitSeq(string(content), "---") {
 				if !strings.Contains(manifest, "kind: HelmRelease") {
 					continue
 				}
+				helmreleases += 1
 				lines := strings.Split(manifest, "\n")
 				Expect(lines).To(ContainElements(
 					Equal("spec:"),
 					Equal("  targetNamespace: my-namespace"),
 				))
 			}
+			Expect(helmreleases).To(BeNumerically(">", 0), "no helmrelease was rendered")
 		})
 
 		It("should create files with proper directory structure", func() {

--- a/pkg/renderer/template/bootstrap/templates/release.yaml
+++ b/pkg/renderer/template/bootstrap/templates/release.yaml
@@ -7,6 +7,11 @@
   {{- $name = printf "%s-%s" ($name | trunc 42) $sha }}
 {{- end }}
 
+{{- $releaseLabel := $k }}
+{{- if gt (len $releaseLabel) 63 }}
+  {{- $releaseLabel = printf "%s-%s" (trunc 31 $releaseLabel) (trunc -31 $releaseLabel) }}
+{{- end }}
+
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -14,7 +19,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    solar.opendefense.cloud/release: {{ $k }}
+    solar.opendefense.cloud/release: {{ $releaseLabel }}
 spec:
   interval: 10m
   url: oci://{{ $v.repository }}
@@ -36,7 +41,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    solar.opendefense.cloud/release: {{ $k }}
+    solar.opendefense.cloud/release: {{ $releaseLabel }}
 spec:
   interval: 10m
   chartRef:

--- a/pkg/renderer/template/bootstrap/templates/release.yaml
+++ b/pkg/renderer/template/bootstrap/templates/release.yaml
@@ -13,6 +13,8 @@ kind: OCIRepository
 metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/release: {{ $k }}
 spec:
   interval: 10m
   url: oci://{{ $v.repository }}
@@ -33,6 +35,8 @@ kind: HelmRelease
 metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/release: {{ $k }}
 spec:
   interval: 10m
   chartRef:

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -4,6 +4,11 @@
   {{- $name = printf "%s-%s" ($name | trunc 42) $sha }}
 {{- end }}
 
+{{- $componentLabel := $.Values.component.name }}
+{{- if gt (len $componentLabel) 63 }}
+  {{- $componentLabel = printf "%s-%s" (trunc 31 $componentLabel) (trunc -31 $componentLabel) }}
+{{- end }}
+
 {{- $epName := .Values.entrypoint.resourceName }}
 {{- if not (hasKey .Values.resources $epName) }}
   {{- fail (printf "entrypoint resource %q not found in .Values.resources" $epName) }}
@@ -22,7 +27,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    solar.opendefense.cloud/component: {{ $.Values.component.name }}
+    solar.opendefense.cloud/component: {{ $componentLabel }}
 spec:
   interval: 4m
   url: oci://{{ $resource.repository }}
@@ -48,7 +53,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    solar.opendefense.cloud/component: {{ $.Values.component.name }}
+    solar.opendefense.cloud/component: {{ $componentLabel }}
 spec:
   interval: 10m
   chartRef:

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -55,7 +55,9 @@ spec:
     kind: OCIRepository
     name: {{ $name }}
   releaseName: {{ $name }}
-  targetNamespace: << .TargetNamespace >>
+  <<- with .TargetNamespace >>
+  targetNamespace: << . >>
+  <<- end >>
   install:
     remediation:
       retries: 3

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -21,6 +21,8 @@ kind: OCIRepository
 metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/component: {{ $.Values.component.name }}
 spec:
   interval: 4m
   url: oci://{{ $resource.repository }}
@@ -45,6 +47,8 @@ kind: HelmRelease
 metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/component: {{ $.Values.component.name }}
 spec:
   interval: 10m
   chartRef:

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -51,6 +51,7 @@ spec:
     kind: OCIRepository
     name: {{ $name }}
   releaseName: {{ $name }}
+  targetNamespace: << .TargetNamespace >>
   install:
     remediation:
       retries: 3

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -302,7 +302,12 @@ var _ = Describe("solar", Ordered, func() {
 
 		It("should render a Helm chart when a Release is created for a ComponentVersion", func() {
 			By("creating a Release for the ComponentVersion")
-			applyResource(testns, filepath.Join(dir, "test", "fixtures", "e2e", "release.yaml"))
+			release := patchYAMLFile(
+				filepath.Join(dir, "test", "fixtures", "e2e", "release.yaml"),
+				fmt.Sprintf(`[{"op": "replace", "path": "/spec/targetNamespace", "value":"%s"}]`, testns),
+			)
+			defer func() { _ = os.Remove(release) }()
+			applyResource(testns, release)
 
 			By("waiting for ComponentVersionResolved condition to be set")
 			Eventually(func(g Gomega) {
@@ -475,7 +480,24 @@ var _ = Describe("solar", Ordered, func() {
 				"-l", deploySelector,
 				"--for=condition=Available", "--timeout=5m")
 			_, err := run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "workload deployments did not become Available")
+			Expect(err).NotTo(HaveOccurred(), "workload deployment did not become Available")
+
+			// FIXME: The release currently errors, because of incorrect chart generation -> #316
+			//			Eventually(func() bool {
+			//				return getStatusCondition(
+			//					testns,
+			//					"helmreleases.helm.toolkit.fluxcd.io/solar-bootstrap-test-release",
+			//					"Ready")
+			//			}).Should(BeTrue())
+
+			//			By("verifying released component has targetNamespace set correctly", func() {
+			//				cmd := exec.Command(kubectlBinary, "get", "-n", testns,
+			//					"helmreleases.helm.toolkit.fluxcd.io/solar-bootstrap-test-ocm-software-toi-demo-helmdemo-0-12-0-release",
+			//					"-o", "jsonpath={.spec.targetNamespace}")
+			//				output, err := run(cmd)
+			//				Expect(err).NotTo(HaveOccurred())
+			//				Expect(output).To(Equal(testns))
+			//			})
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -482,22 +482,36 @@ var _ = Describe("solar", Ordered, func() {
 			_, err := run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "workload deployment did not become Available")
 
-			// FIXME: The release currently errors, because of incorrect chart generation -> #316
-			//			Eventually(func() bool {
-			//				return getStatusCondition(
-			//					testns,
-			//					"helmreleases.helm.toolkit.fluxcd.io/solar-bootstrap-test-release",
-			//					"Ready")
-			//			}).Should(BeTrue())
+			cmd = exec.Command(kubectlBinary, "get", "-n", testns,
+				"helmreleases.helm.toolkit.fluxcd.io", "-oname",
+				"-l", "solar.opendefense.cloud/release=test-opendefense-cloud-ocm-demo-v26-4-0-release")
 
-			//			By("verifying released component has targetNamespace set correctly", func() {
-			//				cmd := exec.Command(kubectlBinary, "get", "-n", testns,
-			//					"helmreleases.helm.toolkit.fluxcd.io/solar-bootstrap-test-ocm-software-toi-demo-helmdemo-0-12-0-release",
-			//					"-o", "jsonpath={.spec.targetNamespace}")
-			//				output, err := run(cmd)
-			//				Expect(err).NotTo(HaveOccurred())
-			//				Expect(output).To(Equal(testns))
-			//			})
+			releaseHelmRelease, err := run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "could not get release HelmRelease")
+			releaseHelmRelease = strings.TrimSpace(releaseHelmRelease)
+
+			Eventually(func() bool {
+				return getStatusCondition(
+					testns,
+					releaseHelmRelease,
+					"Ready")
+			}).Should(BeTrue())
+
+			cmd = exec.Command(kubectlBinary, "get", "-n", testns,
+				"helmreleases.helm.toolkit.fluxcd.io", "-oname",
+				"-l", "solar.opendefense.cloud/component=opendefense-cloud-ocm-demo")
+
+			componentHelmRelease, err := run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "could not get component HelmRelease")
+			componentHelmRelease = strings.TrimSpace(componentHelmRelease)
+
+			By("verifying released component has targetNamespace set correctly", func() {
+				cmd := exec.Command(kubectlBinary, "get", "-n", testns, componentHelmRelease,
+					"-o", "jsonpath={.spec.targetNamespace}")
+				output, err := run(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(testns))
+			})
 		})
 	})
 })

--- a/test/fixtures/e2e/release.yaml
+++ b/test/fixtures/e2e/release.yaml
@@ -4,4 +4,5 @@ metadata:
   name: test-opendefense-cloud-ocm-demo-v26-4-1-release
 spec:
   componentVersionRef:
-    name: opendefense-cloud-ocm-demo-v26-4-1
+    name: opendefense-cloud-ocm-demo-v26-4-0
+  targetNamespace: default


### PR DESCRIPTION
Fixes #239 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases and renderer configs now include a required targetNamespace to specify deployment namespace per release.

* **Templates**
  * Rendered resources gain stable release/component labels; HelmRelease manifests emit spec.targetNamespace when present.

* **Documentation**
  * API reference and OpenAPI schemas updated to document and require targetNamespace.

* **Tests**
  * Unit and e2e tests updated to validate targetNamespace propagation and HelmRelease readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->