### PR TITLE
Remove obsolete polling of RenderTasks

### DIFF
--- a/pkg/controller/hydratedtarget_controller.go
+++ b/pkg/controller/hydratedtarget_controller.go
@@ -164,8 +164,8 @@ func (r *HydratedTargetReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	// RenderTask still running, requeue
-	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	// RenderTask still running
+	return ctrlResult, nil
 }
 
 func (r *HydratedTargetReconciler) updateStatusConditionsFromRenderTask(ctx context.Context, res *solarv1alpha1.HydratedTarget, rt *solarv1alpha1.RenderTask) (changed bool) {

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -162,8 +162,8 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	// RenderTask still running, requeue
-	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	// RenderTask still running
+	return ctrlResult, nil
 }
 
 func (r *ReleaseReconciler) updateStatusConditionsFromRenderTask(ctx context.Context, res *solarv1alpha1.Release, rt *solarv1alpha1.RenderTask) (changed bool) {


### PR DESCRIPTION
Since we watch the `RenderTask` and reconcile on Status changes, we don't need this explicit re-queuing.

https://github.com/opendefensecloud/solution-arsenal/blob/74a3e6a7aaa6474503b86257ea08499ba8dc229a/pkg/controller/hydratedtarget_controller.go#L339-L341

https://github.com/opendefensecloud/solution-arsenal/blob/74a3e6a7aaa6474503b86257ea08499ba8dc229a/pkg/controller/release_controller.go#L323-L325

Closes https://github.com/opendefensecloud/solution-arsenal/issues/155.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized controller reconciliation behavior for in-progress task handling across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->