### PR TITLE
feat: add targetNamespace to Release

### DIFF
--- a/api/solar/release_rest.go
+++ b/api/solar/release_rest.go
@@ -13,10 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ resource.Object = &Release{}
-var _ resource.ObjectWithStatusSubResource = &Release{}
-var _ rest.PrepareForUpdater = &Release{}
-var _ rest.PrepareForCreater = &Release{}
+var (
+	_ resource.Object                      = &Release{}
+	_ resource.ObjectWithStatusSubResource = &Release{}
+	_ rest.PrepareForUpdater               = &Release{}
+	_ rest.PrepareForCreater               = &Release{}
+)
 
 func (o *Release) GetObjectMeta() *metav1.ObjectMeta {
 	return &o.ObjectMeta

--- a/api/solar/release_types.go
+++ b/api/solar/release_types.go
@@ -15,6 +15,9 @@ type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
+	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
+	// +optional
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/renderer_types.go
+++ b/api/solar/renderer_types.go
@@ -47,6 +47,8 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
+	// TargetNamespace is the namespace the Component gets deployed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`
 }

--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -15,6 +15,9 @@ type ReleaseSpec struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef corev1.LocalObjectReference `json:"componentVersionRef"`
+	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
+	// +optional
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/v1alpha1/renderer_types.go
+++ b/api/solar/v1alpha1/renderer_types.go
@@ -47,6 +47,8 @@ type ReleaseConfig struct {
 	Chart ChartConfig `json:"chart"`
 	// Input is the input of the release.
 	Input ReleaseInput `json:"input"`
+	// TargetNamespace is the namespace the Component gets deployed to.
+	TargetNamespace string `json:"targetNamespace"`
 	// Values are additional values to be rendered into the release chart.
 	Values runtime.RawExtension `json:"values"`
 }

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1277,6 +1277,7 @@ func autoConvert_v1alpha1_ReleaseConfig_To_solar_ReleaseConfig(in *ReleaseConfig
 	if err := Convert_v1alpha1_ReleaseInput_To_solar_ReleaseInput(&in.Input, &out.Input, s); err != nil {
 		return err
 	}
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	return nil
 }
@@ -1293,6 +1294,7 @@ func autoConvert_solar_ReleaseConfig_To_v1alpha1_ReleaseConfig(in *solar.Release
 	if err := Convert_solar_ReleaseInput_To_v1alpha1_ReleaseInput(&in.Input, &out.Input, s); err != nil {
 		return err
 	}
+	out.TargetNamespace = in.TargetNamespace
 	out.Values = in.Values
 	return nil
 }
@@ -1358,6 +1360,7 @@ func Convert_solar_ReleaseList_To_v1alpha1_ReleaseList(in *solar.ReleaseList, ou
 
 func autoConvert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *solar.ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
+	out.TargetNamespace = (*string)(unsafe.Pointer(in.TargetNamespace))
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil
@@ -1370,6 +1373,7 @@ func Convert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *sol
 
 func autoConvert_solar_ReleaseSpec_To_v1alpha1_ReleaseSpec(in *solar.ReleaseSpec, out *ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
+	out.TargetNamespace = (*string)(unsafe.Pointer(in.TargetNamespace))
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil

--- a/api/solar/v1alpha1/zz_generated.deepcopy.go
+++ b/api/solar/v1alpha1/zz_generated.deepcopy.go
@@ -841,6 +841,11 @@ func (in *ReleaseList) DeepCopyObject() runtime.Object {
 func (in *ReleaseSpec) DeepCopyInto(out *ReleaseSpec) {
 	*out = *in
 	out.ComponentVersionRef = in.ComponentVersionRef
+	if in.TargetNamespace != nil {
+		in, out := &in.TargetNamespace, &out.TargetNamespace
+		*out = new(string)
+		**out = **in
+	}
 	in.Values.DeepCopyInto(&out.Values)
 	if in.FailedJobTTL != nil {
 		in, out := &in.FailedJobTTL, &out.FailedJobTTL

--- a/api/solar/zz_generated.deepcopy.go
+++ b/api/solar/zz_generated.deepcopy.go
@@ -841,6 +841,11 @@ func (in *ReleaseList) DeepCopyObject() runtime.Object {
 func (in *ReleaseSpec) DeepCopyInto(out *ReleaseSpec) {
 	*out = *in
 	out.ComponentVersionRef = in.ComponentVersionRef
+	if in.TargetNamespace != nil {
+		in, out := &in.TargetNamespace, &out.TargetNamespace
+		*out = new(string)
+		**out = **in
+	}
 	in.Values.DeepCopyInto(&out.Values)
 	if in.FailedJobTTL != nil {
 		in, out := &in.FailedJobTTL, &out.FailedJobTTL

--- a/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releaseconfig.go
@@ -18,6 +18,8 @@ type ReleaseConfigApplyConfiguration struct {
 	Chart *ChartConfigApplyConfiguration `json:"chart,omitempty"`
 	// Input is the input of the release.
 	Input *ReleaseInputApplyConfiguration `json:"input,omitempty"`
+	// TargetNamespace is the namespace the Component gets deployed to.
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values are additional values to be rendered into the release chart.
 	Values *runtime.RawExtension `json:"values,omitempty"`
 }
@@ -41,6 +43,14 @@ func (b *ReleaseConfigApplyConfiguration) WithChart(value *ChartConfigApplyConfi
 // If called multiple times, the Input field is set to the value of the last call.
 func (b *ReleaseConfigApplyConfiguration) WithInput(value *ReleaseInputApplyConfiguration) *ReleaseConfigApplyConfiguration {
 	b.Input = value
+	return b
+}
+
+// WithTargetNamespace sets the TargetNamespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TargetNamespace field is set to the value of the last call.
+func (b *ReleaseConfigApplyConfiguration) WithTargetNamespace(value string) *ReleaseConfigApplyConfiguration {
+	b.TargetNamespace = &value
 	return b
 }
 

--- a/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
@@ -19,6 +19,8 @@ type ReleaseSpecApplyConfiguration struct {
 	// ComponentVersionRef is a reference to the ComponentVersion to be released.
 	// It points to the specific version of a component that this release is based on.
 	ComponentVersionRef *v1.LocalObjectReference `json:"componentVersionRef,omitempty"`
+	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
+	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	Values *runtime.RawExtension `json:"values,omitempty"`
@@ -40,6 +42,14 @@ func ReleaseSpec() *ReleaseSpecApplyConfiguration {
 // If called multiple times, the ComponentVersionRef field is set to the value of the last call.
 func (b *ReleaseSpecApplyConfiguration) WithComponentVersionRef(value v1.LocalObjectReference) *ReleaseSpecApplyConfiguration {
 	b.ComponentVersionRef = &value
+	return b
+}
+
+// WithTargetNamespace sets the TargetNamespace field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TargetNamespace field is set to the value of the last call.
+func (b *ReleaseSpecApplyConfiguration) WithTargetNamespace(value string) *ReleaseSpecApplyConfiguration {
+	b.TargetNamespace = &value
 	return b
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1609,6 +1609,14 @@ func schema_solar_api_solar_v1alpha1_ReleaseConfig(ref common.ReferenceCallback)
 							Ref:         ref(v1alpha1.ReleaseInput{}.OpenAPIModelName()),
 						},
 					},
+					"targetNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetNamespace is the namespace the Component gets deployed to.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Values are additional values to be rendered into the release chart.",
@@ -1616,7 +1624,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseConfig(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"chart", "input", "values"},
+				Required: []string{"chart", "input", "targetNamespace", "values"},
 			},
 		},
 		Dependencies: []string{
@@ -1730,6 +1738,13 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 							Description: "ComponentVersionRef is a reference to the ComponentVersion to be released. It points to the specific version of a component that this release is based on.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
+						},
+					},
+					"targetNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TargetNamespace is the namespace the ComponentVersion gets deployed to.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"values": {

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -490,6 +490,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `chart` _[ChartConfig](#chartconfig)_ | Chart is the ChartConfig for the rendered chart. |  |  |
 | `input` _[ReleaseInput](#releaseinput)_ | Input is the input of the release. |  |  |
+| `targetNamespace` _string_ | TargetNamespace is the namespace the Component gets deployed to. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values are additional values to be rendered into the release chart. |  |  |
 
 
@@ -528,6 +529,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `componentVersionRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ComponentVersionRef is a reference to the ComponentVersion to be released.<br />It points to the specific version of a component that this release is based on. |  |  |
+| `targetNamespace` _string_ | TargetNamespace is the namespace the ComponentVersion gets deployed to. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values contains deployment-specific values or configuration for the release.<br />These values override defaults from the component version and are used during deployment. |  |  |
 | `failedJobTTL` _integer_ | failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.<br />After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete<br />the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.<br />If not set, defaults to 3600 (1 hour). |  |  |
 

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -480,6 +480,11 @@ func (r *TargetReconciler) computeReleaseRenderTaskSpec(rel *solarv1alpha1.Relea
 	repo := fmt.Sprintf("%s/%s", target.Namespace, chartName)
 	tag := fmt.Sprintf("v0.0.%d", rel.GetGeneration())
 
+	var targetNamespace string
+	if rel.Spec.TargetNamespace != nil {
+		targetNamespace = *rel.Spec.TargetNamespace
+	}
+
 	return solarv1alpha1.RenderTaskSpec{
 		RendererConfig: solarv1alpha1.RendererConfig{
 			Type: solarv1alpha1.RendererConfigTypeRelease,
@@ -495,7 +500,8 @@ func (r *TargetReconciler) computeReleaseRenderTaskSpec(rel *solarv1alpha1.Relea
 					Resources:  cv.Spec.Resources,
 					Entrypoint: cv.Spec.Entrypoint,
 				},
-				Values: rel.Spec.Values,
+				Values:          rel.Spec.Values,
+				TargetNamespace: targetNamespace,
 			},
 		},
 		Repository:     repo,

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -70,6 +70,7 @@ var _ = Describe("TargetController", Ordered, func() {
 				Spec: solarv1alpha1.ReleaseSpec{
 					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
 					Values:              runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
+					TargetNamespace:     new("my-namespace"),
 				},
 			}
 		}
@@ -191,6 +192,7 @@ var _ = Describe("TargetController", Ordered, func() {
 			}, eventuallyTimeout).Should(Succeed())
 
 			Expect(rt.Spec.RendererConfig.Type).To(Equal(solarv1alpha1.RendererConfigTypeRelease))
+			Expect(rt.Spec.RendererConfig.ReleaseConfig.TargetNamespace).To(Equal("my-namespace"))
 			Expect(rt.Spec.BaseURL).To(Equal("registry.example.com"))
 			Expect(rt.Spec.PushSecretRef).NotTo(BeNil())
 			Expect(rt.Spec.PushSecretRef.Name).To(Equal("registry-credentials"))

--- a/pkg/renderer/render_release_test.go
+++ b/pkg/renderer/render_release_test.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -350,16 +350,16 @@ var _ = Describe("RenderRelease", func() {
 		})
 
 		It("should handle target namespace", func() {
-			checkHelmRelease := func(content []byte, check types.GomegaMatcher) {
+			checkHelmRelease := func(content []unstructured.Unstructured, check types.GomegaMatcher) {
 				GinkgoHelper()
 				helmreleases := 0
-				for manifest := range strings.SplitSeq(string(content), "---") {
-					if !strings.Contains(manifest, "kind: HelmRelease") {
+				for _, manifest := range content {
+					if manifest.GetAPIVersion() != "helm.toolkit.fluxcd.io/v2" ||
+						manifest.GetKind() != "HelmRelease" {
 						continue
 					}
 					helmreleases += 1
-					lines := strings.Split(manifest, "\n")
-					Expect(lines).To(check)
+					Expect(manifest.Object).To(check)
 				}
 				Expect(helmreleases).To(BeNumerically(">", 0), "helmrelease was not rendered")
 			}
@@ -376,7 +376,16 @@ var _ = Describe("RenderRelease", func() {
 					Component: solarv1alpha1.ReleaseComponent{
 						Name: "test-component",
 					},
-					Resources: map[string]solarv1alpha1.ResourceAccess{},
+					Resources: map[string]solarv1alpha1.ResourceAccess{
+						"foo": {
+							Repository: "example.com/my-chart",
+							Tag:        "1.0.0",
+						},
+					},
+					Entrypoint: solarv1alpha1.Entrypoint{
+						ResourceName: "foo",
+						Type:         solarv1alpha1.EntrypointTypeHelm,
+					},
 				},
 				Values:          runtime.RawExtension{},
 				TargetNamespace: "my-namespace",
@@ -386,14 +395,13 @@ var _ = Describe("RenderRelease", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			releasePath := filepath.Join(result.Dir, "templates", "release.yaml")
-			content, err := os.ReadFile(releasePath)
+			manifests, err := helmTemplate("foo", "default", result.Dir)
 			Expect(err).NotTo(HaveOccurred())
 
-			checkHelmRelease(content, ContainElements(
-				Equal("spec:"),
-				Equal("  targetNamespace: my-namespace"),
-			))
+			checkHelmRelease(manifests,
+				HaveKeyWithValue("spec",
+					HaveKeyWithValue("targetNamespace", "my-namespace"),
+				))
 
 			By("checking if spec.targetNamespace is not set when a TargetNamespace was not given")
 			config = solarv1alpha1.ReleaseConfig{
@@ -407,7 +415,16 @@ var _ = Describe("RenderRelease", func() {
 					Component: solarv1alpha1.ReleaseComponent{
 						Name: "test-component",
 					},
-					Resources: map[string]solarv1alpha1.ResourceAccess{},
+					Resources: map[string]solarv1alpha1.ResourceAccess{
+						"foo": {
+							Repository: "example.com/my-chart",
+							Tag:        "1.0.0",
+						},
+					},
+					Entrypoint: solarv1alpha1.Entrypoint{
+						ResourceName: "foo",
+						Type:         solarv1alpha1.EntrypointTypeHelm,
+					},
 				},
 				Values: runtime.RawExtension{},
 			}
@@ -416,13 +433,13 @@ var _ = Describe("RenderRelease", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			releasePath = filepath.Join(result.Dir, "templates", "release.yaml")
-			content, err = os.ReadFile(releasePath)
+			manifests, err = helmTemplate("foo", "default", result.Dir)
 			Expect(err).NotTo(HaveOccurred())
 
-			checkHelmRelease(content, Not(ContainElements(
-				ContainSubstring("targetNamespace:"),
-			)))
+			checkHelmRelease(manifests,
+				HaveKeyWithValue("spec",
+					Not(HaveKey("targetNamespace")),
+				))
 		})
 
 		It("should handle multiple resources", func() {

--- a/pkg/renderer/render_release_test.go
+++ b/pkg/renderer/render_release_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -345,6 +347,82 @@ var _ = Describe("RenderRelease", func() {
 			result, err = RenderRelease(config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
+		})
+
+		It("should handle target namespace", func() {
+			checkHelmRelease := func(content []byte, check types.GomegaMatcher) {
+				GinkgoHelper()
+				helmreleases := 0
+				for manifest := range strings.SplitSeq(string(content), "---") {
+					if !strings.Contains(manifest, "kind: HelmRelease") {
+						continue
+					}
+					helmreleases += 1
+					lines := strings.Split(manifest, "\n")
+					Expect(lines).To(check)
+				}
+				Expect(helmreleases).To(BeNumerically(">", 0), "helmrelease was not rendered")
+			}
+
+			By("checking if spec.targetNamespace was set when a TargetNamespace was given")
+			config := solarv1alpha1.ReleaseConfig{
+				Chart: solarv1alpha1.ChartConfig{
+					Name:        "test-release",
+					Description: "Test Release Chart",
+					Version:     "1.0.0",
+					AppVersion:  "1.0.0",
+				},
+				Input: solarv1alpha1.ReleaseInput{
+					Component: solarv1alpha1.ReleaseComponent{
+						Name: "test-component",
+					},
+					Resources: map[string]solarv1alpha1.ResourceAccess{},
+				},
+				Values:          runtime.RawExtension{},
+				TargetNamespace: "my-namespace",
+			}
+
+			result, err = RenderRelease(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			releasePath := filepath.Join(result.Dir, "templates", "release.yaml")
+			content, err := os.ReadFile(releasePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkHelmRelease(content, ContainElements(
+				Equal("spec:"),
+				Equal("  targetNamespace: my-namespace"),
+			))
+
+			By("checking if spec.targetNamespace is not set when a TargetNamespace was not given")
+			config = solarv1alpha1.ReleaseConfig{
+				Chart: solarv1alpha1.ChartConfig{
+					Name:        "test-release",
+					Description: "Test Release Chart",
+					Version:     "1.0.0",
+					AppVersion:  "1.0.0",
+				},
+				Input: solarv1alpha1.ReleaseInput{
+					Component: solarv1alpha1.ReleaseComponent{
+						Name: "test-component",
+					},
+					Resources: map[string]solarv1alpha1.ResourceAccess{},
+				},
+				Values: runtime.RawExtension{},
+			}
+
+			result, err = RenderRelease(config)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			releasePath = filepath.Join(result.Dir, "templates", "release.yaml")
+			content, err = os.ReadFile(releasePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			checkHelmRelease(content, Not(ContainElements(
+				ContainSubstring("targetNamespace:"),
+			)))
 		})
 
 		It("should handle multiple resources", func() {

--- a/pkg/renderer/suite_test.go
+++ b/pkg/renderer/suite_test.go
@@ -4,7 +4,17 @@
 package renderer
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"testing"
+
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/loader"
+	"helm.sh/helm/v4/pkg/cli"
+	releasev1 "helm.sh/helm/v4/pkg/release/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,4 +23,55 @@ import (
 func TestRenderer(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Renderer")
+}
+
+// helmTemplate templates a helm chart in path given the release name and namespace.
+// It returns a list of the templated manifests or an error.
+func helmTemplate(name, namespace, path string) ([]unstructured.Unstructured, error) {
+	GinkgoHelper()
+
+	settings := cli.New()
+	actionConfig := &action.Configuration{}
+
+	if err := actionConfig.Init(settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER")); err != nil {
+		return nil, err
+	}
+
+	chart, err := loader.Load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	install := action.NewInstall(actionConfig)
+	install.DryRunStrategy = action.DryRunClient
+	install.ReleaseName = name
+	install.Namespace = namespace
+
+	releaser, err := install.Run(chart, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rel, ok := releaser.(*releasev1.Release)
+	if !ok {
+		return nil, fmt.Errorf("releaser could not be cast to a release")
+	}
+
+	manifests := []unstructured.Unstructured{}
+	for m := range strings.SplitSeq(rel.Manifest, "---") {
+		if strings.TrimSpace(m) == "" {
+			continue
+		}
+
+		var object map[string]any
+		if err := yaml.Unmarshal([]byte(m), &object); err != nil {
+			return nil, err
+		}
+		manifest := unstructured.Unstructured{
+			Object: object,
+		}
+		manifests = append(manifests, manifest)
+	}
+
+	return manifests, nil
 }

--- a/pkg/renderer/template/bootstrap/templates/release.yaml
+++ b/pkg/renderer/template/bootstrap/templates/release.yaml
@@ -7,12 +7,22 @@
   {{- $name = printf "%s-%s" ($name | trunc 42) $sha }}
 {{- end }}
 
+{{- $releaseLabel := $k }}
+{{- if gt (len $releaseLabel) 63 }}
+  {{- $sha := $releaseLabel | sha256sum | trunc 10 }}
+  {{- $releaseLabel = printf "%s-%s" ($releaseLabel | trunc 52) $sha }}
+{{- end }}
+
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/release: {{ $releaseLabel }}
+  annotations:
+    solar.opendefense.cloud/release: {{ $k }}
 spec:
   interval: 10m
   url: oci://{{ $v.repository }}
@@ -33,6 +43,10 @@ kind: HelmRelease
 metadata:
   name: {{ $name }}
   namespace: {{ $.Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/release: {{ $releaseLabel }}
+  annotations:
+    solar.opendefense.cloud/release: {{ $k }}
 spec:
   interval: 10m
   chartRef:

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -68,6 +68,9 @@ spec:
   install:
     remediation:
       retries: 3
+    <<- with .TargetNamespace >>
+    createNamespace: true
+    <<- end >>
   upgrade:
     remediation:
       retries: 3
@@ -75,5 +78,8 @@ spec:
     enable: true
   driftDetection:
     mode: enabled
+  <<- with .TargetNamespace >>
+  targetNamespace: << . >>
+  <<- end >>
   values:
     << .Values | toYaml | nindent 4 >>

--- a/pkg/renderer/template/release/templates/release.yaml
+++ b/pkg/renderer/template/release/templates/release.yaml
@@ -4,6 +4,12 @@
   {{- $name = printf "%s-%s" ($name | trunc 42) $sha }}
 {{- end }}
 
+{{- $componentLabel := $.Values.component.name }}
+{{- if gt (len $componentLabel) 63 }}
+  {{- $sha := $componentLabel | sha256sum | trunc 10 }}
+  {{- $componentLabel = printf "%s-%s" ($componentLabel | trunc 52) $sha }}
+{{- end }}
+
 {{- $epName := .Values.entrypoint.resourceName }}
 {{- if not (hasKey .Values.resources $epName) }}
   {{- fail (printf "entrypoint resource %q not found in .Values.resources" $epName) }}
@@ -21,6 +27,10 @@ kind: OCIRepository
 metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/component: {{ $componentLabel }}
+  annotations:
+    solar.opendefense.cloud/component: {{ $.Values.component.name }}
 spec:
   interval: 4m
   url: oci://{{ $resource.repository }}
@@ -45,6 +55,10 @@ kind: HelmRelease
 metadata:
   name: {{ $name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    solar.opendefense.cloud/component: {{ $componentLabel }}
+  annotations:
+    solar.opendefense.cloud/component: {{ $.Values.component.name }}
 spec:
   interval: 10m
   chartRef:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,7 @@ const controllerNamespace = "solar-system"
 var _ = Describe("solar", Ordered, func() {
 	var controllerPodName string
 	var testns string
+	var deployns string
 	testStart := time.Now()
 
 	SetDefaultEventuallyTimeout(10 * time.Minute)
@@ -67,6 +68,7 @@ var _ = Describe("solar", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		testns = setupTestNS()
+		deployns = fmt.Sprintf("%s-deploy", testns)
 
 		By("deploying registry credentials to test namespace for per-task push auth")
 		applyResource(testns, filepath.Join(dir, "test", "fixtures", "e2e", "zot-deploy-auth.yaml"))
@@ -98,6 +100,14 @@ var _ = Describe("solar", Ordered, func() {
 		cmd := exec.Command(helmBinary, "uninstall", "-n", testns, "solar-discovery")
 		_, _ = run(cmd)
 		cmd = exec.Command(helmBinary, "uninstall", "-n", testns, "solar-discovery-scan")
+		_, _ = run(cmd)
+
+		By("removing testns")
+		cmd = exec.Command(kubectlBinary, "delete", "ns", testns)
+		_, _ = run(cmd)
+
+		By("removing deployns")
+		cmd = exec.Command(kubectlBinary, "delete", "ns", deployns)
 		_, _ = run(cmd)
 
 		By("undeploying the apiserver and controller-manager")
@@ -302,7 +312,12 @@ var _ = Describe("solar", Ordered, func() {
 
 		It("should render a Helm chart when a Release is created for a ComponentVersion", func() {
 			By("creating a Release for the ComponentVersion")
-			applyResource(testns, filepath.Join(dir, "test", "fixtures", "e2e", "release.yaml"))
+			release := patchYAMLFile(
+				filepath.Join(dir, "test", "fixtures", "e2e", "release.yaml"),
+				fmt.Sprintf(`[{"op": "replace", "path": "/spec/targetNamespace", "value":"%s"}]`, deployns),
+			)
+			defer func() { _ = os.Remove(release) }()
+			applyResource(testns, release)
 
 			By("waiting for ComponentVersionResolved condition to be set")
 			Eventually(func(g Gomega) {
@@ -459,23 +474,66 @@ var _ = Describe("solar", Ordered, func() {
 			// Each inner HelmRelease deploys its own workload. We expect two
 			// deployments: one from the directly assigned release and one from
 			// the profile-assigned release.
-			deploySelector := "helm.toolkit.fluxcd.io/namespace=" + testns
-			Eventually(func(g Gomega) {
-				cmd := exec.Command(kubectlBinary, "get", "deployments", "-n", testns,
+
+			// Get all the component HelmReleases
+			cmd := exec.Command(kubectlBinary, "get", "helmreleases.helm.toolkit.fluxcd.io", "-n", testns,
+				"-l", "solar.opendefense.cloud/component=opendefense-cloud-ocm-demo",
+				"-o", "jsonpath={.items[*].metadata.name}")
+			out, err := run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			deploymentHelmReleases := strings.Fields(out)
+			Expect(deploymentHelmReleases).To(HaveLen(2),
+				"did not find expected 2 HelmReleases, got %d", len(deploymentHelmReleases))
+
+			// Map the Deployment names and namespaces to their parent HelmReleases
+			type foundDeployment struct {
+				Name      string
+				Namespace string
+			}
+
+			foundDeployments := make(map[string]foundDeployment)
+
+			for _, helmrelease := range deploymentHelmReleases {
+				cmd := exec.Command(kubectlBinary, "get", "helmreleases.helm.toolkit.fluxcd.io", "-n", testns, helmrelease,
+					"-o", "jsonpath={.spec.targetNamespace}")
+				out, err := run(cmd)
+				Expect(err).NotTo(HaveOccurred())
+
+				// `.spec.targetNamespace` is an optional field used to specify the namespace to which the Helm release is made.
+				// It defaults to the namespace of the HelmRelease.
+				// Source: <https://fluxcd.io/flux/components/helm/helmreleases/#target-namespace>
+				targetns := out
+				if targetns == "" {
+					targetns = testns
+				}
+
+				deploySelector := fmt.Sprintf("helm.toolkit.fluxcd.io/name=%s", helmrelease)
+				cmd = exec.Command(kubectlBinary, "get", "deployments", "-n", targetns,
 					"-l", deploySelector,
 					"-o", "jsonpath={.items[*].metadata.name}")
-				out, err := run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				deployments := strings.Fields(out)
-				g.Expect(deployments).To(HaveLen(2),
-					"expected 2 workload deployments (direct + profile release), got: %v", deployments)
-			}).Should(Succeed())
+				out, err = run(cmd)
+				Expect(err).NotTo(HaveOccurred())
 
-			cmd := exec.Command(kubectlBinary, "wait", "-n", testns, "deployments",
-				"-l", deploySelector,
-				"--for=condition=Available", "--timeout=5m")
-			_, err := run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "workload deployments did not become Available")
+				deployments := strings.Fields(out)
+				Expect(deployments).To(HaveLen(1),
+					"did not find exactly one deployment for %s, got %d", helmrelease, len(deployments))
+
+				foundDeployments[helmrelease] = foundDeployment{
+					Name:      deployments[0],
+					Namespace: targetns,
+				}
+			}
+
+			Expect(foundDeployments).To(HaveLen(2), "did not find expected 2 deployments, got %d", len(foundDeployments))
+
+			// Verify Deployments become available
+			for _, deploy := range foundDeployments {
+				cmd := exec.Command(kubectlBinary, "wait", "deployments",
+					"-n", deploy.Namespace, deploy.Name,
+					"--for=condition=Available", "--timeout=5m")
+				_, err := run(cmd)
+				Expect(err).NotTo(HaveOccurred(), "workload deployment %s/%s did not become Available", deploy.Namespace, deploy.Name)
+			}
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -103,11 +103,11 @@ var _ = Describe("solar", Ordered, func() {
 		_, _ = run(cmd)
 
 		By("removing testns")
-		cmd = exec.Command(kubectlBinary, "delete", "ns", testns)
+		cmd = exec.Command(kubectlBinary, "delete", "ns", "--timeout", "2m", testns)
 		_, _ = run(cmd)
 
 		By("removing deployns")
-		cmd = exec.Command(kubectlBinary, "delete", "ns", deployns)
+		cmd = exec.Command(kubectlBinary, "delete", "ns", "--timeout", "2m", deployns)
 		_, _ = run(cmd)
 
 		By("undeploying the apiserver and controller-manager")
@@ -475,56 +475,58 @@ var _ = Describe("solar", Ordered, func() {
 			// deployments: one from the directly assigned release and one from
 			// the profile-assigned release.
 
-			// Get all the component HelmReleases
+			// Get the HelmReleases created by the ocm-demo component
 			cmd := exec.Command(kubectlBinary, "get", "helmreleases.helm.toolkit.fluxcd.io", "-n", testns,
 				"-l", "solar.opendefense.cloud/component=opendefense-cloud-ocm-demo",
 				"-o", "jsonpath={.items[*].metadata.name}")
 			out, err := run(cmd)
 			Expect(err).NotTo(HaveOccurred())
+
 			deploymentHelmReleases := strings.Fields(out)
 			Expect(deploymentHelmReleases).To(HaveLen(2),
 				"did not find expected 2 HelmReleases, got %d", len(deploymentHelmReleases))
 
-			// Map the Deployment names and namespaces to their parent HelmReleases
 			type foundDeployment struct {
 				Name      string
 				Namespace string
 			}
 
 			foundDeployments := make(map[string]foundDeployment)
+			Eventually(func(g Gomega) {
+				for _, helmrelease := range deploymentHelmReleases {
+					// Determine in which namespace to look for the deployment
+					cmd := exec.Command(kubectlBinary, "get", "helmreleases.helm.toolkit.fluxcd.io", "-n", testns, helmrelease,
+						"-o", "jsonpath={.spec.targetNamespace}")
+					out, err := run(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
 
-			for _, helmrelease := range deploymentHelmReleases {
-				cmd := exec.Command(kubectlBinary, "get", "helmreleases.helm.toolkit.fluxcd.io", "-n", testns, helmrelease,
-					"-o", "jsonpath={.spec.targetNamespace}")
-				out, err := run(cmd)
-				Expect(err).NotTo(HaveOccurred())
+					// `.spec.targetNamespace` is an optional field used to specify the namespace to which the Helm release is made.
+					// It defaults to the namespace of the HelmRelease.
+					// Source: <https://fluxcd.io/flux/components/helm/helmreleases/#target-namespace>
+					targetns := out
+					if targetns == "" {
+						targetns = testns
+					}
 
-				// `.spec.targetNamespace` is an optional field used to specify the namespace to which the Helm release is made.
-				// It defaults to the namespace of the HelmRelease.
-				// Source: <https://fluxcd.io/flux/components/helm/helmreleases/#target-namespace>
-				targetns := out
-				if targetns == "" {
-					targetns = testns
+					// Get the deployment from the target namespace
+					deploySelector := fmt.Sprintf("helm.toolkit.fluxcd.io/name=%s", helmrelease)
+					cmd = exec.Command(kubectlBinary, "get", "deployments", "-n", targetns,
+						"-l", deploySelector,
+						"-o", "jsonpath={.items[*].metadata.name}")
+					out, err = run(cmd)
+					g.Expect(err).NotTo(HaveOccurred())
+
+					deployments := strings.Fields(out)
+					g.Expect(deployments).To(HaveLen(1),
+						"did not find exactly one deployment for %s, got %d", helmrelease, len(deployments))
+
+					foundDeployments[helmrelease] = foundDeployment{
+						Name:      deployments[0],
+						Namespace: targetns,
+					}
 				}
-
-				deploySelector := fmt.Sprintf("helm.toolkit.fluxcd.io/name=%s", helmrelease)
-				cmd = exec.Command(kubectlBinary, "get", "deployments", "-n", targetns,
-					"-l", deploySelector,
-					"-o", "jsonpath={.items[*].metadata.name}")
-				out, err = run(cmd)
-				Expect(err).NotTo(HaveOccurred())
-
-				deployments := strings.Fields(out)
-				Expect(deployments).To(HaveLen(1),
-					"did not find exactly one deployment for %s, got %d", helmrelease, len(deployments))
-
-				foundDeployments[helmrelease] = foundDeployment{
-					Name:      deployments[0],
-					Namespace: targetns,
-				}
-			}
-
-			Expect(foundDeployments).To(HaveLen(2), "did not find expected 2 deployments, got %d", len(foundDeployments))
+				g.Expect(foundDeployments).To(HaveLen(2), "did not find expected 2 deployments, got %d", len(foundDeployments))
+			}).Should(Succeed())
 
 			// Verify Deployments become available
 			for _, deploy := range foundDeployments {

--- a/test/fixtures/e2e/release.yaml
+++ b/test/fixtures/e2e/release.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   componentVersionRef:
     name: opendefense-cloud-ocm-demo-v26-4-1
+  targetNamespace: demo


### PR DESCRIPTION
Fixes #239 

Successor of #299

- Add targetNamespace field to Releases
- Render targetNamespace in HelmRelease
- Generate RenderTasks with targetNamespace in RendererConfig
- Adjust end to end test to both verify targetNamespace gets set as well as look for deployments in the correct namespaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional targetNamespace added to Release/ReleaseConfig and client apply builders; renderer and controller propagate it and set createNamespace only when provided.
  * Generated manifests include stable release/component labels plus annotations with original names for traceability.

* **Documentation**
  * API reference and OpenAPI schemas updated to document targetNamespace.

* **Tests**
  * Unit, renderer and e2e tests added/updated to validate targetNamespace behavior, rendering, deployment and cleanup.

* **Style**
  * Minor internal grouping changes for compile-time assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->