### PR TITLE
Restore randomized naming for test namespace

### DIFF
--- a/hack/dev-cluster.sh
+++ b/hack/dev-cluster.sh
@@ -85,6 +85,11 @@ setup_zot_discovery() {
         --repo=https://zotregistry.dev/helm-charts \
         -f test/fixtures/zot-discovery.values.yaml \
         zot-discovery zot
+    # Acts as a stable alias for the discovery webhook address which is dynamic due to the randomized name of the test namespace. 
+    # The discovery Zot points in its config to this fixed service's address. During testing we update this service to point to the actual 
+    # discovery webhook address without a Zot redeploy.
+    $KUBECTL apply --namespace zot \
+        -f test/fixtures/discovery-webhook-ptr-svc.yaml
 }
 
 setup_zot_deploy() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/rand"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"sigs.k8s.io/yaml"
@@ -219,7 +220,7 @@ func portForward(typename string, localport int, remoteport int, args ...string)
 func setupTestNS() string {
 	GinkgoHelper()
 
-	testns := "test"
+	testns := fmt.Sprintf("testns-%s", rand.String(5))
 	cmd := exec.Command(kubectlBinary, "create", "namespace", testns)
 	_, err := run(cmd)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -64,17 +64,22 @@ var _ = Describe("solar", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		testns = setupTestNS()
+
+		// update discovery webhook pointer service to point to the actual discovery webhook address which has been
+		// determined once the name of the test namespace has been defined
+		svc := patchYAMLFile(
+			filepath.Join(dir, "test", "fixtures", "discovery-webhook-ptr-svc.yaml"),
+			fmt.Sprintf(`[{"op": "replace", "path": "/spec/externalName", "value":"discovery-zot-webhook.%s.svc.cluster.local"}]`, testns),
+		)
+		defer func() { _ = os.Remove(svc) }()
+		applyResource("zot", svc)
 	})
 
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
 	// and deleting the namespaces.
 	AfterAll(func() {
-		By("removing test namespace")
-		cmd := exec.Command(kubectlBinary, "delete", "ns", testns)
-		_, _ = run(cmd)
-
 		By("undeploying the apiserver and controller-manager")
-		cmd = exec.Command(helmBinary, "uninstall", "-n", controllerNamespace, "solar")
+		cmd := exec.Command(helmBinary, "uninstall", "-n", controllerNamespace, "solar")
 		_, _ = run(cmd)
 
 		By("removing manager namespace")

--- a/test/fixtures/discovery-webhook-ptr-svc.yaml
+++ b/test/fixtures/discovery-webhook-ptr-svc.yaml
@@ -1,0 +1,8 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: discovery-zot-webhook-pointer
+  namespace: zot
+spec:
+  type: ExternalName
+  externalName: discovery-zot-webhook.test.svc.cluster.local

--- a/test/fixtures/zot-discovery.values.yaml
+++ b/test/fixtures/zot-discovery.values.yaml
@@ -30,7 +30,7 @@ configFiles:
           "sinks": [
             {
               "type": "http",
-              "address": "http://discovery-zot-webhook.test.svc.cluster.local:8080/webhook/events",
+              "address": "http://discovery-zot-webhook-pointer.zot.svc.cluster.local:8080/webhook/events",
               "timeout": "1s"
             }
           ]


### PR DESCRIPTION
We've temporarily removed the randomized naming of the test namespace to get the integs run for discovery. This PR restores the randomized naming with the help of a "pointer service" to keep the address for the zot webhook handler constant to avoid a redeployment of Zot during test execution. The address of the webhook handler is configured in the discovery Zot's config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development cluster setup to apply discovery webhook service configuration during Zot discovery installation.
  * Enhanced test infrastructure to support dynamic namespace naming and improved webhook endpoint isolation.

* **Tests**
  * Modified e2e test setup to dynamically patch and apply discovery webhook service resources with namespace-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->