### PR TITLE
feat: improve dev flow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,4 @@
 
 export DIRENV_WARN_TIMEOUT=20s
 
-eval "$(nix --extra-experimental-features "nix-command flakes" --no-pure-eval print-dev-env)"
-
-[[ -f .git/hooks/pre-commit.legacy ]] && rm -v .git/hooks/pre-commit.legacy
+use flake

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -58,8 +58,6 @@ jobs:
           go-version: ${{ needs.lint.outputs.go-version }}
       - name: test
         run: |
-          make ocm
-          make ocm-transfer-demo
           make test
       - name: Convert coverage to lcov
         uses: jandelgado/gcov2lcov-action@v1.2.0

--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,6 @@ apiserver.local.config/
 default.etcd/
 .DS_Store
 
-# Devenv
-.devenv*
-devenv.local.nix
-devenv.local.yaml
-
 # direnv
 .direnv
 
@@ -56,3 +51,5 @@ pkg/ui/static
 web/dist
 web/node_modules
 web/.vite
+
+common.mk

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,17 @@
+# Include ODC common make targets
+DEV_KIT_VERSION := v1.0.2
+-include common.mk
+common.mk:
+	curl --fail -sSL https://raw.githubusercontent.com/opendefensecloud/dev-kit/$(DEV_KIT_VERSION)/common.mk -o common.mk.download && \
+	mv common.mk.download $@
 
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
-
-# Set MAKEFLAGS to suppress entering/leaving directory messages
-MAKEFLAGS += --no-print-directory
-
-BUILD_PATH ?= $(shell pwd)
 HACK_DIR ?= $(shell cd hack 2>/dev/null && pwd)
-LOCALBIN ?= $(BUILD_PATH)/bin
 SOLAR_CHART_DIR ?= $(BUILD_PATH)/charts/solar
+
 OCM_DEMO_DIR ?= $(BUILD_PATH)/test/fixtures/ocm-demo-ctf
 OCM_DEMO_VERSION ?= v26.4.2
 
-OS := $(shell go env GOOS)
-ARCH := $(shell go env GOARCH)
-
-GO ?= go
-SHELLCHECK ?= shellcheck
-MKDOCS ?= mkdocs
-DOCKER ?= docker
-KIND ?= kind
-KUBECTL ?= kubectl
-HELM ?= helm
-FLUX ?= flux
-YQ ?= yq
-OSV_SCANNER ?= $(LOCALBIN)/osv-scanner
-GINKGO ?= $(LOCALBIN)/ginkgo
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
-SETUP_ENVTEST ?= $(LOCALBIN)/setup-envtest
-ADDLICENSE ?= $(LOCALBIN)/addlicense
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-OPENAPI_GEN ?= $(LOCALBIN)/openapi-gen
-CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
-HELM_DOCS ?= $(LOCALBIN)/helm-docs
-OCM ?= $(LOCALBIN)/ocm
-
-OSV_SCANNER_VERSION ?= $(shell sed -rn 's#uses: "google/osv-scanner-action.*(v.*)$$#\1#p' .github/workflows/osv-scanner.yml | uniq | tr -d "[:space:]")
-GINKGO_VERSION ?= $(shell go list -json -m -u github.com/onsi/ginkgo/v2 | jq -r '.Version')
-GOLANGCI_LINT_VERSION ?= v2.10.1
-SETUP_ENVTEST_VERSION ?= release-0.22
-ADDLICENSE_VERSION ?= v1.1.1
-CONTROLLER_TOOLS_VERSION ?= v0.19.0
-OPENAPI_GEN_VERSION ?= $(shell go list -json -m -u k8s.io/kube-openapi | jq -r '.Version')
 ENVTEST_K8S_VERSION ?= 1.34.1
-CRD_REF_DOCS_VERSION ?= v0.2.0
-HELM_DOCS_VERSION ?= v1.14.2
-OCM_VERSION ?= 0.34.3
 
 export GOPRIVATE=*.go.opendefense.cloud/solar
 export GNOSUMDB=*.go.opendefense.cloud/solar
@@ -63,67 +27,41 @@ TIMESTAMP := $(shell date '+%Y%m%d%H%M%S')
 DEV_TAG ?= dev.$(TIMESTAMP)
 export DEV_TAG
 
-##@ General
-
-# The help target prints out all targets with their descriptions organized
-# beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
-# entire set of makefiles included in this invocation, looking for lines of the
-# file as xyz: ## something, and then pretty-format the target and help. Then,
-# if there's a line with ##@ something, that gets pretty-printed as a category.
-# More info on the usage of ANSI control characters for terminal formatting:
-# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
-# More info on the awk command:
-# http://linuxcommand.org/lc3_adv_awk.php
-
-help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-
-.PHONY: clean
-clean:
-	rm -rf $(LOCALBIN)
-
 .PHONY: codegen
-codegen: openapi-gen manifests ## Run code generation, e.g. openapi
+codegen: $(OPENAPI_GEN) manifests ## Run code generation, e.g. openapi
 	OPENAPI_GEN=$(OPENAPI_GEN) ./hack/update-codegen.sh
 	$(MAKE) docs-crd-ref
 
 .PHONY: fmt
-fmt: addlicense golangci-lint ## Add license headers and format code
-	find . -not -path '*/.*' -name '*.go' -exec $(ADDLICENSE) -c 'BWI GmbH and Solution Arsenal contributors' -l apache -s=only {} +
+fmt: $(ADDLICENSE) $(GOLANGCI_LINT) ## Add license headers and format code
+	git ls-files | grep '.*\.go$$' | xargs $(ADDLICENSE) -c 'BWI GmbH and Solution Arsenal contributors' -l apache -s=only
 	$(GO) fmt ./...
 	$(GOLANGCI_LINT) run --fix
 
-.PHONY: mod
-mod: ## Do go mod tidy, download, verify
-	@$(GO) mod tidy
-	@$(GO) mod download
-	@$(GO) mod verify
-
 .PHONY: lint
-lint: lint-no-golangci golangci-lint ## Run linters such as golangci-lint and addlicence checks
-	$(GOLANGCI_LINT) run -v
+lint: lint-no-golangci golangci-lint ## Run linters
 
 .PHONY: lint-no-golangci
-lint-no-golangci: addlicense
-	find . -not -path '*/.*' -name '*.go' -exec $(ADDLICENSE) -check  -l apache -s=only -check {} +
-	shellcheck hack/*.sh
-
-.PHONY: scan
-scan: osv-scanner
-	$(OSV_SCANNER) scan --config ./.osv-scanner.toml -r .
+lint-no-golangci: $(ADDLICENSE) shellcheck  ## Run linters but not golangci-lint to exit early in CI/CD pipeline
+	git ls-files | grep '.*\.go$$' | xargs $(ADDLICENSE) -check -l apache -s=only -check
 
 .PHONY: test
-test: setup-envtest ginkgo ocm-transfer-demo ## Run all tests
+test: $(SETUP_ENVTEST) $(GINKGO) ocm-transfer-demo ## Run all tests
 	@KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile $(testargs)
-	@cat solar.full.coverprofile | grep -v /solar/api > solar.coverprofile
+	@grep -v /solar/api solar.full.coverprofile > solar.coverprofile
 
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.
-	TAG=e2e OCM=$(OCM) KIND_CLUSTER=$(KIND_CLUSTER_E2E) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	HELM=$(HELM) \
+	KIND=$(KIND) \
+	KIND_CLUSTER=$(KIND_CLUSTER_E2E) \
+	KUBECTL=$(KUBECTL) \
+	MAKE=$(MAKE) \
+	OCM=$(OCM) \
+	$(GO) test -tags=e2e ./test/e2e/ -v -ginkgo.v
 
 .PHONY: manifests
-manifests: controller-gen ## Generate ClusterRole and CustomResourceDefinition objects.
+manifests: $(CONTROLLER_GEN) ## Generate ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./pkg/controller/...;./api/..." output:rbac:artifacts:config=$(SOLAR_CHART_DIR)/files
 
 .PHONY: kind-load-local-images
@@ -132,20 +70,6 @@ kind-load-local-images:
 	$(KIND) load docker-image localhost/local/solar-controller-manager:$(TAG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image localhost/local/solar-renderer:$(TAG) --name $(KIND_CLUSTER)
 	$(KIND) load docker-image localhost/local/solar-discovery:$(TAG) --name $(KIND_CLUSTER)
-
-.PHONY: setup-local-cluster
-setup-local-cluster: ## Set up a Kind cluster for local development if it does not exist
-	@command -v $(KIND) >/dev/null 2>&1 || { \
-		echo "Kind is not installed. Please install Kind manually."; \
-		exit 1; \
-	}
-	@case "$$($(KIND) get clusters)" in \
-		*"$(KIND_CLUSTER)"*) \
-			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
-		*) \
-			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
-	esac
 
 KIND_CLUSTER_E2E ?= solar-test-e2e
 
@@ -187,6 +111,8 @@ dev-cluster-rebuild: ## Rebuild images from source and load them into the local 
 cleanup-dev-cluster: ## Tear down the Kind cluster used for local tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER_DEV)
 
+DOCKER ?= docker
+
 .PHONY: docker-build
 docker-build: docker-build-apiserver docker-build-manager docker-build-discovery docker-build-renderer
 
@@ -223,77 +149,16 @@ docs: docs-docker-build ## Serve the documentation using Docker.
 	@$(DOCKER) run --rm -it -p 8000:8000 -v ${PWD}:/docs ${DOCS_IMG}
 
 .PHONY: docs-crd-ref
-docs-crd-ref: crd-ref-docs ## Generate CRD reference documentation.
+docs-crd-ref: $(CRD_REF_DOCS) ## Generate CRD reference documentation.
 	$(CRD_REF_DOCS) --source-path=api/solar/v1alpha1 --config=crd-ref-docs.yaml --output-path=./docs/user-guide/api-reference.md --renderer=markdown
 
 .PHONY: docs-helm-ref
-docs-helm-ref: helm-docs ## Generate Helm Chart reference documentation.
+docs-helm-ref: $(HELM_DOCS) ## Generate Helm Chart reference documentation.
 	cd $(SOLAR_CHART_DIR) && $(HELM_DOCS) --template-files=README.md.gotmpl
 
 .PHONY: ocm-transfer-demo
-ocm-transfer-demo: ocm ## Transfer the ocm-demo component to the local OCM CTF directory
+ocm-transfer-demo: $(OCM) ## Transfer the ocm-demo component to the local OCM CTF directory
 	@if [ ! -d $(OCM_DEMO_DIR) ] || ! grep -q '"tag":"$(OCM_DEMO_VERSION)"' $(OCM_DEMO_DIR)/artifact-index.json 2>/dev/null; then \
 		rm -rf $(OCM_DEMO_DIR); \
 		$(OCM) transfer components --latest --copy-resources --type directory ghcr.io/opendefensecloud//opendefense.cloud/ocm-demo:$(OCM_DEMO_VERSION) $(OCM_DEMO_DIR); \
 	fi
-
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-.PHONY: controller-gen
-controller-gen: $(LOCALBIN) ## Download controller-gen locally if necessary.
-	@test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-.PHONY: golangci-lint
-golangci-lint: $(LOCALBIN) ## Download golangci-lint locally if necessary.
-	@test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint --version | grep -q $(GOLANGCI_LINT_VERSION) || \
-	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-
-.PHONY: ginkgo
-ginkgo: $(LOCALBIN) ## Download ginkgo locally if necessary.
-	@test -s $(LOCALBIN)/ginkgo && $(LOCALBIN)/ginkgo version | grep -q $(subst v,,$(GINKGO_VERSION)) || \
-	GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
-
-.PHONY: addlicense
-addlicense: $(LOCALBIN) ## Download addlicense locally if necessary.
-	@test -s $(LOCALBIN)/addlicense && grep -q $(ADDLICENSE_VERSION) $(LOCALBIN)/.addlicense-version 2>/dev/null || \
-	GOBIN=$(LOCALBIN) go install github.com/google/addlicense@$(ADDLICENSE_VERSION); \
-	echo $(ADDLICENSE_VERSION) > $(LOCALBIN)/.addlicense-version
-
-.PHONY: setup-envtest
-setup-envtest: $(LOCALBIN) ## Download setup-envtest locally if necessary.
-	@test -s $(LOCALBIN)/setup-envtest && grep -q $(SETUP_ENVTEST_VERSION) $(LOCALBIN)/.setup-envtest-version 2>/dev/null || \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION); \
-	echo $(SETUP_ENVTEST_VERSION) > $(LOCALBIN)/.setup-envtest-version
-
-.PHONY: openapi-gen
-openapi-gen: $(LOCALBIN) ## Download openapi-gen locally if necessary.
-	@test -s $(LOCALBIN)/openapi-gen && grep -q $(OPENAPI_GEN_VERSION) $(LOCALBIN)/.openapi-gen-version 2>/dev/null || \
-	GOBIN=$(LOCALBIN) go install k8s.io/kube-openapi/cmd/openapi-gen@$(OPENAPI_GEN_VERSION); \
-	echo $(OPENAPI_GEN_VERSION) > $(LOCALBIN)/.openapi-gen-version
-
-.PHONY: crd-ref-docs
-crd-ref-docs: $(LOCALBIN) ## Download crd-ref-docs locally if necessary.
-	@test -s $(LOCALBIN)/crd-ref-docs && $(LOCALBIN)/crd-ref-docs --version | grep -q $(CRD_REF_DOCS_VERSION) || \
-	GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)
-
-.PHONY: helm-docs
-helm-docs: $(LOCALBIN)
-	@test -s $(LOCALBIN)/helm-docs && grep -q $(HELM_DOCS_VERSION) $(LOCALBIN)/.helm-docs-version 2>/dev/null || \
-	GOBIN=$(LOCALBIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION); \
-	echo $(HELM_DOCS_VERSION) > $(LOCALBIN)/.helm-docs-version
-
-.PHONY: ocm
-ocm: $(LOCALBIN) ## Download ocm locally if necessary.
-	@test -s $(LOCALBIN)/ocm && $(LOCALBIN)/ocm version | jq -r '"\(.Major).\(.Minor).\(.Patch)"' | grep -q $(OCM_VERSION) || (\
-	curl -L -o $(LOCALBIN)/ocm.tar.gz "https://github.com/open-component-model/ocm/releases/download/v$(OCM_VERSION)/ocm-$(OCM_VERSION)-$(OS)-$(ARCH).tar.gz"; \
-	tar -xvf $(LOCALBIN)/ocm.tar.gz -C $(LOCALBIN); \
-	chmod +x $(LOCALBIN)/ocm; \
-	rm $(LOCALBIN)/ocm.tar.gz)
-
-.PHONY: osv-scanner
-osv-scanner: $(LOCALBIN)
-	@test -n $(OSV_SCANNER_VERSION) || exit 1
-	@test -s $(LOCALBIN)/osv-scanner && $(LOCALBIN)/osv-scanner --version | grep -q $(subst v,,$(OSV_SCANNER_VERSION)) || \
-	GOBIN=$(LOCALBIN) go install github.com/google/osv-scanner/v2/cmd/osv-scanner@$(OSV_SCANNER_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ lint-no-golangci: $(ADDLICENSE) shellcheck  ## Run linters but not golangci-lint
 
 .PHONY: test
 test: $(SETUP_ENVTEST) $(GINKGO) ocm-transfer-demo ## Run all tests
-	@KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile $(testargs)
+	OCM=$(OCM) \
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile $(testargs)
 	@grep -v /solar/api solar.full.coverprofile > solar.coverprofile
 
 .PHONY: test-e2e

--- a/docs/walk-through/01-discovery.md
+++ b/docs/walk-through/01-discovery.md
@@ -104,7 +104,7 @@ configurations:
 ```
 
 ```bash
-SSL_CERT_FILE=./ca.crt ./bin/ocm --config ./ocmconfig transfer ctf ./test/fixtures/ocm-demo-ctf https://localhost:4443/test
+SSL_CERT_FILE=./ca.crt ./bin/go/ocm --config ./ocmconfig transfer ctf ./test/fixtures/ocm-demo-ctf https://localhost:4443/test
 ```
 
 Take a look at the discovery registry: <https://localhost:4443/explore>. The

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,50 @@
 {
   "nodes": {
+    "dev-kit": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "git-hooks": "git-hooks",
+        "go-overlay": [
+          "go-overlay"
+        ],
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777018789,
+        "narHash": "sha256-zPYQuLwrMwlYyFAG3aiTta65xaZglt9YSS6/ploHXaY=",
+        "owner": "opendefensecloud",
+        "repo": "dev-kit",
+        "rev": "8158d30fafe63a596db9b6fe2680b7c72b1a8cc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "opendefensecloud",
+        "repo": "dev-kit",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -34,56 +78,44 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
         "nixpkgs": [
+          "dev-kit",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "go-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -95,6 +127,29 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
+          "dev-kit",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "go-overlay",
           "git-hooks",
           "nixpkgs"
         ]
@@ -115,10 +170,10 @@
     },
     "go-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "git-hooks": [
-          "git-hooks"
+        "flake-utils": [
+          "flake-utils"
         ],
+        "git-hooks": "git-hooks_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -139,8 +194,12 @@
     },
     "gomod2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": [
+          "dev-kit",
+          "flake-utils"
+        ],
         "nixpkgs": [
+          "dev-kit",
           "nixpkgs"
         ]
       },
@@ -176,44 +235,13 @@
     },
     "root": {
       "inputs": {
+        "dev-kit": "dev-kit",
         "flake-utils": "flake-utils",
-        "git-hooks": "git-hooks",
         "go-overlay": "go-overlay",
-        "gomod2nix": "gomod2nix",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,87 +1,37 @@
 {
-  description = "solar - development environment";
+  description = "SOLAR development flake";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
 
-    git-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     go-overlay = {
       url = "github:purpleclay/go-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.git-hooks.follows = "git-hooks";
+      inputs.flake-utils.follows = "flake-utils";
     };
 
-    gomod2nix = {
-      url = "github:nix-community/gomod2nix";
+    dev-kit = {
+      url = "github:opendefensecloud/dev-kit";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.go-overlay.follows = "go-overlay";
+      inputs.flake-utils.follows = "flake-utils";
     };
   };
 
-  outputs = { nixpkgs, flake-utils, ... }@inputs:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [
-          inputs.go-overlay.overlays.default
-          inputs.gomod2nix.overlays.default
-        ];
-      };
-
-      goVersion = "1.26.2";
-      go = pkgs.go-bin.versions.${goVersion};
-
-      pre-commit-golangci-lint = pkgs.writeScriptBin "pre-commit-golangci-lint" ''
-        #!/usr/bin/env bash
-        set -e
-        make golangci-lint
-        for dir in $(echo "$@" | xargs -n1 dirname | sort -u); do
-          ./bin/golangci-lint run ./"$dir"
-        done
-      '';
-
-      pre-commit-check = inputs.git-hooks.lib.${system}.run {
-        src = ./.;
-        hooks = {
-          gofmt.enable = true;
-
-          golangci-lint = {
-            enable = true;
-            entry = "${pre-commit-golangci-lint}/bin/pre-commit-golangci-lint";
-          };
-
-          osv-scanner = {
-            enable = true;
-            entry = "make scan";
-            files = "\\.(mod|sum)$|requirements\\.txt$";
-            pass_filenames = false;
-          };
+  outputs = { nixpkgs, flake-utils, dev-kit, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = dev-kit.lib.mkShell {
+          inherit system;
+          goVersion = "1.26.2";
+          packages = [
+            pkgs.fluxcd
+          ];
         };
-      };
-    in {
-      devShells.default = pkgs.mkShell {
-        inherit (pre-commit-check) shellHook;
-        packages = with pkgs; [
-          fluxcd
-          gnumake
-          jq
-          kind
-          kubectl
-          kubernetes-helm
-          shellcheck
-          yq-go
-          go
-          gotools
-          golangci-lint
-          osv-scanner
-        ];
-      };
-
-      checks.pre-commit-check = pre-commit-check;
-    }
-  );
+      }
+    );
 }

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,4 +1,4 @@
-// Copyright 2026 BWI GmbH & Solution Arsenal Contributors
+// Copyright 2026 BWI GmbH and Solution Arsenal Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package tools

--- a/pkg/discovery/apiwriter/apiwriter_test.go
+++ b/pkg/discovery/apiwriter/apiwriter_test.go
@@ -152,7 +152,7 @@ var _ = Describe("APIWriter", Ordered, func() {
 		Expect(registryProvider.Register(testRegistry)).To(Succeed())
 
 		_, err = test.Run(exec.Command(
-			"./bin/ocm", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+			test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
 		))
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/pkg/discovery/handler/handler_test.go
+++ b/pkg/discovery/handler/handler_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Handler", Ordered, func() {
 		Expect(registryProvider.Register(testRegistry)).To(Succeed())
 
 		_, err = test.Run(exec.Command(
-			"./bin/ocm", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+			test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
 		))
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -159,7 +159,7 @@ var _ = Describe("Handler", Ordered, func() {
 			Expect(registryProvider.Register(testRegistryWAuth)).To(Succeed())
 
 			_, err = test.Run(exec.Command(
-				"./bin/ocm", "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+				test.EnvName("ocm"), "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
 			))
 			Expect(err).NotTo(HaveOccurred())
 
@@ -205,7 +205,6 @@ var _ = Describe("Handler", Ordered, func() {
 			Expect(h).ToNot(BeNil())
 			_, err = handler.getHandlerForType(KroHandler)
 			Expect(err).To(HaveOccurred())
-
 		})
 	})
 })

--- a/pkg/discovery/qualifier/qualifier_test.go
+++ b/pkg/discovery/qualifier/qualifier_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Qualifier", Ordered, func() {
 		Expect(registryProvider.Register(testRegistry)).To(Succeed())
 
 		_, err = test.Run(exec.Command(
-			"./bin/ocm", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
+			test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistry.GetURL()),
 		))
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -158,7 +158,7 @@ var _ = Describe("Qualifier", Ordered, func() {
 			Expect(registryProvider.Register(testRegistryWAuth)).To(Succeed())
 
 			_, err = test.Run(exec.Command(
-				"./bin/ocm", "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistryWAuth.GetURL()),
+				test.EnvName("ocm"), "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("%s/test", testRegistryWAuth.GetURL()),
 			))
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/discovery/scanner/registry_scanner_test.go
+++ b/pkg/discovery/scanner/registry_scanner_test.go
@@ -45,7 +45,7 @@ var _ = Describe("RegistryScanner", Ordered, func() {
 
 		registryHost = testServerUrl.Host
 
-		_, err = test.Run(exec.Command("./bin/ocm", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("http://%s/test", registryHost)))
+		_, err = test.Run(exec.Command(test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("http://%s/test", registryHost)))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -124,7 +124,7 @@ var _ = Describe("RegistryScanner", Ordered, func() {
 			testServerWAuthUrl, err := url.Parse(testServerWAuth.URL)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = test.Run(exec.Command("./bin/ocm", "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("http://%s/test", testServerWAuthUrl.Host)))
+			_, err = test.Run(exec.Command(test.EnvName("ocm"), "--config", "./test/fixtures/units/ocm-config.yaml", "transfer", "ctf", "./test/fixtures/ocm-demo-ctf", fmt.Sprintf("http://%s/test", testServerWAuthUrl.Host)))
 			Expect(err).NotTo(HaveOccurred())
 
 			testRegWAuth := &discovery.Registry{

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,43 @@
       ],
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "ENVTEST_K8S_VERSION \\?= (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "DEV_KIT_VERSION := (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "opendefensecloud/dev-kit",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "tools.lock"
+      ],
+      "matchStrings": [
+        "(?<depName>[^\\s]+) (?<packageName>[^@]+)@(?<currentValue>v?[^\\s]+)"
+      ],
+      "versioningTemplate": "semver",
+      "datasourceTemplate": "go"
     }
+
   ]
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opendefense.cloud/solar/test"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -33,13 +34,6 @@ const (
 )
 
 var (
-	kindBinary = func() string {
-		if v, ok := os.LookupEnv("KIND"); ok {
-			return v
-		} else {
-			return "kind"
-		}
-	}()
 	kindCluster = func() string {
 		if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 			return v
@@ -47,35 +41,11 @@ var (
 			return "kind"
 		}
 	}()
-	helmBinary = func() string {
-		if v, ok := os.LookupEnv("HELM"); ok {
-			return v
-		} else {
-			return "helm"
-		}
-	}()
-	kubectlBinary = func() string {
-		if v, ok := os.LookupEnv("KUBECTL"); ok {
-			return v
-		} else {
-			return "kubectl"
-		}
-	}()
-	makeBinary = func() string {
-		if v, ok := os.LookupEnv("MAKE"); ok {
-			return v
-		} else {
-			return "make"
-		}
-	}()
-	ocmBinary = func() string {
-		if v, ok := os.LookupEnv("OCM"); ok {
-			return v
-		} else {
-			return "ocm"
-		}
-	}()
-
+	kindBinary     = test.EnvName("kind")
+	helmBinary     = test.EnvName("helm")
+	kubectlBinary  = test.EnvName("kubectl")
+	makeBinary     = test.EnvName("make")
+	ocmBinary      = test.EnvName("ocm")
 	kubeConfigPath = ""
 )
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode"
 
 	"github.com/onsi/ginkgo/v2"
 )
@@ -46,4 +47,29 @@ func Run(cmd *exec.Cmd) (string, error) {
 	}
 
 	return string(output), nil
+}
+
+// EnvName gets the content of an upper snake case environment variable and falling back on the name itself
+func EnvName(name string) string {
+	content, ok := os.LookupEnv(toUpperSnakeCase(name))
+	if !ok || content == "" {
+		return name
+	}
+
+	return content
+}
+
+func toUpperSnakeCase(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+
+	return strings.ToUpper(b.String())
 }

--- a/tools.lock
+++ b/tools.lock
@@ -1,0 +1,10 @@
+addlicense github.com/google/addlicense@v1.1.1
+controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
+crd-ref-docs github.com/elastic/crd-ref-docs@v0.2.0
+ginkgo github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
+golangci-lint github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+helm-docs github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
+ocm ocm.software/ocm/cmds/ocm@v0.40.0
+openapi-gen k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20260414162039-ec9c827d403f
+osv-scanner github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
+setup-envtest sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22


### PR DESCRIPTION
- migrate makefile to the new [dev-kit](https://github.com/opendefensecloud/dev-kit/)
- migrate flake to reference dev-kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized build/tool management via a pinned shared toolkit and simplified Make targets.
  * Switched local developer environment to flake-based usage and removed legacy pre-commit cleanup.
  * Simplified CI test invocation and updated ignore rules.
  * Extended dependency automation/configuration to track additional tool sources.

* **Tests**
  * Tests now resolve tooling via environment-aware helpers instead of hardcoded paths.

* **Documentation**
  * Updated walkthrough CLI example to reference the revised binary path.

* **Style**
  * Minor copyright wording update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->