### PR TITLE
feat: add uniqueName to ReleaseSpec

### DIFF
--- a/api/solar/release_rest.go
+++ b/api/solar/release_rest.go
@@ -85,7 +85,13 @@ func (o *Release) Validate(ctx context.Context) field.ErrorList {
 }
 
 func (o *Release) ValidateUpdate(ctx context.Context, old runtime.Object) field.ErrorList {
-	return validateRelease(o)
+	errors := validateRelease(o)
+	or := old.(*Release)
+	if o.Spec.UniqueName != or.Spec.UniqueName {
+		errors = append(errors, field.Forbidden(field.NewPath("spec").Child("uniqueName"), "uniqueName is immutable"))
+	}
+
+	return errors
 }
 
 func validateRelease(o *Release) field.ErrorList {

--- a/api/solar/release_rest.go
+++ b/api/solar/release_rest.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var (
@@ -20,6 +21,8 @@ var (
 	_ rest.PrepareForUpdater               = &Release{}
 	_ rest.PrepareForCreater               = &Release{}
 	_ rest.TableConverter                  = &Release{}
+	_ rest.Validater                       = &Release{}
+	_ rest.ValidateUpdater                 = &Release{}
 )
 
 func (o *Release) GetObjectMeta() *metav1.ObjectMeta {
@@ -75,4 +78,21 @@ func (o *Release) ConvertToTable(ctx context.Context, tableOptions runtime.Objec
 		},
 		[]any{o.Name, o.Spec.ComponentVersionRef.Name, status, duration.HumanDuration(metav1.Now().Sub(o.CreationTimestamp.Time))},
 	), nil
+}
+
+func (o *Release) Validate(ctx context.Context) field.ErrorList {
+	return validateRelease(o)
+}
+
+func (o *Release) ValidateUpdate(ctx context.Context, old runtime.Object) field.ErrorList {
+	return validateRelease(o)
+}
+
+func validateRelease(o *Release) field.ErrorList {
+	errors := field.ErrorList{}
+	if o.Spec.UniqueName == "" {
+		errors = append(errors, field.Required(field.NewPath("spec").Child("uniqueName"), "uniqueName must not be empty"))
+	}
+
+	return errors
 }

--- a/api/solar/release_rest_test.go
+++ b/api/solar/release_rest_test.go
@@ -55,7 +55,21 @@ var _ = Describe("Release REST", func() {
 			Expect(errs[0].Field).To(Equal("spec.uniqueName"))
 		})
 
-		It("accepts a non-empty UniqueName", func() {
+		It("rejects a changed UniqueName", func() {
+			old := &solar.Release{
+				Spec: solar.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+					UniqueName:          "kyverno",
+				},
+			}
+			updated := old.DeepCopy()
+			updated.Spec.UniqueName = "kyverno-renamed"
+			errs := updated.ValidateUpdate(context.Background(), old)
+			Expect(errs).NotTo(BeEmpty())
+			Expect(errs[0].Field).To(Equal("spec.uniqueName"))
+		})
+
+		It("accepts an unchanged UniqueName", func() {
 			r := &solar.Release{
 				Spec: solar.ReleaseSpec{
 					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},

--- a/api/solar/release_rest_test.go
+++ b/api/solar/release_rest_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package solar_test
+
+import (
+	"context"
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"go.opendefense.cloud/solar/api/solar"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Release REST", func() {
+	Describe("Validate (create path)", func() {
+		It("rejects an empty UniqueName", func() {
+			r := &solar.Release{
+				Spec: solar.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+					UniqueName:          "",
+				},
+			}
+			errs := r.Validate(context.Background())
+			Expect(errs).NotTo(BeEmpty())
+			Expect(errs[0].Field).To(Equal("spec.uniqueName"))
+		})
+
+		It("accepts a non-empty UniqueName", func() {
+			r := &solar.Release{
+				Spec: solar.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+					UniqueName:          "kyverno",
+				},
+			}
+			Expect(r.Validate(context.Background())).To(BeEmpty())
+		})
+	})
+
+	Describe("ValidateUpdate (update path)", func() {
+		It("rejects an empty UniqueName", func() {
+			old := &solar.Release{
+				Spec: solar.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+					UniqueName:          "kyverno",
+				},
+			}
+			updated := old.DeepCopy()
+			updated.Spec.UniqueName = ""
+			errs := updated.ValidateUpdate(context.Background(), old)
+			Expect(errs).NotTo(BeEmpty())
+			Expect(errs[0].Field).To(Equal("spec.uniqueName"))
+		})
+
+		It("accepts a non-empty UniqueName", func() {
+			r := &solar.Release{
+				Spec: solar.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+					UniqueName:          "kyverno",
+				},
+			}
+			Expect(r.ValidateUpdate(context.Background(), r.DeepCopy())).To(BeEmpty())
+		})
+	})
+
+	Describe("ReleaseSpec JSON", func() {
+		It("serializes UniqueName", func() {
+			spec := solar.ReleaseSpec{
+				ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+				UniqueName:          "kyverno",
+			}
+			data, err := json.Marshal(spec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring(`"uniqueName":"kyverno"`))
+		})
+
+		It("deserializes UniqueName", func() {
+			data := []byte(`{"componentVersionRef":{"name":"kyverno-v1"},"uniqueName":"kyverno"}`)
+			var spec solar.ReleaseSpec
+			Expect(json.Unmarshal(data, &spec)).To(Succeed())
+			Expect(spec.UniqueName).To(Equal("kyverno"))
+		})
+
+		It("round-trips UniqueName through JSON", func() {
+			original := solar.ReleaseSpec{
+				ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
+				UniqueName:          "kyverno",
+			}
+			data, err := json.Marshal(original)
+			Expect(err).NotTo(HaveOccurred())
+			var restored solar.ReleaseSpec
+			Expect(json.Unmarshal(data, &restored)).To(Succeed())
+			Expect(restored.UniqueName).To(Equal(original.UniqueName))
+		})
+	})
+})

--- a/api/solar/release_types.go
+++ b/api/solar/release_types.go
@@ -18,6 +18,9 @@ type ReleaseSpec struct {
 	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
 	// +optional
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
+	// UniqueName is a logical identifier used to ensure this component is deployed
+	// only once per target cluster when multiple Profiles match the same target.
+	UniqueName string `json:"uniqueName"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -18,6 +18,9 @@ type ReleaseSpec struct {
 	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
 	// +optional
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
+	// UniqueName is a logical identifier used to ensure this component is deployed
+	// only once per target cluster when multiple Profiles match the same target.
+	UniqueName string `json:"uniqueName"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	// +optional

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1399,6 +1399,7 @@ func Convert_solar_ReleaseList_To_v1alpha1_ReleaseList(in *solar.ReleaseList, ou
 func autoConvert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *solar.ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
 	out.TargetNamespace = (*string)(unsafe.Pointer(in.TargetNamespace))
+	out.UniqueName = in.UniqueName
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil
@@ -1412,6 +1413,7 @@ func Convert_v1alpha1_ReleaseSpec_To_solar_ReleaseSpec(in *ReleaseSpec, out *sol
 func autoConvert_solar_ReleaseSpec_To_v1alpha1_ReleaseSpec(in *solar.ReleaseSpec, out *ReleaseSpec, s conversion.Scope) error {
 	out.ComponentVersionRef = in.ComponentVersionRef
 	out.TargetNamespace = (*string)(unsafe.Pointer(in.TargetNamespace))
+	out.UniqueName = in.UniqueName
 	out.Values = in.Values
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	return nil

--- a/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/releasespec.go
@@ -21,6 +21,9 @@ type ReleaseSpecApplyConfiguration struct {
 	ComponentVersionRef *v1.LocalObjectReference `json:"componentVersionRef,omitempty"`
 	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
+	// UniqueName is a logical identifier used to ensure this component is deployed
+	// only once per target cluster when multiple Profiles match the same target.
+	UniqueName *string `json:"uniqueName,omitempty"`
 	// Values contains deployment-specific values or configuration for the release.
 	// These values override defaults from the component version and are used during deployment.
 	Values *runtime.RawExtension `json:"values,omitempty"`
@@ -50,6 +53,14 @@ func (b *ReleaseSpecApplyConfiguration) WithComponentVersionRef(value v1.LocalOb
 // If called multiple times, the TargetNamespace field is set to the value of the last call.
 func (b *ReleaseSpecApplyConfiguration) WithTargetNamespace(value string) *ReleaseSpecApplyConfiguration {
 	b.TargetNamespace = &value
+	return b
+}
+
+// WithUniqueName sets the UniqueName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the UniqueName field is set to the value of the last call.
+func (b *ReleaseSpecApplyConfiguration) WithUniqueName(value string) *ReleaseSpecApplyConfiguration {
+	b.UniqueName = &value
 	return b
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -1799,6 +1799,14 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"uniqueName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UniqueName is a logical identifier used to ensure this component is deployed only once per target cluster when multiple Profiles match the same target.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"values": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Values contains deployment-specific values or configuration for the release. These values override defaults from the component version and are used during deployment.",
@@ -1813,7 +1821,7 @@ func schema_solar_api_solar_v1alpha1_ReleaseSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"componentVersionRef"},
+				Required: []string{"componentVersionRef", "uniqueName"},
 			},
 		},
 		Dependencies: []string{

--- a/cmd/solar-apiserver/apiserver_test.go
+++ b/cmd/solar-apiserver/apiserver_test.go
@@ -5,6 +5,7 @@ package main_test
 
 import (
 	"go.opendefense.cloud/kit/envtest"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -83,7 +84,10 @@ var _ = Describe("Release", func() {
 					Namespace:    ns.Name,
 					GenerateName: "test-",
 				},
-				Spec: solarv1alpha1.ReleaseSpec{},
+				Spec: solarv1alpha1.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-component-v1"},
+					UniqueName:          "my-component",
+				},
 			}
 			Expect(k8sClient.Create(ctx, rel)).To(Succeed())
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rel), rel)).To(Succeed())

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -550,6 +550,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `componentVersionRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ComponentVersionRef is a reference to the ComponentVersion to be released.<br />It points to the specific version of a component that this release is based on. |  |  |
 | `targetNamespace` _string_ | TargetNamespace is the namespace the ComponentVersion gets deployed to. |  |  |
+| `uniqueName` _string_ | UniqueName is a logical identifier used to ensure this component is deployed<br />only once per target cluster when multiple Profiles match the same target. |  |  |
 | `values` _[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#rawextension-runtime-pkg)_ | Values contains deployment-specific values or configuration for the release.<br />These values override defaults from the component version and are used during deployment. |  |  |
 | `failedJobTTL` _integer_ | failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.<br />After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete<br />the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.<br />If not set, defaults to 3600 (1 hour). |  |  |
 

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -28,6 +28,7 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 					ComponentVersionRef: corev1.LocalObjectReference{
 						Name: "my-component-v1",
 					},
+					UniqueName: "my-component",
 					Values: runtime.RawExtension{
 						Raw: []byte(`{"key": "value"}`),
 					},
@@ -58,6 +59,14 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 			}
 		}
 	)
+
+	Describe("UniqueName validation", func() {
+		It("should reject a Release with an empty UniqueName", func() {
+			release := validRelease("test-release-empty-unique-name", ns)
+			release.Spec.UniqueName = ""
+			Expect(k8sClient.Create(ctx, release)).NotTo(Succeed())
+		})
+	})
 
 	Describe("ComponentVersion resolution", func() {
 		It("should set ComponentVersionResolved=True when ComponentVersion exists", func() {

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -69,6 +69,7 @@ var _ = Describe("TargetController", Ordered, func() {
 				},
 				Spec: solarv1alpha1.ReleaseSpec{
 					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
+					UniqueName:          "my-component",
 					Values:              runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
 					TargetNamespace:     new("my-namespace"),
 				},

--- a/test/fixtures/e2e/profile-release.yaml
+++ b/test/fixtures/e2e/profile-release.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   componentVersionRef:
     name: opendefense-cloud-ocm-demo-v26-4-2
+  uniqueName: opendefense-cloud-ocm-demo
   values:
     imagePullSecrets:
       - name: regcred

--- a/test/fixtures/e2e/release.yaml
+++ b/test/fixtures/e2e/release.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   componentVersionRef:
     name: opendefense-cloud-ocm-demo-v26-4-2
+  uniqueName: opendefense-cloud-ocm-demo
   targetNamespace: demo
   values:
     imagePullSecrets:


### PR DESCRIPTION
Closes #242.

Adds a required `uniqueName` field to `ReleaseSpec`. The field serves as a logical identifier for a component deployment and will be used by the Profile controller (#246) to enforce that a given component (e.g. Kyverno) is deployed only once per target cluster, even when multiple Profiles match the same target.

The field is required rather than optional — there is no implicit fallback, and the ADR treats the unique name as fundamental to every Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a required ReleaseSpec field `uniqueName` to uniquely identify releases and avoid duplicate component deployments when multiple profiles match the same cluster.

* **Validation**
  * Creation requires non-empty `spec.uniqueName`; updates reject empty or changed `uniqueName` (immutable).

* **Documentation**
  * API reference updated to document the new `uniqueName` field.

* **Tests & Fixtures**
  * Tests and example manifests updated to include and validate `uniqueName`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->