### PR TITLE
chore: run golang GitHub action on tools.lock changes

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -12,6 +12,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "tools.lock"
   pull_request:
     branches: [main, develop]
     paths:
@@ -21,6 +22,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "tools.lock"
 
 env:
   GO_MODULE: https://github.com/opendefensecloud/solution-arsenal


### PR DESCRIPTION
## What
Golang GitHub action uses tools referenced in tools.lock like addlicense (via `make lint-no-golangci`) or ginkgo (via `make test`).

## Why
Ensure that version bumps in tools.lock don't create regressions by verifying the change with related GitHub actions.

## Testing
none

## Checklist
- [x] Tests added/updated --> n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated testing infrastructure to better detect and respond to tool dependency updates. Code quality checks now run consistently whenever development tool versions are modified, during both standard code pushes and pull request reviews. This ensures more reliable validation across all development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->