### PR TITLE
fix(api): add missing listType markers to Conditions fields

### DIFF
--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -55,6 +55,8 @@ type ReleaseStatus struct {
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchMergeKey:"type" patchStrategy:"merge"`
 
 	// RenderTaskRef is a reference to the RenderTask responsible for this Release.

--- a/api/solar/v1alpha1/rendertask_types.go
+++ b/api/solar/v1alpha1/rendertask_types.go
@@ -55,6 +55,8 @@ type RenderTaskStatus struct {
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchMergeKey:"type" patchStrategy:"merge"`
 
 	// JobRef is a reference to the Job that is executing the rendering.

--- a/client-go/openapi/api_violations.report
+++ b/client-go/openapi/api_violations.report
@@ -1,5 +1,3 @@
-API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alpha1,ReleaseStatus,Conditions
-API rule violation: list_type_missing,go.opendefense.cloud/solar/api/solar/v1alpha1,RenderTaskStatus,Conditions
 API rule violation: names_match,go.opendefense.cloud/solar/api/solar/v1alpha1,RendererConfig,BootstrapConfig
 API rule violation: names_match,go.opendefense.cloud/solar/api/solar/v1alpha1,RendererConfig,ReleaseConfig
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -2083,6 +2083,10 @@ func schema_solar_api_solar_v1alpha1_ReleaseStatus(ref common.ReferenceCallback)
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "type",
 								"x-kubernetes-patch-strategy":  "merge",
 							},
@@ -2342,6 +2346,10 @@ func schema_solar_api_solar_v1alpha1_RenderTaskStatus(ref common.ReferenceCallba
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "type",
 								"x-kubernetes-patch-strategy":  "merge",
 							},


### PR DESCRIPTION
## What
Add missing `+listType=map` / `+listMapKey=type` markers to `Conditions` fields in `ReleaseStatus` and `RenderTaskStatus`.

## Why
`make codegen` generates `client-go/openapi/api_violations.report`. Two `list_type_missing` violations were reported for our namespace — all other status types in the package (`TargetStatus`, `ProfileStatus`, `RegistryStatus`, etc.) already carry these markers; `ReleaseStatus` and `RenderTaskStatus` were just missed.

## Testing
Run `make codegen` and verify no `list_type_missing` entries remain for `go.opendefense.cloud/solar` in `client-go/openapi/api_violations.report`.

## Checklist
  - [x] ~~Tests added/updated~~ markers are validated by `make codegen` :arrow_right: see diff in violations report
  - [x] No breaking changes (or upgrade path documented above)
  - [x] Readable commit history (squashed and cleaned up as desired)
  - [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes API resource schema metadata to improve list merging and patching behavior in status definitions.
  * Updated OpenAPI specifications to align with Kubernetes best practices for list type handling.
  * Resolved API schema compliance violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->