### PR TITLE
chore: switching runners

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   pr-title:
     name: PR Title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:
@@ -31,7 +31,7 @@ jobs:
 
   commitlint:
     name: Commit Messages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -88,7 +88,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
       - name: Sign image with cosign
         env:
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,7 +42,7 @@ jobs:
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-image')) ||
       (github.event_name == 'release' && github.event.action == 'published')
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: docker/metadata-action@v6
@@ -88,7 +88,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@v4.1.1
       - name: Sign image with cosign
         env:
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,7 +42,7 @@ jobs:
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-image')) ||
       (github.event_name == 'release' && github.event.action == 'published')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: docker/metadata-action@v6

--- a/.github/workflows/docs-develop.yaml
+++ b/.github/workflows/docs-develop.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-develop.yaml
+++ b/.github/workflows/docs-develop.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   lint:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     outputs:
       go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.version }}
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   lint:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -43,7 +43,7 @@ jobs:
           version: 'v4.0.1'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Login to GHCR # required for cosign
         uses: docker/login-action@v4

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    runs-on: arc-scale-set
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -43,7 +43,7 @@ jobs:
           version: 'v4.0.1'
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Login to GHCR # required for cosign
         uses: docker/login-action@v4

--- a/.github/workflows/issues-add-labels.yaml
+++ b/.github/workflows/issues-add-labels.yaml
@@ -6,7 +6,7 @@ on:
       - opened
 jobs:
   label_issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     steps:

--- a/.github/workflows/issues-add-to-project.yml
+++ b/.github/workflows/issues-add-to-project.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/add-to-project@v2.0.0
         with:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -25,7 +25,7 @@ jobs:
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # (Optional) GitHub Enterprise requires GHE_HOST variable set
       #- name: Set GHE_HOST

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -89,7 +89,7 @@ jobs:
 
   docker-release:
     name: Docker Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: release
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,14 @@ lint-no-golangci: $(ADDLICENSE) shellcheck  ## Run linters but not golangci-lint
 
 .PHONY: test
 test: $(SETUP_ENVTEST) $(GINKGO) ocm-transfer-demo ## Run all tests
+	mkdir -p $(BUILD_PATH)/coverdata
 	OCM=$(OCM) \
+	GOCOVERDIR=$(BUILD_PATH)/coverdata \
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile $(testargs)
-	@grep -v /solar/api solar.full.coverprofile > solar.coverprofile
+	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile --keep-separate-coverprofiles $(testargs)
+	@echo 'mode: count' > $(BUILD_PATH)/solar.full.coverprofile && \
+	 cat $(BUILD_PATH)/*_solar.full.coverprofile 2>/dev/null | grep -v '^mode:' >> $(BUILD_PATH)/solar.full.coverprofile || true
+	@grep -v /solar/api $(BUILD_PATH)/solar.full.coverprofile > solar.coverprofile || true
 
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/renovate.json
+++ b/renovate.json
@@ -60,7 +60,15 @@
       ],
       "versioningTemplate": "semver",
       "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/).github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "runs-on:\\s*(?<depName>\\w+)-(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-runners",
+      "versioningTemplate": "docker"
     }
-
   ]
 }


### PR DESCRIPTION
## What
Migrate to GitHub Runners, fix tests for different filesystem situations.

Additionally this fixes a E2E test fail.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI/CD runners to Ubuntu 24.04 across workflows (Docker, Go, Helm, docs, release, and CI checks).
  * Adjusted the signing tool version used in publishing workflows.
  * Improved test coverage reporting to aggregate per-package results into a combined coverage profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->