### PR TITLE
fix(ci): prevent incorrect helm package selection

### DIFF
--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -103,7 +103,7 @@ jobs:
               helm package "${chart}"
 
               # Push to OCI registry
-              PACKAGE=$(ls ${CHART_NAME}-*.tgz)
+              PACKAGE=$(ls ${CHART_NAME}-[0-9]*.tgz)
               helm push "${PACKAGE}" oci://ghcr.io/${{ github.repository_owner }}/charts &> push-metadata.txt
               echo "✓ Published ${PACKAGE} to ghcr.io/${{ github.repository_owner }}/charts"
               CHART_DIGEST=$(awk '/Digest: /{print $2}' push-metadata.txt)

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -110,5 +110,7 @@ jobs:
               echo "CHART_DIGEST=${CHART_DIGEST}" | tee -a $GITHUB_ENV
 
               cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME}@${CHART_DIGEST}"
+
+              rm -f "${PACKAGE}"
             fi
           done


### PR DESCRIPTION
Closes #450.

The issue: In the second loop iteration (for the chart solar), the package name was derived using:

```
ls ${CHART_NAME}-*.tgz
```

Because `solar-discovery-0.1.0.tgz` was already present in the workspace from the first iteration, the `ls` command matched both `solar-0.1.0.tgz` and `solar-discovery-0.1.0.tgz`. This resulted in the `PACKAGE` variable containing multiple filenames, causing `helm push` to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Helm chart publishing workflow with more precise artifact selection and automated cleanup of local package files after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->