### PR TITLE
fix: trigger golang GitHub action on Makefile changes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -11,6 +11,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
   pull_request:
     branches: [main, develop]
     paths:
@@ -19,6 +20,7 @@ on:
       - "flake.nix"
       - "go.mod"
       - "go.sum"
+      - "Makefile"
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/solution-arsenal


### PR DESCRIPTION
## What
See https://github.com/opendefensecloud/artifact-conduit/pull/321.

## Why
Golang GitHub action is supposed to run on Makefile changes.

## Testing
n/a

## Checklist
- [x] Tests added/updated -> n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
