### PR TITLE
docs: add controller and discovery pipeline documentation

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -15,6 +15,16 @@ nav:
 - Developer Guide:
   - CODE_OF_CONDUCT.md
   - CONTRIBUTING.md
-  - developer-guide/*.md
+  - developer-guide/architecture.md
+  - developer-guide/rendering-pipeline.md
+  - developer-guide/dev-cluster-with-kind.md
+  - developer-guide/working-with-docs.md
+  - Discovery:
+    - developer-guide/discovery_pipeline.md
+  - Controllers:
+    - developer-guide/release_controller.md
+    - developer-guide/profile_controller.md
+    - developer-guide/target_controller.md
+    - developer-guide/rendertask_controller.md
   - ADRs:
     - developer-guide/adrs/*.md

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -3,46 +3,67 @@
 SolAr is implemented as a Kubernetes Extension API Server integrated with the Kubernetes API Aggregation Layer. This architectural approach provides several advantages over Custom Resource Definitions (CRDs), including dedicated storage isolation, custom API implementation flexibility, and reduced risk to the hosting cluster's control plane.
 
 ```mermaid
-graph TB
-    subgraph "User Interface Layer"
-        User["User/Operator"]
-        Kubectl["kubectl CLI"]
+graph LR
+    subgraph UI["User Interface Layer"]
+        User["User / Operator"]
+        Kubectl["kubectl"]
         GitOps["GitOps Tools"]
+        User --> Kubectl
+        GitOps --> Kubectl
     end
 
-    subgraph "Kubernetes Control Plane"
-        K8sAPI["Kubernetes API Server"]
-        APIAgg["API Aggregation Layer"]
+    subgraph CP["Control Plane"]
+        K8sAPI["K8s API Server"]
+        APIAgg["API Aggregation"]
+        K8sAPI <--> APIAgg
+    end
 
-        subgraph "SolAr API Server"
-            SOLARAPI["SolAr Extension API Server"]
-            SOLARETCD["SolAr etcd<br/>Isolated Storage"]
+    subgraph DP["Data Plane"]
+        subgraph SolArAPI["SolAr API"]
+            SOLARAPI["SolAr API Server"]
+            SOLARETCD["SolAr etcd"]
+            SOLARAPI <--> SOLARETCD
+        end
+        subgraph Controllers["SolAr Controller Manager"]
+            TargetCtrl["Target Controller"]
+            ReleaseCtrl["Release Controller"]
+            ProfileCtrl["Profile Controller"]
+            RenderTaskCtrl["RenderTask Controller"]
+        end
+        Discovery["solar-discovery"]
+        RenderJob["RenderTask Jobs"]
+    end
+
+    subgraph ES["External Services"]
+        subgraph US["Upstream"]
+            SrcReg["Source Registries<br/>OCI / S3 / Helm"]
+        end
+        subgraph DS["Downstream"]
+            DstReg["Render Registries<br/>OCI"]
         end
     end
 
-    subgraph "SolAr Controller Manager"
-        TargetCtrl["Target Controller"]
-        ReleaseCtrl["Release Controller"]
-        ProfileCtrl["Profile Controller"]
-        RenderTaskCtrl["RenderTask Controller"]
+    subgraph TC["Target Cluster"]
+        Flux["Flux"]
+        App["Deployed App"]
+        Flux --> App
     end
 
-    subgraph "SolAr Discovery (standalone)"
-        Discovery["solar-discovery<br/>Scans OCI registries<br/>for OCM packages"]
-    end
+    Kubectl -->|"API requests"| K8sAPI
+    APIAgg -->|"proxies solar.* requests"| SOLARAPI
 
-    subgraph "External Systems"
-        SrcReg["Source Systems<br/>OCI Registries, S3,<br/>Helm Repos, HTTP"]
-        DstReg["Render Registries<br/>OCI Registries for<br/>rendered charts"]
-    end
+    ProfileCtrl -->|"watches Profiles +<br/>Targets, creates<br/>ReleaseBindings"| SOLARAPI
+    ReleaseCtrl -->|"validates Release →<br/>ComponentVersion"| SOLARAPI
+    TargetCtrl -->|"reads ReleaseBindings,<br/>Registries, Releases, CVs;<br/>creates RenderTasks"| SOLARAPI
+    RenderTaskCtrl -->|"watches RenderTasks,<br/>reads PushSecret,<br/>updates status"| SOLARAPI
+    RenderTaskCtrl -->|"creates + manages Jobs"| RenderJob
 
-    User -->|"Creates Releases,<br/>Targets, Profiles"| Kubectl
-    GitOps -->|"Declarative Config"| Kubectl
-    Kubectl -->|"API Requests"| K8sAPI
+    Discovery -->|"scans"| SrcReg
+    Discovery -->|"writes Components +<br/>ComponentVersions"| K8sAPI
+    RenderJob -->|"pushes charts"| DstReg
 
-    K8sAPI <-->|"Routes solar.opendefense.cloud"| APIAgg
-    APIAgg <-->|"Custom Resources"| SOLARAPI
-    SOLARAPI <-->|"Persists"| SOLARETCD
+    Flux -->|"pulls charts"| DstReg
+    Flux -->|"pulls images"| SrcReg
 ```
 
 **Architecture: SolAr System Components and Data Flow**
@@ -71,6 +92,7 @@ graph TB
 
     subgraph "Binding Resources"
         ReleaseBinding["ReleaseBinding"]
+        RegistryBinding["RegistryBinding"]
         Registry["Registry"]
     end
 
@@ -91,6 +113,8 @@ graph TB
     ReleaseBinding -->|"binds"| Target
 
     Target -->|"references"| Registry
+    RegistryBinding -->|"grants access"| Registry
+    RegistryBinding -->|"binds"| Target
     Target -->|"creates"| RenderTask
 
     Registry -->|"provides credentials<br/>and hostname"| RenderTask
@@ -102,6 +126,7 @@ graph TB
 - **Release** — declares which ComponentVersion to deploy and with what configuration.
 - **Target** — represents a deployment target (cluster). References a Registry via `renderRegistryRef` for pushing rendered charts.
 - **Registry** — stores OCI registry hostname and push credentials (`solarSecretRef`).
+- **RegistryBinding** — grants a specific Target permission to use a specific Registry for chart pushing.
 - **ReleaseBinding** — declares that a Release should be deployed to a Target. Created manually or automatically by the Profile controller.
 - **Profile** — matches Targets by label selector and automatically creates ReleaseBindings for a given Release.
 - **RenderTask** — internal resource created by the Target controller to drive chart rendering jobs.
@@ -109,4 +134,11 @@ graph TB
 ## Controllers
 
 - [Rendering pipeline](./rendering-pipeline.md) — how Targets, Releases, and RenderTasks produce deployable Helm charts
+- [Release controller](./release_controller.md) — validates Release → ComponentVersion references
+- [Profile controller](./profile_controller.md) — automates ReleaseBinding creation via label selectors
+- [Target controller](./target_controller.md) — orchestrates the rendering pipeline per target cluster
 - [RenderTask controller](./rendertask_controller.md) — lifecycle of individual RenderTask resources
+
+## Discovery
+
+- [Discovery pipeline](./discovery_pipeline.md) — how solar-discovery scans OCI registries and writes Component and ComponentVersion resources

--- a/docs/developer-guide/discovery_pipeline.md
+++ b/docs/developer-guide/discovery_pipeline.md
@@ -1,0 +1,222 @@
+# Discovery Pipeline Documentation
+
+## Overview
+
+The SolAr discovery pipeline (`solar-discovery`) is a standalone component that discovers OCM (Open Component Model) packages in OCI registries and writes them into the SolAr API as `Component` and `ComponentVersion` resources.
+
+Discovery is triggered in two ways: by periodically scanning a registry for all repositories, or by receiving push notifications from the registry via webhook. These modes can be used together or independently (`scanInterval: 0` disables polling).
+
+The pipeline is composed of a chain of channel-connected stages. Each stage processes events from its input channel and publishes results to its output channel, making the pipeline fully asynchronous and back-pressure-aware.
+
+## Pipeline Stages
+
+```mermaid
+flowchart LR
+    Reg[(OCI Registry)]
+    Webhook[Webhook Server]
+    Scanner[Registry Scanner]
+    Chan([repoEvents channel])
+
+    subgraph Pipeline
+        Q[Qualifier]
+        F[Filter]
+        H[Handler]
+        W[APIWriter]
+    end
+
+    K8s[(SolAr API)]
+
+    Reg -->|poll interval| Scanner
+    Reg -->|push notification| Webhook
+    Scanner -->|RepositoryEvent| Chan
+    Webhook -->|RepositoryEvent| Chan
+    Chan --> Q
+    Q -->|ComponentVersionEvent| F
+    F -->|ComponentVersionEvent| H
+    H -->|WriteAPIResourceEvent| W
+    W -->|create/update/delete| K8s
+```
+
+### Event Sources
+
+| Source          | Output            | Responsibility                                                          |
+| --------------- | ----------------- | ----------------------------------------------------------------------- |
+| RegistryScanner | `RepositoryEvent` | Periodically scans all repositories in an OCI registry                  |
+| WebhookServer   | `RepositoryEvent` | Accepts push notifications from OCI registries and emits events directly |
+
+### Pipeline Stages
+
+| Stage     | Input                   | Output                  | Responsibility                                                                   |
+| --------- | ----------------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| Qualifier | `RepositoryEvent`       | `ComponentVersionEvent` | Resolves repository name to namespace + component, looks up all versions via OCM |
+| Filter    | `ComponentVersionEvent` | `ComponentVersionEvent` | Drops events for ComponentVersions that already exist in the cluster             |
+| Handler   | `ComponentVersionEvent` | `WriteAPIResourceEvent` | Fetches the OCM component descriptor and builds the API resource payload         |
+| APIWriter | `WriteAPIResourceEvent` | –                       | Creates, updates, or deletes `Component` and `ComponentVersion` resources        |
+
+## Event Types
+
+```mermaid
+classDiagram
+    class RepositoryEvent {
+        Registry
+        Repository
+        Version
+        Digest
+        Type
+    }
+
+    class ComponentVersionEvent {
+        Namespace
+        Component
+        Version
+    }
+
+    class WriteAPIResourceEvent {
+        ComponentSpec
+        HelmDiscovery
+        Type
+    }
+
+    RepositoryEvent --> ComponentVersionEvent : Qualifier
+    ComponentVersionEvent --> WriteAPIResourceEvent : Handler
+```
+
+## Registry Scanner
+
+The `RegistryScanner` scans a single OCI registry on a configurable interval (`ScanInterval`, default 24 h). It lists all repositories via the ORAS library and emits a `RepositoryEvent` for each one. Concurrent scans are prevented by a mutex — if a scan is still running when the next tick fires, the tick is skipped.
+
+OCI registries can also push change notifications via webhooks. The `WebhookServer` accepts HTTP POST requests on configured paths and converts them directly into `RepositoryEvent`s, bypassing the polling interval.
+
+## Qualifier
+
+The Qualifier resolves a raw `RepositoryEvent` (registry + repository path) into one or more `ComponentVersionEvent`s by:
+
+1. Splitting the repository path into `namespace/component` segments.
+2. If the event already carries a specific version (e.g. from a webhook), emitting a single event for that version.
+3. Otherwise, looking up all versions of the component in the OCM repository and emitting one event per version.
+
+## Filter
+
+The Filter prevents duplicate work. For `EventCreated` events it checks whether the corresponding `ComponentVersion` already exists in the SolAr API. If it does, the event is silently dropped. All other event types (update, delete) pass through unconditionally.
+
+## Handler
+
+The Handler fetches the OCM component descriptor for a component version and builds the `ComponentVersion` payload. Currently handles components that contain exactly one Helm chart resource. Components with zero or more than one Helm chart are not yet supported.
+
+## APIWriter
+
+The APIWriter creates, updates, or deletes `Component` and `ComponentVersion` resources in the SolAr API. On deletion, if no more versions of a component remain, the parent `Component` resource is also deleted.
+
+## Sequence Diagrams
+
+### Scanner: Periodic poll discovers changes
+
+```mermaid
+sequenceDiagram
+    participant Timer as Tick (interval)
+    participant Scanner as Registry Scanner
+    participant Reg as OCI Registry
+    participant Chan as repoEvents channel
+
+    Timer->>Scanner: tick
+    Scanner->>Reg: List repositories
+    Reg-->>Scanner: [ocm-demo, other-component, …]
+    loop for each repository
+        Scanner->>Chan: RepositoryEvent(repo=ocm-demo, version="")
+    end
+```
+
+### Webhook: Registry pushes a change notification
+
+```mermaid
+sequenceDiagram
+    participant Dev as Solution Maintainer
+    participant Reg as OCI Registry
+    participant Webhook as Webhook Server
+    participant Chan as repoEvents channel
+
+    Dev->>Reg: ocm transfer ctf ./ocm-demo-ctf localhost/test
+    Note over Reg: Pushes opendefense.cloud/ocm-demo v26.4.1
+    Reg->>Webhook: POST /webhook/zot-discovery<br/>(repo=…/ocm-demo, tag=v26.4.1)
+    Webhook->>Chan: RepositoryEvent(version=v26.4.1)
+```
+
+### Shared pipeline: qualify, filter & write
+
+Once a `RepositoryEvent` is on the channel, both the scanner and webhook paths converge into this shared pipeline starting with the Qualifier.
+
+```mermaid
+sequenceDiagram
+    participant Chan as repoEvents channel
+    participant Qualifier as Qualifier
+    participant Reg as OCI Registry
+    participant Filter as Filter
+    participant Handler as Handler
+    participant Writer as APIWriter
+    participant K8s as SolAr API
+
+    Chan->>Qualifier: RepositoryEvent(ocm-demo, version="")
+    Note over Qualifier: No version specified —<br/>look up all versions
+    Qualifier->>Reg: ListComponentVersions(ocm-demo)
+    Reg-->>Qualifier: [v26.4.1, v26.4.0, …]
+    loop for each version
+        Qualifier->>Filter: ComponentVersionEvent(ocm-demo, vX.Y.Z)
+    end
+    Filter->>K8s: Get ComponentVersion "…-v26-4-1"
+    K8s-->>Filter: NotFound
+    Filter->>Handler: pass event
+    Handler->>Reg: LookupComponentVersion(ocm-demo, v26.4.1)
+    Reg-->>Handler: ComponentDescriptor (1 Helm resource)
+    Handler->>Writer: WriteAPIResourceEvent(ComponentSpec)
+    Writer->>K8s: Ensure Component "opendefense-cloud-ocm-demo"
+    Writer->>K8s: Create ComponentVersion "…-v26-4-1"
+```
+
+### Component version deleted from registry (with Component cascade)
+
+```mermaid
+sequenceDiagram
+    participant Dev as Solution Maintainer
+    participant Reg as OCI Registry
+    participant Webhook as Webhook Server
+
+    Dev->>Reg: Delete OCI tag v26.4.1
+    Reg->>Webhook: POST /webhook/zot-discovery<br/>(type=Deleted, digest=sha256:abc123…)
+    Note over Webhook: Only webhooks carry deletion events.<br/>The scanner emits EventCreated only.
+```
+
+#### Pipeline passthrough & cascade delete
+
+```mermaid
+sequenceDiagram
+    participant Qualifier as Qualifier
+    participant Filter as Filter
+    participant Handler as Handler
+    participant Writer as APIWriter
+    participant K8s as SolAr API
+
+    Note over Qualifier: RepositoryEvent(type=Deleted) —<br/>no OCM lookup needed
+    Qualifier->>Filter: ComponentVersionEvent(type=Deleted)
+    Note over Filter: Deletions bypass exists-check
+    Filter->>Handler: pass through
+    Note over Handler: No descriptor fetch needed
+    Handler->>Writer: WriteAPIResourceEvent(type=Deleted, digest=sha256:abc123…)
+    Writer->>K8s: List CVs (label: digest=abc123…)
+    K8s-->>Writer: [ocm-demo-v26-4-1]
+    Writer->>K8s: Delete ComponentVersion
+    Writer->>K8s: List CVs (label: component=ocm-demo)
+    K8s-->>Writer: [] (none remaining)
+    Writer->>K8s: Delete Component
+```
+
+## Configuration
+
+The discovery pipeline is configured via the `solar-discovery` binary flags and a registry configuration file. Per-registry settings include:
+
+| Setting          | Description                                             |
+| ---------------- | ------------------------------------------------------- |
+| `scanInterval`   | Polling interval for registry scans (0 = webhook only)  |
+| `webhookPath`    | HTTP path to register for push notifications (optional) |
+| `credentials`    | Username/password for authenticated registries          |
+| `plainHTTP`      | Whether to use plain HTTP instead of HTTPS              |
+

--- a/docs/developer-guide/profile_controller.md
+++ b/docs/developer-guide/profile_controller.md
@@ -1,0 +1,91 @@
+# Profile Controller Documentation
+
+## Overview
+
+The Profile controller manages the lifecycle of `Profile` custom resources in SolAr. It evaluates each Profile's `targetSelector` label selector against all Targets in the same namespace and creates or deletes `ReleaseBinding` resources accordingly.
+
+A Profile is the mechanism for automated, fleet-wide rollouts: rather than manually binding each Target to a Release, an operator defines a Profile that continuously keeps the binding set in sync with the set of matching Targets.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Kubernetes
+        Ctrl[Profile Controller]
+        Prof[Profile]
+        T1[Target A]
+        T2[Target B]
+        T3[Target C ✗]
+        RB1[ReleaseBinding A]
+        RB2[ReleaseBinding B]
+        Rel[Release]
+    end
+
+    Ctrl -->|reconciles| Prof
+    Prof -->|evaluates targetSelector| T1
+    Prof -->|evaluates targetSelector| T2
+    Prof -->|no match| T3
+
+    Prof -->|creates / owns| RB1
+    Prof -->|creates / owns| RB2
+
+    RB1 -->|binds Target A to| Rel
+    RB2 -->|binds Target B to| Rel
+```
+
+## Resource Owner References
+
+```mermaid
+flowchart LR
+    subgraph Profile
+        P[Profile]
+    end
+
+    subgraph Owned Resources
+        RB1[ReleaseBinding A]
+        RB2[ReleaseBinding B]
+    end
+
+    P -->|owns| RB1
+    P -->|owns| RB2
+```
+
+ReleaseBindings are created with an owner reference to the Profile. Kubernetes garbage-collects them automatically when the Profile is deleted.
+
+## Status Fields
+
+| Field              | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `matchedTargets`   | Number of Targets currently matched by the selector |
+
+## Watch Triggers
+
+The Profile controller is triggered when:
+
+- A `Profile` resource is created, updated, or deleted.
+- A `ReleaseBinding` owned by the Profile changes (via `Owns`).
+- A `Target` in the same namespace changes — the controller re-evaluates all Profiles whose selector might match the changed Target.
+
+## ReleaseBinding Naming
+
+ReleaseBindings are created with `generateName` using the pattern:
+
+```text
+<profile-name>-<target-name>-<random-suffix>
+```
+
+Names are truncated to 57 characters before the suffix to stay within the 63-character Kubernetes label value limit.
+
+## Relationship to Other Controllers
+
+```mermaid
+flowchart LR
+    ProfileCtrl[Profile Controller] -->|creates / deletes| ReleaseBinding
+    ReleaseBinding -->|triggers| TargetCtrl[Target Controller]
+    TargetCtrl -->|creates| RenderTask
+```
+
+Deleting a Profile cascades into:
+1. Kubernetes GC removes owned ReleaseBindings.
+2. Target controller notices the missing bindings and stops managing the corresponding RenderTasks.
+

--- a/docs/developer-guide/release_controller.md
+++ b/docs/developer-guide/release_controller.md
@@ -1,0 +1,58 @@
+# Release Controller Documentation
+
+## Overview
+
+The Release controller manages the lifecycle of `Release` custom resources in SolAr. Its primary responsibility is to validate that a Release's referenced `ComponentVersion` exists and to reflect the resolution status via status conditions.
+
+The Release controller does **not** trigger rendering — that is handled by the Target controller once a Release is bound to a Target via a `ReleaseBinding`.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Kubernetes
+        Ctrl[Release Controller]
+        Rel[Release]
+        CV[ComponentVersion]
+    end
+
+    Ctrl -->|reconciles| Rel
+    Rel -->|resolves| CV
+```
+
+## Status Conditions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unresolved: Release created
+    Unresolved --> ComponentVersionResolved: ComponentVersion found
+    Unresolved --> Unresolved: ComponentVersion missing (no requeue)
+    ComponentVersionResolved --> Unresolved: ComponentVersion deleted
+    ComponentVersionResolved --> [*]
+```
+
+| Condition                    | Status  | Reason      | Description                          |
+| ---------------------------- | ------- | ----------- | ------------------------------------ |
+| `ComponentVersionResolved`   | `True`  | `Resolved`  | ComponentVersion exists              |
+| `ComponentVersionResolved`   | `False` | `NotFound`  | ComponentVersion does not exist      |
+
+## Watch Triggers
+
+The Release controller is triggered when:
+
+- A `Release` resource is created, updated, or deleted.
+
+It does **not** watch `ComponentVersion` directly — if the ComponentVersion appears later, the Release will be reconciled again only when a change to the Release itself triggers a new reconcile. For production use, external signals (e.g. re-applying the Release) are required if a ComponentVersion is created after the Release.
+
+## Relationship to Other Controllers
+
+The Release controller is intentionally minimal. Rendering logic is delegated to the Target controller:
+
+```mermaid
+flowchart LR
+    Release -->|validated by| ReleaseCtrl[Release Controller]
+    Release -->|referenced by| ReleaseBinding
+    ReleaseBinding -->|bound by| Target
+    Target -->|creates RenderTasks via| TargetCtrl[Target Controller]
+```
+

--- a/docs/developer-guide/rendertask_controller.md
+++ b/docs/developer-guide/rendertask_controller.md
@@ -4,8 +4,7 @@
 
 The RenderTask controller manages the lifecycle of `RenderTask` custom
 resources in SolAr. It creates and manages a Kubernetes Job that executes the
-renderer container, along with associated Secrets for configuration and
-authentication.
+renderer container, along with a configuration Secret.
 
 A RenderTask is immutable once created.
 
@@ -19,7 +18,7 @@ flowchart TD
         J[Job]
         J -->|creates| Renderer[Renderer Pod]
         CS[Config Secret]
-        AS[Auth Secret]
+        PS[Push Secret]
     end
 
     subgraph Registry
@@ -29,13 +28,13 @@ flowchart TD
     Ctrl -->|reconciles| RT
 
     RT -->|creates| CS
-    RT -->|creates| AS
     RT -->|creates| J
+    RT -.->|referenced via pushSecretRef| PS
 
     Renderer -->|pushes| Chart
 
     Renderer -.-|mounts| CS
-    Renderer -.-|mounts| AS
+    Renderer -.-|mounts| PS
 ```
 
 ## Resource Owner References
@@ -49,12 +48,10 @@ flowchart LR
     subgraph Owned Resources
         JS[Job]
         CS[Config Secret]
-        AS[Auth Secret]
     end
 
     RT -->|owns| JS
     RT -->|owns| CS
-    RT -->|owns| AS
 ```
 
 ## Status Conditions
@@ -84,13 +81,12 @@ stateDiagram-v2
 | ----------   | --------------             | ----------- |
 | RenderJob    | `render-<rendertask-name>` | Inherited   |
 | ConfigSecret | `render-<rendertask-name>` | Inherited   |
-| AuthSecret   | `auth-<rendertask-name>`   | Inherited   |
 
 ## Cleanup Behavior
 
-- **On successful completion**: Deletes Job, config Secret, and auth Secret
-- **On deletion**: Deletes Job, config Secret, and auth Secret, then removes finalizer
-- **TTL**: Job has `TTLSecondsAfterFinished: 3600` (1 hour) as fallback cleanup
+- **On successful completion**: Deletes Job and config Secret.
+- **On deletion**: Owned resources (Job and config Secret) are garbage-collected by Kubernetes via owner references.
+- **On failure**: Config Secret is deleted after `spec.failedJobTTL` (default 1 hour). The Job is removed by Kubernetes via `TTLSecondsAfterFinished`.
 
 ## Controller Configuration
 
@@ -114,7 +110,6 @@ resolved by the Target controller from the Target's `renderRegistryRef`:
 3. When creating a RenderTask, the Target controller sets these values on the
    RenderTask spec so the renderer Job can authenticate to the registry.
 
-If `pushSecretRef` is set on the RenderTask, the controller copies the
-referenced secret into the RenderTask's namespace so it can be mounted by the
-renderer Pod. The copied secret is cleaned up together with the other
-RenderTask resources.
+If `pushSecretRef` is set on the RenderTask, the controller mounts the
+referenced secret directly into the renderer Pod. The push secret is managed
+externally and is not owned by the RenderTask.

--- a/docs/developer-guide/target_controller.md
+++ b/docs/developer-guide/target_controller.md
@@ -1,0 +1,162 @@
+# Target Controller Documentation
+
+## Overview
+
+The Target controller is the central orchestrator of the SolAr rendering pipeline. It manages the lifecycle of `Target` custom resources and drives the two-stage rendering pipeline that produces deployable Helm charts for each target cluster.
+
+For each Target, the controller:
+
+1. Resolves the render `Registry` referenced by `spec.renderRegistryRef`.
+2. Collects all `ReleaseBinding` resources that reference the Target.
+3. Creates a per-release `RenderTask` for each bound Release (Stage 1).
+4. Once all release RenderTasks succeed, creates a bootstrap `RenderTask` that bundles all rendered release charts (Stage 2).
+5. Manages cleanup of stale RenderTasks when the release set changes.
+
+See [Rendering Pipeline](./rendering-pipeline.md) for a detailed description of the two-stage pipeline.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Inputs
+        RB[ReleaseBindings]
+        Reg[Registry]
+        Rel[Releases]
+    end
+
+    subgraph Target Controller
+        Ctrl[TargetReconciler]
+    end
+
+    subgraph Outputs
+        RT1["RenderTask\n(per release)"]
+        RT2["RenderTask\n(bootstrap)"]
+    end
+
+    RB -->|triggers| Ctrl
+    Reg -->|triggers| Ctrl
+    Rel -->|triggers| Ctrl
+    RT1 -->|status change triggers| Ctrl
+    RT2 -->|status change triggers| Ctrl
+
+    Ctrl -->|creates/tracks| RT1
+    Ctrl -->|creates/tracks| RT2
+```
+
+## Status Conditions
+
+```mermaid
+stateDiagram-v2
+    [*] --> RegistryUnresolved: Target created
+    RegistryUnresolved --> RegistryResolved: Registry found with SolarSecretRef
+    RegistryResolved --> ReleasesRendering: ReleaseBindings exist
+    ReleasesRendering --> ReleasesRendered: All release RenderTasks succeeded
+    ReleasesRendered --> BootstrapRendering: Bootstrap RenderTask created
+    BootstrapRendering --> BootstrapReady: Bootstrap RenderTask succeeded
+    BootstrapRendering --> BootstrapFailed: Bootstrap RenderTask failed
+    ReleasesRendering --> ReleasesFailed: Any release RenderTask failed
+```
+
+| Condition            | Status  | Reason                  | Description                                          |
+| -------------------- | ------- | ----------------------- | ---------------------------------------------------- |
+| `RegistryResolved`   | `True`  | `Resolved`              | Registry found and has `solarSecretRef`              |
+| `RegistryResolved`   | `False` | `NotFound`              | Registry resource not found                          |
+| `RegistryResolved`   | `False` | `MissingSolarSecretRef` | Registry exists but lacks push credentials           |
+| `ReleasesRendered`   | `True`  | `AllRendered`           | All release RenderTasks completed successfully       |
+| `ReleasesRendered`   | `False` | `NoBindings`            | No ReleaseBindings found for this Target             |
+| `ReleasesRendered`   | `False` | `Pending`               | Waiting for release RenderTasks to complete          |
+| `ReleasesRendered`   | `False` | `MissingDependencies`   | One or more Releases or ComponentVersions not found  |
+| `ReleasesRendered`   | `False` | `ReleaseFailed`         | At least one release RenderTask failed               |
+| `BootstrapReady`     | `True`  | `Ready`                 | Bootstrap RenderTask succeeded; `ChartURL` populated |
+| `BootstrapReady`     | `False` | `Failed`                | Bootstrap RenderTask failed                          |
+
+## Finalizer
+
+The Target controller adds the finalizer `solar.opendefense.cloud/target-finalizer` to every Target. On deletion, it:
+
+1. Deletes all RenderTasks owned by the Target.
+2. Removes the finalizer to allow the Target to be garbage-collected.
+
+## RenderTask Naming
+
+| RenderTask type | Name pattern                            |
+| --------------- | --------------------------------------- |
+| Release         | `render-rel-<release-name>-<hash>`      |
+| Bootstrap       | `render-tgt-<target-name>-<version>`    |
+
+## Bootstrap Versioning
+
+The bootstrap chart version is incremented whenever the set of bound releases or their resolved content changes, ensuring a new chart is pushed whenever the desired state changes. Stale RenderTasks from prior versions are cleaned up after the current bootstrap succeeds.
+
+## Watch Triggers
+
+| Watched Resource  | Mapping                                           |
+| ----------------- | ------------------------------------------------- |
+| `Target`          | Direct reconcile of the Target                    |
+| `ReleaseBinding`  | Reconcile the Target referenced by the binding    |
+| `RenderTask`      | Reconcile the owning Target (status change only)  |
+| `Registry`        | Reconcile all Targets that reference the Registry |
+| `Release`         | Reconcile all Targets bound to the Release        |
+
+## Sequence Diagrams
+
+### New Release added via Profile (triggers bootstrap re-render)
+
+```mermaid
+sequenceDiagram
+    participant User as Deployment Coordinator
+    participant K8s as Kubernetes API
+    participant ProfileCtrl as Profile Controller
+    participant TargetCtrl as Target Controller
+    participant RenderTaskCtrl as RenderTask Controller
+    participant Registry as OCI Registry
+
+    User->>K8s: Create Profile (targetSelector, releaseRef)
+    K8s->>ProfileCtrl: Reconcile(Profile)
+    ProfileCtrl->>K8s: Create ReleaseBinding (Target ← Release)
+
+    K8s->>TargetCtrl: Reconcile(Target) [new ReleaseBinding]
+    TargetCtrl->>K8s: Create release RenderTask
+    K8s->>RenderTaskCtrl: Reconcile(RenderTask)
+    RenderTaskCtrl->>Registry: Push release chart
+    RenderTaskCtrl->>K8s: Update RenderTask status (succeeded)
+
+    K8s->>TargetCtrl: Reconcile(Target) [RenderTask status changed]
+    TargetCtrl->>K8s: Update status (ReleasesRendered=True)
+    Note over TargetCtrl: Bootstrap input changed → create new bootstrap RenderTask,<br/>delete stale one from prior version
+    TargetCtrl->>K8s: Create bootstrap RenderTask
+    K8s->>RenderTaskCtrl: Reconcile(RenderTask)
+    RenderTaskCtrl->>Registry: Push bootstrap chart
+    RenderTaskCtrl->>K8s: Update RenderTask status (succeeded)
+
+    K8s->>TargetCtrl: Reconcile(Target) [RenderTask status changed]
+    TargetCtrl->>K8s: Update status (BootstrapReady=True)
+```
+
+### Target deletion
+
+```mermaid
+sequenceDiagram
+    participant User as Cluster Maintainer
+    participant K8s as Kubernetes API
+    participant TargetCtrl as Target Controller
+
+    User->>K8s: Delete Target
+    K8s->>TargetCtrl: Reconcile(Target) [DeletionTimestamp set]
+    TargetCtrl->>K8s: List owned RenderTasks
+    TargetCtrl->>K8s: Delete all owned RenderTasks
+    TargetCtrl->>K8s: Remove finalizer
+    Note over K8s: Target is garbage-collected
+```
+
+## Relationship to Other Controllers
+
+```mermaid
+flowchart LR
+    ProfileCtrl[Profile Controller] -->|creates| ReleaseBinding
+    ReleaseBinding -->|triggers| TargetCtrl[Target Controller]
+    TargetCtrl -->|creates| RenderTask
+    RenderTask -->|managed by| RenderTaskCtrl[RenderTask Controller]
+    RenderTaskCtrl -->|status update triggers| TargetCtrl
+```
+


### PR DESCRIPTION
## Summary
Add comprehensive developer documentation for SolAr's controllers and discovery pipeline.
## Changes
### New Documentation
- **`docs/developer-guide/discovery_pipeline.md`** - Documents the solar-discovery pipeline that scans OCI registries for OCM packages. Covers:
  - Pipeline stages (RegistryScanner, Qualifier, Filter, Handler, APIWriter)
  - Event types and data flow
  - Runner concurrency model
  - Configuration options
- **`docs/developer-guide/release_controller.md`** - Documents the Release controller that validates ComponentVersion references and reports resolution status.
- **`docs/developer-guide/profile_controller.md`** - Documents the Profile controller that automates ReleaseBinding creation via label selectors for fleet-wide rollouts.
- **`docs/developer-guide/target_controller.md`** - Documents the Target controller that orchestrates the two-stage rendering pipeline per target cluster. Includes:
  - Status conditions and state transitions
  - RenderTask naming conventions  
  - Bootstrap versioning
  - Detailed sequence diagrams for common workflows
### Updates
- **`docs/developer-guide/architecture.md`** - Added links to new controller documentation
- **`docs/.nav.yml`** - Explicitly listed nav entries with grouped sections for Discovery and Controllers
## Motivation
This documentation enables new developers to understand SolAr's architecture without reading through implementation code. The controller docs describe behavior, status conditions, watch triggers, and relationships between resources.

## How to review

1. `git switch docs/controller-and-discovery`
2. `make docs`
3. Open http://localhost:8000/developer-guide/architecture/#controllers in a browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added in-depth guides for Discovery, Profile, Release, Target, and RenderTask controllers.
  * Expanded architecture diagrams (switched to left-to-right) and clarified controller interactions, control-flow, and lifecycle behaviors.
  * Reorganized developer guide navigation into an explicit allowlist with grouped Discovery and Controllers sections.
  * Documented a RegistryBinding concept, Profile->ReleaseBinding naming/truncation, Release status resolution behavior, Target bootstrap/versioning semantics, and RenderTask credential/cleanup changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->