### PR TITLE
fix: ocm url for renovate

### DIFF
--- a/tools.lock
+++ b/tools.lock
@@ -4,7 +4,7 @@ crd-ref-docs github.com/elastic/crd-ref-docs@v0.2.0
 ginkgo github.com/onsi/ginkgo/v2/ginkgo@v2.28.1
 golangci-lint github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 helm-docs github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
-ocm ocm.software/ocm/cmds/ocm@v0.40.0
+ocm ocm.software/ocm@v0.40.0
 openapi-gen k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20260414162039-ec9c827d403f
 osv-scanner github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
 setup-envtest sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22


### PR DESCRIPTION
renovate currently cannot lookup the version of ocm:

> Warning
> Renovate failed to look up the following dependencies: Failed to look up go package ocm.software/ocm/cmds/ocm: no-result.
> Files affected: tools.lock

This can be reproduced locally with:

```console
$ curl "https://proxy.golang.org/ocm.software/ocm/cmds/ocm/@v/list"
not found: ocm.software/ocm/cmds/ocm@latest: unrecognized import path "ocm.software/ocm/cmds/ocm": reading https://ocm.software/ocm/cmds/ocm?go-get=1: 404 Not Found
```

however it works with:

```console
$ curl "https://proxy.golang.org/ocm.software/ocm/@v/list"
v0.34.0-rc.2
v0.26.0
v0.36.0
v0.15.0
...
```