### PR TITLE
feat: Draft ADR for Authentication #165

### DIFF
--- a/docs/developer-guide/adrs/007-external-secrets-operator.md
+++ b/docs/developer-guide/adrs/007-external-secrets-operator.md
@@ -23,7 +23,7 @@ The RenderTask controller creates a Job that must push rendered Helm charts to a
 
 **Shortfalls:**
 - Operator-owned credentials are leaked into tenant namespaces.
-- Addressed architecturally by [ADR-006 / #315](../006-Move-RenderTask-Jobs-to-Dedicated-Namespace.md) (make RenderTask cluster-scoped, run Jobs in controller namespace). The credential isolation problem is solved there, but the underlying question of how the push credential itself is provisioned and rotated remains.
+- Addressed architecturally by [ADR-006 / #315](006-Move-RenderTask-Jobs-to-Dedicated-Namespace.md) (make RenderTask cluster-scoped, run Jobs in controller namespace). The credential isolation problem is solved there, but the underlying question of how the push credential itself is provisioned and rotated remains.
 
 ### 3. Flux — pulling charts on target clusters
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a draft ADR (ADR-007) proposing adoption of the External Secrets Operator to provision and refresh Kubernetes Secrets used by Discovery, RenderTask, and Flux.
  * Describes credential lifecycle gaps (rotation, cross-namespace/multi-cluster distribution, CA trust propagation, opaque failures) and compares two ESO approaches (in-cluster mirroring and KMS-backed central store).
  * Specifies required secret formats for each consumer and notes no application code changes are expected.
  * Lists follow-up actions and issues for further discussion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->