### PR TITLE
Fix JSON key of ComponentVersionRef in Release type

### DIFF
--- a/api/solar/release_types.go
+++ b/api/solar/release_types.go
@@ -14,7 +14,7 @@ import (
 type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
-	ComponentVersionRef corev1.LocalObjectReference `json:"componentRef"`
+	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -14,7 +14,7 @@ import (
 type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
-	ComponentVersionRef corev1.LocalObjectReference `json:"componentRef"`
+	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
@@ -18,7 +18,7 @@ import (
 type ReleaseSpecApplyConfiguration struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
-	ComponentVersionRef *v1.LocalObjectReference `json:"componentRef,omitempty"`
+	ComponentVersionRef *v1.LocalObjectReference `json:"componentVersionRef,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	Values *runtime.RawExtension `json:"values,omitempty"`

--- a/client-go/openapi/api_violations.report
+++ b/client-go/openapi/api_violations.report
@@ -2,7 +2,6 @@ API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alp
 API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alpha1,HydratedTargetStatus,Conditions
 API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alpha1,ReleaseStatus,Conditions
 API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alpha1,RenderTaskStatus,Conditions
-API rule violation: names_match,go.opendefense.cloud/solar/api/solar/v1alpha1,ReleaseSpec,ComponentVersionRef
 API rule violation: names_match,go.opendefense.cloud/solar/api/solar/v1alpha1,RendererConfig,HydratedTargetConfig
 API rule violation: names_match,go.opendefense.cloud/solar/api/solar/v1alpha1,RendererConfig,ReleaseConfig
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1645,7 +1645,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 				Description: "ReleaseSpec defines the desired state of a Release. It specifies which component version to release and its deployment configuration.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"componentRef": {
+					"componentVersionRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ComponentVersionRef is a reference to the ComponentVersion to be released. It points to the specific version of a component that this release is based on.",
 							Default:     map[string]interface{}{},
@@ -1666,7 +1666,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"componentRef"},
+				Required: []string{"componentVersionRef"},
 			},
 		},
 		Dependencies: []string{

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -529,7 +529,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `componentRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ComponentVersionRef is a reference to the ComponentVersion to be released.<br />It points to the specific version of a component that this release is based on. |  |  |
+| `componentVersionRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ComponentVersionRef is a reference to the ComponentVersion to be released.<br />It points to the specific version of a component that this release is based on. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values contains deployment-specific values or configuration for the release.<br />These values override defaults from the component version and are used during deployment. |  |  |
 
 

--- a/test/fixtures/e2e/release.yaml
+++ b/test/fixtures/e2e/release.yaml
@@ -3,5 +3,5 @@ kind: Release
 metadata:
   name: test-ocm-software-toi-demo-helmdemo-0-12-0-release
 spec:
-  componentRef:
+  componentVersionRef:
     name: ocm-software-toi-demo-helmdemo-0-12-0


### PR DESCRIPTION
We've called the field in the Release type `ComponentVersionRef` and the JSON key `componentRef`. Since we actually reference a ComponentVersion resource, I've adapted the JSON key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Updated the `ReleaseSpec` field name from `componentRef` to `componentVersionRef` in Release API requests and responses. Update your configurations and API clients to use the new field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->