### PR TITLE
fix: dev-cluster setup for manual e2e testing

### DIFF
--- a/hack/dev-cluster.sh
+++ b/hack/dev-cluster.sh
@@ -178,6 +178,7 @@ setup_solar() {
         --set discovery.image.tag="$TAG"
     $KUBECTL apply --namespace=solar-system \
         -f test/fixtures/e2e/zot-deploy-auth.yaml
+    $KUBECTL label namespace solar-system trust=enabled --overwrite
 }
 
 # main orchestrates cluster setup by invoking cert-manager, trust-manager, Zot components, Flux, and (unless SKIP_SOLAR is "true") Solar, then prints DONE.

--- a/test/fixtures/ocmconfig
+++ b/test/fixtures/ocmconfig
@@ -12,3 +12,5 @@ configurations:
             properties:
               username: admin
               password: admin
+  - type: oci.uploader.config.ocm.software
+    preferRelativeAccess: true


### PR DESCRIPTION
- label solar-system namespace
- add preferRelativeAccess to other ocmconfig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development cluster initialization with updated namespace configuration
  * Extended test fixture settings to support additional uploader-specific behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->