### PR TITLE
Revert "chore(deps): update golang version sync to v1.26.2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1 AS builder
 
 WORKDIR /workspace
 RUN go env -w GOMODCACHE=/root/.cache/go-build

--- a/devenv.nix
+++ b/devenv.nix
@@ -15,7 +15,7 @@
 
   # https://devenv.sh/languages/
   languages.go.enable = true;
-  languages.go.version = "1.26.2";
+  languages.go.version = "1.26.1";
 
   files."bin/pre-commit-golangci-lint" = {
     text = ''

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opendefense.cloud/solar
 
-go 1.26.2
+go 1.26.1
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Reverts opendefensecloud/solution-arsenal#370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.26.2 to 1.26.1 across build and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->