### PR TITLE
Support relativeOciReference OCM access type in discovery

### DIFF
--- a/pkg/discovery/apiwriter/apiwriter.go
+++ b/pkg/discovery/apiwriter/apiwriter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	v1 "k8s.io/api/core/v1"
@@ -18,6 +19,7 @@ import (
 	"ocm.software/ocm/api/ocm"
 	"ocm.software/ocm/api/ocm/compdesc"
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/ociartifact"
+	"ocm.software/ocm/api/ocm/extensions/accessmethods/relativeociref"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -99,32 +101,34 @@ func (rs *APIWriter) ensureComponentVersion(ctx context.Context, ref oci.RefSpec
 	// Get Resources
 	resources := map[string]solarv1alpha1.ResourceAccess{}
 	for _, res := range spec.Resources {
-		ra := solarv1alpha1.ResourceAccess{}
-
 		acc, err := octx.AccessSpecForSpec(res.GetAccess())
 		if err != nil {
 			return fmt.Errorf("failed to parse access spec for resource %s: %w", res.Name, err)
 		}
 
+		var rawRef string
 		switch typed := acc.(type) {
-		// NOTE: Currently only OCI is supported
+		// NOTE: Currently only ociReference and relativeOciReference are supported
 		case *ociartifact.AccessSpec:
-			ociref, err := oci.ParseRef(typed.ImageReference)
-			if err != nil {
-				return err
+			rawRef = typed.ImageReference
+		case *relativeociref.AccessSpec:
+			u := url.URL{
+				Scheme: ref.Scheme,
+				Host:   ref.Host,
+				Path:   typed.Reference,
 			}
-			repository, err := url.JoinPath(ociref.Host, ociref.Repository)
-			if err != nil {
-				return err
-			}
-			ra.Repository = fmt.Sprintf("%s://%s", ociref.Scheme, repository)
-			ra.Tag = ociref.Version()
-
+			rawRef = u.String()
 		default:
-			return fmt.Errorf("unsupported access type: %s", acc.GetType())
+			rs.Logger().Info("Unsupported access type, skipping resource (will be an error in the future)", "type", acc.GetType())
+			continue
 		}
 
-		resources[res.Name] = ra
+		ociref, err := oci.ParseRef(rawRef)
+		if err != nil {
+			return fmt.Errorf("failed to parse OCI reference %q: %w", rawRef, err)
+		}
+
+		resources[res.Name] = rs.newResourceAccess(ociref)
 	}
 
 	// Get Entrypoint
@@ -241,6 +245,22 @@ func (rs *APIWriter) ensureComponent(ctx context.Context, ref oci.RefSpec, spec 
 	}
 
 	return err
+}
+
+func (rs *APIWriter) newResourceAccess(ociref oci.RefSpec) solarv1alpha1.ResourceAccess {
+	u := url.URL{
+		Scheme: ociref.Scheme,
+		Host:   ociref.Host,
+		Path:   ociref.Repository,
+	}
+	repo := u.String()
+	// if u.Scheme is empty, u.String() omits scheme:
+	repo = strings.TrimPrefix(repo, "//")
+
+	return solarv1alpha1.ResourceAccess{
+		Repository: repo,
+		Tag:        ociref.Version(),
+	}
 }
 
 func (rs *APIWriter) getOciRef(ev discovery.WriteAPIResourceEvent) (oci.RefSpec, error) {

--- a/pkg/discovery/apiwriter/apiwriter_test.go
+++ b/pkg/discovery/apiwriter/apiwriter_test.go
@@ -21,6 +21,7 @@ import (
 	"ocm.software/ocm/api/ocm/compdesc"
 	compmetav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/ociartifact"
+	"ocm.software/ocm/api/ocm/extensions/accessmethods/relativeociref"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -82,6 +83,28 @@ func createEvent(eventType discovery.EventType) discovery.WriteAPIResourceEvent 
 					},
 					Access: &ociartifact.AccessSpec{
 						ImageReference: "oci://zot.local/mychart:v1.0.0",
+					},
+				},
+				{
+					ResourceMeta: compdesc.ResourceMeta{
+						ElementMeta: compdesc.ElementMeta{
+							Name:    "myimage1",
+							Version: "v1.1.1",
+						},
+					},
+					Access: &ociartifact.AccessSpec{
+						ImageReference: "zot.local:443/myimage1:v1.1.1",
+					},
+				},
+				{
+					ResourceMeta: compdesc.ResourceMeta{
+						ElementMeta: compdesc.ElementMeta{
+							Name:    "myimage2",
+							Version: "v2.2.2",
+						},
+					},
+					Access: &relativeociref.AccessSpec{
+						Reference: "myimage2:v2.2.2",
 					},
 				},
 			},
@@ -183,6 +206,10 @@ var _ = Describe("APIWriter", Ordered, func() {
 			Expect(cv.Spec.Resources).NotTo(BeNil())
 			Expect(cv.Spec.Resources["mychart"].Repository).To(Equal("oci://zot.local/mychart"))
 			Expect(cv.Spec.Resources["mychart"].Tag).To(Equal("v1.0.0"))
+			Expect(cv.Spec.Resources["myimage1"].Repository).To(Equal("zot.local:443/myimage1"))
+			Expect(cv.Spec.Resources["myimage1"].Tag).To(Equal("v1.1.1"))
+			Expect(cv.Spec.Resources["myimage2"].Repository).To(Equal(testRegistry.GetURL() + "/myimage2"))
+			Expect(cv.Spec.Resources["myimage2"].Tag).To(Equal("v2.2.2"))
 
 			Expect(cv.Spec.Entrypoint.Type).To(Equal(solarv1alpha1.EntrypointTypeHelm))
 			Expect(cv.Spec.Entrypoint.ResourceName).To(Equal("mychart"))


### PR DESCRIPTION
Adds support for

* OCM access type `relativeOciReference`

Example snippet of OCM component descriptor:
```
- access:
      reference: test/ocm.software/toi/demo/helmdemo/echoserver:0.1.0@sha256:8ab41f82c9a28535f1add8ffbcd6d625a19ece63c4e921f9c8358820019d1ec2
      type: relativeOciReference
```

It is needed in particular for the discovery integ test where we upload the OCM package with `preferRelativeAccess` set to `true` to handle the fact that the upload registry URL is `localhost:4443` and the download registry URL is `zot-discovery.zot.svc.cluster.local:443`. 

* Different URL patterns for the OCM access type `ociReference` like `zot.local:443` (without scheme but with port).

Relates to https://github.com/opendefensecloud/solution-arsenal/issues/99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded component resource reference support to handle both absolute and relative OCI references with proper resolution
  * Enhanced fault tolerance: unrecognized resource types are now logged and gracefully skipped instead of terminating operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->