### PR TITLE
Fix package grouping and make sure dockerfile specifies patch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7 AS builder
 
 WORKDIR /workspace
 RUN go env -w GOMODCACHE=/root/.cache/go-build

--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,10 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["go"],
+      "matchDatasources": ["docker", "golang-version"],
+      "matchPackageNames": ["go", "golang"],
       "groupName": "golang version sync",
-      "groupSlug": "go-version",
-      "matchUpdateTypes": ["minor", "patch"]
+      "groupSlug": "go-version"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Several issues addressed:
1. `matchPackageNames: ["go"]`, also required `golang` as this is the OCI image name to properly match Dockerfile updates
2. `custom.regex` is not matched, so we match through datasources instead!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure and refined dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->