### PR TITLE
fix: Fix step order in discovery integs

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -256,13 +256,13 @@ var _ = Describe("solar", Ordered, func() {
 			}).Should(Succeed())
 
 			// re-push OCM package, re-create via scan for subsequent tests
-			applyResource(testns, filepath.Join(dir, "test", "fixtures", "e2e", "discovery-scan.yaml"))
-
 			By("re-pushing the OCM package after tag deletion")
 			cmd = exec.Command(ocmBinary, "--config", ocmconfig, "transfer", "ctf", helmdemoCtf, fmt.Sprintf("localhost:%d/test", localport))
 			cmd.Env = append(cmd.Env, "SSL_CERT_FILE="+caCrt)
 			_, err = run(cmd)
 			Expect(err).NotTo(HaveOccurred())
+
+			applyResource(testns, filepath.Join(dir, "test", "fixtures", "e2e", "discovery-scan.yaml"))
 
 			Eventually(func(g Gomega) {
 				verifyComp(g)


### PR DESCRIPTION
First push the OCM package and apply the discovery scan resource afterwards to make sure that the OCM package exists in the OCI registry before the initial scan of the discovery resources starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reordered end-to-end test procedures to adjust when discovery scan configurations are applied in relation to package transfer and republication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->