### PR TITLE
feat(controller): implement release resolver in Target controller (#246)

### DIFF
--- a/api/solar/release_rest.go
+++ b/api/solar/release_rest.go
@@ -95,9 +95,12 @@ func (o *Release) ValidateUpdate(ctx context.Context, old runtime.Object) field.
 }
 
 func validateRelease(o *Release) field.ErrorList {
-	errors := field.ErrorList{}
-	if o.Spec.UniqueName == "" {
-		errors = append(errors, field.Required(field.NewPath("spec").Child("uniqueName"), "uniqueName must not be empty"))
+	var errors field.ErrorList
+	if o.Spec.ComponentVersionRef.Name == "" {
+		errors = append(errors, field.Required(
+			field.NewPath("spec").Child("componentVersionRef").Child("name"),
+			"componentVersionRef.name must not be empty",
+		))
 	}
 
 	return errors

--- a/api/solar/release_rest_test.go
+++ b/api/solar/release_rest_test.go
@@ -17,16 +17,16 @@ import (
 
 var _ = Describe("Release REST", func() {
 	Describe("Validate (create path)", func() {
-		It("rejects an empty UniqueName", func() {
+		It("rejects an empty componentVersionRef.name", func() {
 			r := &solar.Release{
 				Spec: solar.ReleaseSpec{
-					ComponentVersionRef: corev1.LocalObjectReference{Name: "kyverno-v1"},
-					UniqueName:          "",
+					ComponentVersionRef: corev1.LocalObjectReference{Name: ""},
+					UniqueName:          "kyverno",
 				},
 			}
 			errs := r.Validate(context.Background())
 			Expect(errs).NotTo(BeEmpty())
-			Expect(errs[0].Field).To(Equal("spec.uniqueName"))
+			Expect(errs[0].Field).To(Equal("spec.componentVersionRef.name"))
 		})
 
 		It("accepts a non-empty UniqueName", func() {

--- a/api/solar/release_types.go
+++ b/api/solar/release_types.go
@@ -26,7 +26,7 @@ type ReleaseSpec struct {
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
 	// UniqueName is a logical identifier used to ensure this component is deployed
 	// only once per target cluster when multiple Profiles match the same target.
-	UniqueName string `json:"uniqueName"`
+	UniqueName string `json:"uniqueName,omitempty"`
 	// AntiAffinity defines exclusion rules. If another Release matching this
 	// label selector is already bound to the same Target, this Release should
 	// not be deployed there (or a conflict condition should be raised).
@@ -60,6 +60,10 @@ type ReleaseStatus struct {
 	// RenderTaskRef is a reference to the RenderTask responsible for this Release.
 	// +optional
 	RenderTaskRef *corev1.ObjectReference `json:"renderTaskRef,omitempty"`
+
+	// EffectiveUniqueName is the unique name used for deduplication on Targets.
+	// +optional
+	EffectiveUniqueName string `json:"effectiveUniqueName,omitempty"`
 }
 
 // +genclient

--- a/api/solar/v1alpha1/release_types.go
+++ b/api/solar/v1alpha1/release_types.go
@@ -24,9 +24,12 @@ type ReleaseSpec struct {
 	// TargetNamespace is the namespace the ComponentVersion gets deployed to.
 	// +optional
 	TargetNamespace *string `json:"targetNamespace,omitempty"`
-	// UniqueName is a logical identifier used to ensure this component is deployed
-	// only once per target cluster when multiple Profiles match the same target.
-	UniqueName string `json:"uniqueName"`
+	// UniqueName is a logical identifier that ensures only one Release of this
+	// component is deployed per Target when multiple Profiles match.
+	// If not set, it defaults to the parent Component name (derived from the
+	// referenced ComponentVersion). Immutable once set.
+	// +optional
+	UniqueName string `json:"uniqueName,omitempty"`
 	// AntiAffinity defines exclusion rules. If another Release matching this
 	// label selector is already bound to the same Target, this Release should
 	// not be deployed there (or a conflict condition should be raised).
@@ -62,6 +65,12 @@ type ReleaseStatus struct {
 	// RenderTaskRef is a reference to the RenderTask responsible for this Release.
 	// +optional
 	RenderTaskRef *corev1.ObjectReference `json:"renderTaskRef,omitempty"`
+
+	// EffectiveUniqueName is the unique name used for deduplication on Targets.
+	// Equals Spec.UniqueName when set; otherwise the parent Component name derived
+	// from the referenced ComponentVersion.
+	// +optional
+	EffectiveUniqueName string `json:"effectiveUniqueName,omitempty"`
 }
 
 // +genclient

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1601,6 +1601,7 @@ func Convert_solar_ReleaseSpec_To_v1alpha1_ReleaseSpec(in *solar.ReleaseSpec, ou
 func autoConvert_v1alpha1_ReleaseStatus_To_solar_ReleaseStatus(in *ReleaseStatus, out *solar.ReleaseStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
 	out.RenderTaskRef = (*corev1.ObjectReference)(unsafe.Pointer(in.RenderTaskRef))
+	out.EffectiveUniqueName = in.EffectiveUniqueName
 	return nil
 }
 
@@ -1612,6 +1613,7 @@ func Convert_v1alpha1_ReleaseStatus_To_solar_ReleaseStatus(in *ReleaseStatus, ou
 func autoConvert_solar_ReleaseStatus_To_v1alpha1_ReleaseStatus(in *solar.ReleaseStatus, out *ReleaseStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]v1.Condition)(unsafe.Pointer(&in.Conditions))
 	out.RenderTaskRef = (*corev1.ObjectReference)(unsafe.Pointer(in.RenderTaskRef))
+	out.EffectiveUniqueName = in.EffectiveUniqueName
 	return nil
 }
 

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -122,15 +122,22 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrlResult, errLogAndWrap(log, err, "failed to get ComponentVersion")
 	}
 
-	// ComponentVersion found — set resolved condition
-	changed := apimeta.SetStatusCondition(&res.Status.Conditions, metav1.Condition{
+	// ComponentVersion found — set resolved condition and effective unique name.
+	effectiveUniqueName := res.Spec.UniqueName
+	if effectiveUniqueName == "" {
+		effectiveUniqueName = cv.Spec.ComponentRef.Name
+	}
+
+	condChanged := apimeta.SetStatusCondition(&res.Status.Conditions, metav1.Condition{
 		Type:               ConditionTypeComponentVersionResolved,
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: res.Generation,
 		Reason:             "Resolved",
 		Message:            "ComponentVersion resolved: " + cv.Name,
 	})
-	if changed {
+	nameChanged := res.Status.EffectiveUniqueName != effectiveUniqueName
+	if condChanged || nameChanged {
+		res.Status.EffectiveUniqueName = effectiveUniqueName
 		if err := r.Status().Update(ctx, res); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to update status")
 		}

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -81,11 +81,43 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 		})
 	})
 
-	Describe("UniqueName validation", func() {
-		It("should reject a Release with an empty UniqueName", func() {
-			release := validRelease("test-release-empty-unique-name", ns)
+	Describe("UniqueName", func() {
+		It("should allow creating a Release without a UniqueName", func() {
+			release := validRelease("test-release-no-unique-name", ns)
 			release.Spec.UniqueName = ""
-			Expect(k8sClient.Create(ctx, release)).NotTo(Succeed())
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+		})
+
+		It("should set status.effectiveUniqueName to the Component name when UniqueName is empty", func() {
+			cv := validComponentVersion("eu-fallback-cv", ns)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			release := validRelease("test-release-effective-unique-name-fallback", ns)
+			release.Spec.ComponentVersionRef.Name = cv.Name
+			release.Spec.UniqueName = ""
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			updated := &solarv1alpha1.Release{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Status.EffectiveUniqueName).To(Equal(cv.Spec.ComponentRef.Name))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("should set status.effectiveUniqueName to Spec.UniqueName when explicitly provided", func() {
+			cv := validComponentVersion("eu-explicit-cv", ns)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			release := validRelease("test-release-effective-unique-name-explicit", ns)
+			release.Spec.ComponentVersionRef.Name = cv.Name
+			release.Spec.UniqueName = "custom-unique-name"
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			updated := &solarv1alpha1.Release{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Status.EffectiveUniqueName).To(Equal("custom-unique-name"))
+			}, eventuallyTimeout).Should(Succeed())
 		})
 	})
 

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -19,6 +19,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -35,6 +36,7 @@ const (
 	targetFinalizer = "solar.opendefense.cloud/target-finalizer"
 
 	ConditionTypeRegistryResolved = "RegistryResolved"
+	ConditionTypeReleasesResolved = "ReleasesResolved"
 	ConditionTypeReleasesRendered = "ReleasesRendered"
 	ConditionTypeBootstrapReady   = "BootstrapReady"
 )
@@ -42,11 +44,14 @@ const (
 var ErrReleaseNotRenderedYet = errors.New("release is not rendered yet")
 
 type releaseInfo struct {
-	name     string
-	release  *solarv1alpha1.Release
-	cv       *solarv1alpha1.ComponentVersion
-	rtName   string
-	chartURL string
+	// bindingKey is "<namespace>/<name>" of the originating ReleaseBinding, used as a
+	// deterministic tiebreaker when two releases share the same priority.
+	bindingKey string
+	name       string
+	release    *solarv1alpha1.Release
+	cv         *solarv1alpha1.ComponentVersion
+	rtName     string
+	chartURL   string
 }
 
 type TargetReconciler struct {
@@ -202,7 +207,12 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if len(bindingList.Items) == 0 {
 		log.V(1).Info("No ReleaseBindings found for target")
-		if condErr := r.setCondition(ctx, target, ConditionTypeReleasesRendered, metav1.ConditionFalse, "NoBindings",
+		if condErr := r.setCondition(ctx, target, ConditionTypeReleasesRendered, metav1.ConditionFalse, "NoReleaseBindings",
+			"No ReleaseBindings found for this target"); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+
+		if condErr := r.setCondition(ctx, target, ConditionTypeReleasesResolved, metav1.ConditionFalse, "NoReleaseBindings",
 			"No ReleaseBindings found for this target"); condErr != nil {
 			return ctrl.Result{}, condErr
 		}
@@ -272,11 +282,28 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 		rtName := releaseRenderTaskName(rel.Name, target.Name, rel.GetGeneration())
 		releases = append(releases, releaseInfo{
-			name:    rel.Name,
-			release: rel,
-			cv:      cv,
-			rtName:  rtName,
+			bindingKey: binding.Namespace + "/" + binding.Name,
+			name:       rel.Name,
+			release:    rel,
+			cv:         cv,
+			rtName:     rtName,
 		})
+	}
+
+	// Resolve conflicts: deduplicate by uniqueName (priority wins) and apply anti-affinity rules.
+	var skipped []string
+	releases, skipped = resolveReleaseConflicts(releases)
+	if condErr := r.setResolvedCondition(ctx, target, skipped); condErr != nil {
+		return ctrl.Result{}, condErr
+	}
+
+	if len(releases) == 0 && !pendingDeps {
+		if condErr := r.setCondition(ctx, target, ConditionTypeReleasesRendered, metav1.ConditionFalse, "AllReleaseBindingsFiltered",
+			"All ReleaseBindings were filtered out by the release resolver (uniqueName conflicts or anti-affinity rules)"); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+
+		return ctrl.Result{}, nil
 	}
 
 	// Create per-release RenderTasks (one per target+release pair).
@@ -463,6 +490,125 @@ func (r *TargetReconciler) setCondition(ctx context.Context, target *solarv1alph
 	}
 
 	return nil
+}
+
+func (r *TargetReconciler) setResolvedCondition(ctx context.Context, target *solarv1alpha1.Target, skipped []string) error {
+	if len(skipped) == 0 {
+		return r.setCondition(ctx, target, ConditionTypeReleasesResolved, metav1.ConditionTrue, "NoConflicts", "")
+	}
+
+	return r.setCondition(ctx, target, ConditionTypeReleasesResolved, metav1.ConditionTrue, "Resolved", strings.Join(skipped, "; "))
+}
+
+// resolveReleaseConflicts deduplicates releases by uniqueName (keeping the highest-priority
+// binding) and filters releases that violate anti-affinity rules of already-accepted releases.
+// Releases without a uniqueName are deduplicated using the parent Component name from the CV.
+// It returns the accepted releases and a slice of human-readable filter messages.
+func resolveReleaseConflicts(releases []releaseInfo) ([]releaseInfo, []string) {
+	if len(releases) == 0 {
+		return releases, nil
+	}
+
+	// Step A: uniqueName deduplication.
+	// When UniqueName is empty, fall back to the parent Component name from the CV.
+	namedGroups := map[string][]releaseInfo{}
+
+	for _, ri := range releases {
+		uniqueName := ri.release.Spec.UniqueName
+		if uniqueName == "" {
+			uniqueName = ri.cv.Spec.ComponentRef.Name
+		}
+
+		namedGroups[uniqueName] = append(namedGroups[uniqueName], ri)
+	}
+
+	var accepted []releaseInfo
+
+	var skipped []string
+
+	// byPriority sorts releases with highest priority first; bindingKey breaks ties.
+	byPriority := func(a, b releaseInfo) bool {
+		if a.release.Spec.Priority != b.release.Spec.Priority {
+			return a.release.Spec.Priority > b.release.Spec.Priority
+		}
+
+		return a.bindingKey < b.bindingKey
+	}
+
+	uniqueNames := make([]string, 0, len(namedGroups))
+	for k := range namedGroups {
+		uniqueNames = append(uniqueNames, k)
+	}
+
+	sort.Strings(uniqueNames)
+
+	for _, uniqueName := range uniqueNames {
+		group := namedGroups[uniqueName]
+		sort.Slice(group, func(i, j int) bool { return byPriority(group[i], group[j]) })
+
+		accepted = append(accepted, group[0])
+
+		for _, loser := range group[1:] {
+			skipped = append(skipped, fmt.Sprintf(
+				"binding %s filtered: uniqueName %q conflict, lower priority than %s",
+				loser.bindingKey, uniqueName, group[0].bindingKey,
+			))
+		}
+	}
+
+	// Step B: anti-affinity evaluation.
+	// Walk in deterministic order (priority desc, bindingKey asc); accept each release only
+	// if its AntiAffinity selector does not match any already-accepted release's labels.
+	sort.Slice(accepted, func(i, j int) bool { return byPriority(accepted[i], accepted[j]) })
+
+	resolved := make([]releaseInfo, 0, len(accepted))
+
+	for _, ri := range accepted {
+		// Parse ri's own anti-affinity selector once; bail early on invalid selector.
+		var riSelector labels.Selector
+		if ri.release.Spec.AntiAffinity != nil {
+			sel, err := metav1.LabelSelectorAsSelector(ri.release.Spec.AntiAffinity)
+			if err != nil {
+				skipped = append(skipped, fmt.Sprintf(
+					"binding %s filtered: invalid antiAffinity selector: %v",
+					ri.bindingKey, err,
+				))
+
+				continue
+			}
+
+			riSelector = sel
+		}
+
+		// Check both directions: ri's anti-affinity against already-resolved labels,
+		// and already-resolved anti-affinities against ri's labels.
+		conflict := ""
+		for _, other := range resolved {
+			if riSelector != nil && riSelector.Matches(labels.Set(other.release.Labels)) {
+				conflict = other.bindingKey
+				break
+			}
+
+			if other.release.Spec.AntiAffinity != nil {
+				otherSel, err := metav1.LabelSelectorAsSelector(other.release.Spec.AntiAffinity)
+				if err == nil && otherSel.Matches(labels.Set(ri.release.Labels)) {
+					conflict = other.bindingKey
+					break
+				}
+			}
+		}
+
+		if conflict != "" {
+			skipped = append(skipped, fmt.Sprintf(
+				"binding %s filtered: anti-affinity conflict with %s",
+				ri.bindingKey, conflict,
+			))
+		} else {
+			resolved = append(resolved, ri)
+		}
+	}
+
+	return resolved, skipped
 }
 
 // deleteStaleRenderTasks removes RenderTasks owned by this target that are no

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -5,6 +5,8 @@ package controller
 
 import (
 	"slices"
+	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,7 +72,7 @@ var _ = Describe("TargetController", Ordered, func() {
 				},
 				Spec: solarv1alpha1.ReleaseSpec{
 					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
-					UniqueName:          "my-component",
+					UniqueName:          "my-unique-component",
 					Values:              runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
 					TargetNamespace:     new("my-namespace"),
 				},
@@ -152,7 +154,7 @@ var _ = Describe("TargetController", Ordered, func() {
 			}, eventuallyTimeout).Should(BeTrue())
 		})
 
-		It("should set ReleasesRendered=NoBindings when no ReleaseBindings exist", func() {
+		It("should set ReleasesRendered=NoReleaseBindings when no ReleaseBindings exist", func() {
 			registry := newRegistry("test-registry")
 			_ = k8sClient.Create(ctx, registry) // may already exist
 
@@ -166,7 +168,7 @@ var _ = Describe("TargetController", Ordered, func() {
 				}
 				cond := apimeta.FindStatusCondition(t.Status.Conditions, ConditionTypeReleasesRendered)
 
-				return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "NoBindings"
+				return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == "NoReleaseBindings"
 			}, eventuallyTimeout).Should(BeTrue())
 		})
 
@@ -227,10 +229,12 @@ var _ = Describe("TargetController", Ordered, func() {
 			_ = k8sClient.Create(ctx, cv)
 
 			rel1 := newRelease("rel-cleanup-1")
+			rel1.Spec.UniqueName = "cleanup-component-1"
 			Expect(k8sClient.Create(ctx, rel1)).To(Succeed())
 
 			rel2 := newRelease("rel-cleanup-2")
 			rel2.Spec.ComponentVersionRef.Name = "my-cv"
+			rel2.Spec.UniqueName = "cleanup-component-2"
 			Expect(k8sClient.Create(ctx, rel2)).To(Succeed())
 
 			target := newTarget("test-cleanup")
@@ -290,6 +294,184 @@ var _ = Describe("TargetController", Ordered, func() {
 		})
 	})
 
+	Context("release resolver", Label("resolver"), func() {
+		It("should only create a RenderTask for the higher-priority release on a uniqueName conflict", func() {
+			registry := newRegistry("test-registry")
+			_ = k8sClient.Create(ctx, registry)
+
+			cv := newComponentVersion("my-cv")
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			relHigh := newRelease("rel-resolver-high")
+			relHigh.Spec.UniqueName = "shared-component"
+			relHigh.Spec.Priority = 5
+			Expect(k8sClient.Create(ctx, relHigh)).To(Succeed())
+
+			relLow := newRelease("rel-resolver-low")
+			relLow.Spec.UniqueName = "shared-component"
+			relLow.Spec.Priority = 1
+			Expect(k8sClient.Create(ctx, relLow)).To(Succeed())
+
+			target := newTarget("test-resolver-prio")
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-resolver-high", "test-resolver-prio", "rel-resolver-high"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-resolver-low", "test-resolver-prio", "rel-resolver-low"))).To(Succeed())
+
+			// High-priority release gets a RenderTask
+			highRTName := releaseRenderTaskName("rel-resolver-high", "test-resolver-prio", 1)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: highRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Low-priority release must not get a RenderTask
+			lowRTName := releaseRenderTaskName("rel-resolver-low", "test-resolver-prio", 1)
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: lowRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+				return apierrors.IsNotFound(err)
+			}, 2*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			// Target should reflect the conflict resolution
+			Eventually(func() bool {
+				t := &solarv1alpha1.Target{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), t); err != nil {
+					return false
+				}
+				cond := apimeta.FindStatusCondition(t.Status.Conditions, ConditionTypeReleasesResolved)
+
+				return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == "Resolved" &&
+					strings.Contains(cond.Message, "binding-resolver-low")
+			}, eventuallyTimeout).Should(BeTrue())
+		})
+
+		It("should use namespace-qualified bindingKey as tiebreaker when priorities are equal", func() {
+			registry := newRegistry("test-registry")
+			_ = k8sClient.Create(ctx, registry)
+
+			cv := newComponentVersion("my-cv")
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			relA := newRelease("rel-tiebreak-a")
+			relA.Spec.UniqueName = "tied-component"
+			relA.Spec.Priority = 0
+			Expect(k8sClient.Create(ctx, relA)).To(Succeed())
+
+			relZ := newRelease("rel-tiebreak-z")
+			relZ.Spec.UniqueName = "tied-component"
+			relZ.Spec.Priority = 0
+			Expect(k8sClient.Create(ctx, relZ)).To(Succeed())
+
+			target := newTarget("test-resolver-tiebreak")
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+
+			// "binding-alpha" < "binding-zeta" alphabetically → rel-tiebreak-a wins
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-alpha", "test-resolver-tiebreak", "rel-tiebreak-a"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-zeta", "test-resolver-tiebreak", "rel-tiebreak-z"))).To(Succeed())
+
+			alphaRTName := releaseRenderTaskName("rel-tiebreak-a", "test-resolver-tiebreak", 1)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: alphaRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+			}, eventuallyTimeout).Should(Succeed())
+
+			zetaRTName := releaseRenderTaskName("rel-tiebreak-z", "test-resolver-tiebreak", 1)
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: zetaRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+				return apierrors.IsNotFound(err)
+			}, 2*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() bool {
+				t := &solarv1alpha1.Target{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), t); err != nil {
+					return false
+				}
+				cond := apimeta.FindStatusCondition(t.Status.Conditions, ConditionTypeReleasesResolved)
+
+				return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == "Resolved" &&
+					strings.Contains(cond.Message, "binding-zeta")
+			}, eventuallyTimeout).Should(BeTrue())
+		})
+
+		It("should block a release whose anti-affinity matches another accepted release", func() {
+			registry := newRegistry("test-registry")
+			_ = k8sClient.Create(ctx, registry)
+
+			cv := newComponentVersion("my-cv")
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			// istio: high priority, carries the "service-mesh" label
+			istio := newRelease("rel-istio")
+			istio.Labels = map[string]string{"solar.opendefense.cloud/category": "service-mesh"}
+			istio.Spec.UniqueName = "istio"
+			istio.Spec.Priority = 10
+			Expect(k8sClient.Create(ctx, istio)).To(Succeed())
+
+			// linkerd: lower priority, declares anti-affinity against any service-mesh release
+			linkerd := newRelease("rel-linkerd")
+			linkerd.Spec.UniqueName = "linkerd"
+			linkerd.Spec.Priority = 5
+			linkerd.Spec.AntiAffinity = &metav1.LabelSelector{
+				MatchLabels: map[string]string{"solar.opendefense.cloud/category": "service-mesh"},
+			}
+			Expect(k8sClient.Create(ctx, linkerd)).To(Succeed())
+
+			target := newTarget("test-resolver-antiaffinity")
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-istio", "test-resolver-antiaffinity", "rel-istio"))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-linkerd", "test-resolver-antiaffinity", "rel-linkerd"))).To(Succeed())
+
+			// istio gets a RenderTask
+			istioRTName := releaseRenderTaskName("rel-istio", "test-resolver-antiaffinity", 1)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: istioRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+			}, eventuallyTimeout).Should(Succeed())
+
+			// linkerd is blocked by anti-affinity
+			linkerdRTName := releaseRenderTaskName("rel-linkerd", "test-resolver-antiaffinity", 1)
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: linkerdRTName, Namespace: ns.Name}, &solarv1alpha1.RenderTask{})
+				return apierrors.IsNotFound(err)
+			}, 2*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+			Eventually(func() bool {
+				t := &solarv1alpha1.Target{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), t); err != nil {
+					return false
+				}
+				cond := apimeta.FindStatusCondition(t.Status.Conditions, ConditionTypeReleasesResolved)
+
+				return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == "Resolved"
+			}, eventuallyTimeout).Should(BeTrue())
+		})
+
+		It("should set ReleasesResolved=NoConflicts when there are no conflicts", func() {
+			registry := newRegistry("test-registry")
+			_ = k8sClient.Create(ctx, registry)
+
+			cv := newComponentVersion("my-cv")
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			rel := newRelease("rel-no-conflict")
+			rel.Spec.UniqueName = "unique-component"
+			Expect(k8sClient.Create(ctx, rel)).To(Succeed())
+
+			target := newTarget("test-resolver-no-conflict")
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, newReleaseBinding("binding-no-conflict", "test-resolver-no-conflict", "rel-no-conflict"))).To(Succeed())
+
+			Eventually(func() bool {
+				t := &solarv1alpha1.Target{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(target), t); err != nil {
+					return false
+				}
+				cond := apimeta.FindStatusCondition(t.Status.Conditions, ConditionTypeReleasesResolved)
+
+				return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == "NoConflicts"
+			}, eventuallyTimeout).Should(BeTrue())
+		})
+	})
+
 	Context("when Target is deleted", Label("target"), func() {
 		It("should remove the finalizer and allow deletion", func() {
 			registry := newRegistry("test-registry")
@@ -317,6 +499,137 @@ var _ = Describe("TargetController", Ordered, func() {
 
 				return apierrors.IsNotFound(err)
 			}, eventuallyTimeout).Should(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("resolveReleaseConflicts", func() {
+	makeRI := func(bindingKey, name, uniqueName string, priority int32, relLabels map[string]string, antiAffinity *metav1.LabelSelector, cv *solarv1alpha1.ComponentVersion) releaseInfo {
+		return releaseInfo{
+			bindingKey: bindingKey,
+			name:       name,
+			cv:         cv,
+			release: &solarv1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   name,
+					Labels: relLabels,
+				},
+				Spec: solarv1alpha1.ReleaseSpec{
+					UniqueName:   uniqueName,
+					Priority:     priority,
+					AntiAffinity: antiAffinity,
+				},
+			},
+		}
+	}
+
+	makeCV := func(componentName string) *solarv1alpha1.ComponentVersion {
+		return &solarv1alpha1.ComponentVersion{
+			Spec: solarv1alpha1.ComponentVersionSpec{
+				ComponentRef: corev1.LocalObjectReference{Name: componentName},
+			},
+		}
+	}
+
+	It("returns nil for nil input", func() {
+		accepted, skipped := resolveReleaseConflicts(nil)
+		Expect(accepted).To(BeNil())
+		Expect(skipped).To(BeNil())
+	})
+
+	It("deduplicates releases with empty uniqueName using the component name from the CV", func() {
+		low := makeRI("ns/binding-low", "rel-low", "", 1, nil, nil, makeCV("kyverno"))
+		high := makeRI("ns/binding-high", "rel-high", "", 5, nil, nil, makeCV("kyverno"))
+		accepted, skipped := resolveReleaseConflicts([]releaseInfo{low, high})
+		Expect(accepted).To(HaveLen(1))
+		Expect(accepted[0].name).To(Equal("rel-high"))
+		Expect(skipped).To(HaveLen(1))
+		Expect(skipped[0]).To(ContainSubstring("ns/binding-low"))
+		Expect(skipped[0]).To(ContainSubstring("kyverno"))
+	})
+
+	Context("uniqueName deduplication", func() {
+		It("keeps the release with the higher priority", func() {
+			low := makeRI("ns/binding-low", "rel-low", "kyverno", 1, nil, nil, nil)
+			high := makeRI("ns/binding-high", "rel-high", "kyverno", 5, nil, nil, nil)
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{low, high})
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0].name).To(Equal("rel-high"))
+			Expect(skipped).To(HaveLen(1))
+			Expect(skipped[0]).To(ContainSubstring("ns/binding-low"))
+			Expect(skipped[0]).To(ContainSubstring("kyverno"))
+		})
+
+		It("uses namespace-qualified bindingKey as tiebreaker for equal priority", func() {
+			a := makeRI("ns-a/binding-alpha", "rel-a", "kyverno", 0, nil, nil, nil)
+			b := makeRI("ns-z/binding-zeta", "rel-b", "kyverno", 0, nil, nil, nil)
+			// pass b before a to verify sort is not input-order-dependent
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{b, a})
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0].bindingKey).To(Equal("ns-a/binding-alpha"))
+			Expect(skipped).To(HaveLen(1))
+			Expect(skipped[0]).To(ContainSubstring("ns-z/binding-zeta"))
+		})
+	})
+
+	Context("anti-affinity", func() {
+		It("blocks a release whose anti-affinity matches an already-accepted release", func() {
+			// istio comes first (higher priority), gets accepted
+			istio := makeRI("ns/binding-istio", "istio", "istio", 10,
+				map[string]string{"solar.opendefense.cloud/category": "service-mesh"}, nil, nil)
+			// linkerd declares anti-affinity against any service-mesh release
+			linkerd := makeRI("ns/binding-linkerd", "linkerd", "linkerd", 5, nil,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"solar.opendefense.cloud/category": "service-mesh"},
+				}, nil)
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{istio, linkerd})
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0].name).To(Equal("istio"))
+			Expect(skipped).To(HaveLen(1))
+			Expect(skipped[0]).To(ContainSubstring("ns/binding-linkerd"))
+			Expect(skipped[0]).To(ContainSubstring("anti-affinity"))
+		})
+
+		It("blocks a lower-priority release when a higher-priority release declares anti-affinity against it", func() {
+			// A has higher priority and declares anti-affinity against releases labelled "service-mesh".
+			// B has that label but no anti-affinity of its own.
+			// A is accepted first; B should be blocked by A's anti-affinity.
+			a := makeRI("ns/binding-a", "rel-a", "", 10, nil,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"solar.opendefense.cloud/category": "service-mesh"},
+				}, makeCV("rel-a"))
+			b := makeRI("ns/binding-b", "rel-b", "", 5,
+				map[string]string{"solar.opendefense.cloud/category": "service-mesh"}, nil, makeCV("rel-b"))
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{a, b})
+			Expect(accepted).To(HaveLen(1))
+			Expect(accepted[0].name).To(Equal("rel-a"))
+			Expect(skipped).To(HaveLen(1))
+			Expect(skipped[0]).To(ContainSubstring("ns/binding-b"))
+			Expect(skipped[0]).To(ContainSubstring("anti-affinity"))
+		})
+
+		It("accepts a release when no other release matches its anti-affinity", func() {
+			ri := makeRI("ns/binding-a", "rel-a", "", 0, nil,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"solar.opendefense.cloud/category": "service-mesh"},
+				}, makeCV("rel-a"))
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{ri})
+			Expect(accepted).To(HaveLen(1))
+			Expect(skipped).To(BeEmpty())
+		})
+
+		It("skips a release with an invalid anti-affinity selector", func() {
+			ri := makeRI("ns/binding-invalid", "rel-invalid", "", 0, nil,
+				&metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "k", Operator: "InvalidOp", Values: []string{"v"}},
+					},
+				}, makeCV("rel-invalid"))
+			accepted, skipped := resolveReleaseConflicts([]releaseInfo{ri})
+			Expect(accepted).To(BeEmpty())
+			Expect(skipped).To(HaveLen(1))
+			Expect(skipped[0]).To(ContainSubstring("ns/binding-invalid"))
+			Expect(skipped[0]).To(ContainSubstring("invalid"))
 		})
 	})
 })


### PR DESCRIPTION
## What

Adds a deterministic release resolver to the Target controller that runs after binding collection and before RenderTask creation. Implements uniqueName-based deduplication (priority wins; bindingKey tiebreaker) and bidirectional anti-affinity enforcement.

Also makes `spec.uniqueName` optional on Release: when not set, the effective unique name falls back to the parent Component name from the referenced ComponentVersion, written to `status.effectiveUniqueName` for operator visibility.

## Why
Without conflict resolution, two Profiles can bind the same Target to two versions of the same component (e.g., kyverno v3.2 and v3.3), resulting in duplicate RenderTasks and unpredictable deployments. The resolver enforces that only one Release per logical component reaches the render stage, with the selection governed by explicit priority and anti-affinity rules.

`UniqueName` being optional reduces friction for simple single-profile setups — the system derives a sensible default automatically and exposes it in `status.effectiveUniqueName` so operators can verify without reading docs.

## Testing
- **Unit tests** (`resolveReleaseConflicts`): priority selection, bindingKey tiebreaker, bidirectional anti-affinity, invalid selector, component-name fallback for empty UniqueName.
- **Integration tests** (envtest): higher-priority wins on conflict, alphabetical tiebreaker, anti-affinity blocking, NoConflicts path, optional UniqueName + status.effectiveUniqueName fallback.

Adding e2e scenarios for the resolver was considered but skipped: the resolver is a pure in-process filter with no external I/O. Setting up multiple OCI-registered components, Profiles, and Releases in a live Kind cluster just to test a sort/filter function would add significant fixture overhead for no additional coverage beyond what the envtest integration tests already provide.

## Notes for reviewers
**New condition:** `ReleasesResolved` on Target (`NoConflicts` / `Resolved` with per-binding filter messages / `AllReleaseBindingsFiltered` on ReleasesRendered when all are rejected).

**API change — Release.Spec.UniqueName is now optional:** Previously required and immutable; still immutable once set. Existing Releases with an explicit uniqueName are unaffected. When left empty, the Target controller uses the parent Component name as the effective deduplication key (visible in status.effectiveUniqueName); the field itself remains empty in storage.

**New status field — Release.Status.EffectiveUniqueName:** Read-only, set by the Release controller after CV resolution. Shows the deduplication key actually in use.

**New validation — Release.Spec.ComponentVersionRef.Name:** Now explicitly rejected as empty at create and update time, giving an immediate API error instead of a silent controller failure.

**Conversion:** `EffectiveUniqueName` is added to the internal `ReleaseStatus` type and to the generated conversion functions in `zz_generated.conversion.go` (minimal hand-edit; full codegen not needed for a single string field).

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases may omit UniqueName; an EffectiveUniqueName is derived and persisted for deduplication.
  * Targets now perform deterministic, priority-aware release resolution with bidirectional anti‑affinity filtering and expose a resolved condition with human-readable messages.
* **Bug Fixes**
  * Prevents creating per-release render tasks when all bindings are filtered or none apply.
* **Tests**
  * Added/updated tests for deduplication, priority/tiebreaking, anti‑affinity, resolution outcomes, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->