### PR TITLE
Create rule to update go version directive in go.mod with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,11 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump"
+    },
+    {
       "matchDatasources": ["docker", "golang-version"],
       "matchPackageNames": ["go", "golang"],
       "groupName": "golang version sync",


### PR DESCRIPTION
Renovate skips the go version directive in `go.mod`, let's make sure renovate bumps the version instead!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automatic dependency update configuration for Go modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->