### PR TITLE
feat: polish of ui poc: added impersonation, updated docs, dev-setup,…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ ui-seed-data: ## Seed demo resources (targets, releases, components, etc.) into 
 	$(HACK_DIR)/seed-demo-data.sh
 
 .PHONY: ui-dev
-ui-dev: ui-install ## Start Go backend + Vite dev server against the UI dev cluster
+ui-dev: ui-build ## Start Go backend + Vite dev server against the UI dev cluster
 	@case "$$($(KIND) get clusters 2>/dev/null)" in \
 		*"$(KIND_CLUSTER_UI_DEV)"*) ;; \
 		*) echo "UI dev cluster not found. Creating it..."; $(MAKE) ui-dev-cluster ;; \

--- a/charts/solar/templates/ui/admin-clusterrolebinding.yaml
+++ b/charts/solar/templates/ui/admin-clusterrolebinding.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Create the solar-ui:admin ClusterRole (labeled solar.opendefense.cloud/admin=true,
+no rules — it is a marker role) and, when ui.admin.subjects is non-empty, a
+ClusterRoleBinding that binds those subjects to it.
+
+The solar-ui BFF lists ClusterRoleBindings with this label at runtime using its own
+service-account credentials to determine which logged-in OIDC users have admin access
+(i.e. can reach the /auth/impersonation-targets and /auth/impersonate endpoints).
+
+To grant admin access without Helm, create your own ClusterRoleBinding with
+  roleRef.name: solar-ui:admin
+  labels:
+    solar.opendefense.cloud/admin: "true"
+*/ -}}
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar-ui:admin
+  labels:
+    {{- include "solar.labels" . | nindent 4 }}
+    solar.opendefense.cloud/admin: "true"
+rules: []
+{{- if .Values.ui.admin.subjects }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: solar-ui:admin
+  labels:
+    {{- include "solar.labels" . | nindent 4 }}
+    solar.opendefense.cloud/admin: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar-ui:admin
+subjects:
+  {{- toYaml .Values.ui.admin.subjects | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/solar/templates/ui/impersonation-clusterroles.yaml
+++ b/charts/solar/templates/ui/impersonation-clusterroles.yaml
@@ -9,12 +9,14 @@ The solar-ui BFF lists these ClusterRoles at runtime to discover the available "
 {{- if and .Values.rbac.create .Values.ui.impersonation.targets }}
 {{- $saNamespace := tpl .Values.ui.impersonation.serviceAccountNamespace . }}
 {{- range .Values.ui.impersonation.targets }}
+{{- $hash := sha256sum .username | trunc 6 }}
+{{- $name := printf "solar-ui:impersonate:%s-%s" (.username | lower | replace "@" "-" | replace "." "-" | trunc 56 | trimSuffix "-") $hash }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   {{- /* Derive a safe name from the username: lowercase, replace @ and . with - */}}
-  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+  name: {{ $name }}
   labels:
     {{- include "solar.labels" $ | nindent 4 }}
     solar.opendefense.cloud/impersonatable: "true"
@@ -37,13 +39,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+  name: {{ $name }}
   labels:
     {{- include "solar.labels" $ | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+  name: {{ $name }}
 subjects:
   - kind: ServiceAccount
     name: {{ $.Values.ui.impersonation.serviceAccountName }}

--- a/charts/solar/templates/ui/impersonation-clusterroles.yaml
+++ b/charts/solar/templates/ui/impersonation-clusterroles.yaml
@@ -1,0 +1,52 @@
+{{- /*
+For each entry in .Values.ui.impersonation.targets, create:
+  1. A ClusterRole labeled solar.opendefense.cloud/impersonatable=true with
+     impersonate rules for the user and their groups.
+  2. A ClusterRoleBinding granting that role to the solar-ui ServiceAccount.
+
+The solar-ui BFF lists these ClusterRoles at runtime to discover the available "preview as" options
+*/ -}}
+{{- if and .Values.rbac.create .Values.ui.impersonation.targets }}
+{{- $saNamespace := tpl .Values.ui.impersonation.serviceAccountNamespace . }}
+{{- range .Values.ui.impersonation.targets }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  {{- /* Derive a safe name from the username: lowercase, replace @ and . with - */}}
+  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "solar.labels" $ | nindent 4 }}
+    solar.opendefense.cloud/impersonatable: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+    resourceNames:
+      - {{ .username | quote }}
+  {{- if .groups }}
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+    resourceNames:
+      {{- range .groups }}
+      - {{ . | quote }}
+      {{- end }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "solar.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "solar-ui:impersonate:%s" .username | lower | replace "@" "-" | replace "." "-" | trunc 63 | trimSuffix "-" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.ui.impersonation.serviceAccountName }}
+    namespace: {{ $saNamespace }}
+{{- end }}
+{{- end }}

--- a/charts/solar/templates/ui/rbac.yaml
+++ b/charts/solar/templates/ui/rbac.yaml
@@ -1,0 +1,37 @@
+{{- /*
+Grant the solar-ui BFF service account read-only access to ClusterRoles and
+ClusterRoleBindings so it can:
+  - list ClusterRoles labeled solar.opendefense.cloud/impersonatable=true
+    (used by listImpersonationTargets to discover available "preview as" personas)
+  - list ClusterRoleBindings labeled solar.opendefense.cloud/admin=true
+    (used by isAdminUser to decide whether the logged-in OIDC user has admin access)
+*/ -}}
+{{- if and .Values.rbac.create .Values.ui.impersonation.serviceAccountName }}
+{{- $saNamespace := tpl .Values.ui.impersonation.serviceAccountNamespace . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar-ui:read-rbac
+  labels:
+    {{- include "solar.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: solar-ui:read-rbac
+  labels:
+    {{- include "solar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar-ui:read-rbac
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.ui.impersonation.serviceAccountName }}
+    namespace: {{ $saNamespace }}
+{{- end }}

--- a/charts/solar/values.yaml
+++ b/charts/solar/values.yaml
@@ -475,3 +475,46 @@ rbac:
   #   - apiGroups: [""]
   #     resources: ["secrets"]
   #     verbs: ["get", "list"]
+
+# UI / BFF configuration
+ui:
+  # -- Admin users who can access impersonation-management endpoints.
+  # For each entry in subjects, a ClusterRoleBinding labeled
+  # solar.opendefense.cloud/admin=true is created. The BFF checks this label
+  # at runtime using its own service-account credentials to authorise
+  # GET /auth/impersonation-targets, PUT /auth/impersonate, and
+  # DELETE /auth/impersonate. The check is immune to active impersonation state.
+  admin:
+    # -- Subjects (Kind: User or Group) that are granted solar-ui admin access.
+    subjects: []
+    # - kind: User
+    #   name: admin@solar.local
+    # - kind: Group
+    #   name: solar-admins
+
+  # -- Impersonation personas available in the admin "preview as" feature.
+  # For each entry a ClusterRole labeled solar.opendefense.cloud/impersonatable=true
+  # is created that grants the solar-ui service account the right to impersonate
+  # the given user and groups. The solar-ui BFF discovers these ClusterRoles at
+  # runtime, so adding or removing entries takes effect after a Helm upgrade
+  # without restarting the BFF.
+  #
+  # Each entry must have:
+  #   username  – the exact OIDC subject / e-mail of the user to impersonate
+  #   groups    – the list of OIDC groups to present when impersonating
+  #
+  # The serviceAccountName/Namespace fields tell the binding which service account
+  # to grant these impersonation rights to.
+  impersonation:
+    # -- Name of the solar-ui ServiceAccount that receives impersonation rights.
+    serviceAccountName: solar-ui
+    # -- Namespace of the solar-ui ServiceAccount.
+    serviceAccountNamespace: "{{ .Release.Namespace }}"
+    # -- List of user personas that can be impersonated.
+    targets: []
+    # - username: maintainer@solar.local
+    #   groups:
+    #     - maintainer
+    # - username: coordinator@solar.local
+    #   groups:
+    #     - coordinator

--- a/charts/solar/values.yaml
+++ b/charts/solar/values.yaml
@@ -489,8 +489,10 @@ ui:
     subjects: []
     # - kind: User
     #   name: admin@solar.local
+    #   apiGroup: rbac.authorization.k8s.io
     # - kind: Group
     #   name: solar-admins
+    #   apiGroup: rbac.authorization.k8s.io
 
   # -- Impersonation personas available in the admin "preview as" feature.
   # For each entry a ClusterRole labeled solar.opendefense.cloud/impersonatable=true

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -11,6 +11,7 @@ nav:
   - Installation:
     - operator-manual/installation/installation.md
     - operator-manual/installation/*.md
+  - operator-manual/ui-access-control.md
   - operator-manual/*.md
 - Developer Guide:
   - CODE_OF_CONDUCT.md

--- a/docs/operator-manual/ui-access-control.md
+++ b/docs/operator-manual/ui-access-control.md
@@ -1,0 +1,59 @@
+# UI Access Control
+
+The SolAr UI uses Kubernetes RBAC to control which features are available to logged-in users. There are two distinct access levels:
+
+- **Admin** — can use the "Preview as" impersonation feature to browse the UI as another persona
+- **Regular user** — sees only the resources their own OIDC identity is permitted to access
+
+## Granting Admin Access
+
+Admin access is determined by membership in a `ClusterRoleBinding` labeled `solar.opendefense.cloud/admin=true`. The BFF checks this label using its own service-account credentials, so the check is independent of any active impersonation state.
+
+Use the `ui.admin.subjects` Helm value to declare which users or groups are admins:
+
+```yaml
+ui:
+  admin:
+    subjects:
+      - kind: User
+        name: admin@example.com
+        apiGroup: rbac.authorization.k8s.io
+      - kind: Group
+        name: platform-admins
+        apiGroup: rbac.authorization.k8s.io
+```
+
+This creates a `ClusterRoleBinding` named `solar-ui:admin` with the required label. You can also manage the binding manually — any `ClusterRoleBinding` with the label `solar.opendefense.cloud/admin=true` that lists the user as a subject will grant admin access.
+
+## Configuring Impersonation Personas
+
+Admins can preview the UI as another persona via the "Preview as" dropdown. Personas are defined with `ui.impersonation.targets`:
+
+```yaml
+ui:
+  impersonation:
+    targets:
+      - username: maintainer@example.com
+        groups:
+          - maintainer
+      - username: coordinator@example.com
+        groups:
+          - coordinator
+```
+
+For each entry the chart creates a `ClusterRole` labeled `solar.opendefense.cloud/impersonatable=true` and a `ClusterRoleBinding` that grants the BFF service account the right to impersonate that user. The BFF lists these roles at runtime, so adding or removing personas only requires a `helm upgrade` — no restart needed.
+
+!!! note
+    Personas do not need to be real OIDC users. They are K8s impersonation targets only — give them appropriate `ClusterRole` bindings to define what they can see.
+
+## Required BFF Service Account Permissions
+
+The chart automatically creates a `ClusterRole` named `solar-ui:read-rbac` and binds it to the BFF service account. It grants `list` on `clusterroles` and `clusterrolebindings` — the minimum required for admin checks and persona discovery. No additional setup is needed.
+
+## Summary
+
+| Helm value | Effect |
+|---|---|
+| `ui.admin.subjects` | Users/groups that can access impersonation management |
+| `ui.impersonation.targets` | Personas available in the "Preview as" dropdown |
+| `ui.impersonation.serviceAccountName` | BFF service account that receives impersonation rights (default: `solar-ui`) |

--- a/hack/setup-dex.sh
+++ b/hack/setup-dex.sh
@@ -29,4 +29,7 @@ $KUBECTL wait deployment/dex -n dex --for=condition=Available --timeout=120s
 # Grant the static Dex user cluster-admin for dev/test
 $KUBECTL apply -f "$PROJECT_DIR/test/fixtures/e2e/dex/dex-rbac.yaml"
 
+# Apply dev RBAC: solar roles for impersonation targets + impersonatable ClusterRoles
+$KUBECTL apply -f "$PROJECT_DIR/test/fixtures/e2e/dex/dev-solar-rbac.yaml"
+
 echo "Dex setup complete."

--- a/pkg/ui/api/handler.go
+++ b/pkg/ui/api/handler.go
@@ -39,6 +39,7 @@ var resourceMap = map[string]schema.GroupVersionResource{
 // Handler serves the K8s API proxy routes.
 type Handler struct {
 	baseConfig   *rest.Config
+	clientset    kubernetes.Interface
 	sessionStore *session.Store
 	authProvider auth.Provider
 	log          logr.Logger
@@ -58,8 +59,14 @@ func NewHandler(kubeconfig string, store *session.Store, provider auth.Provider,
 		return nil, fmt.Errorf("failed to create kubernetes config: %w", err)
 	}
 
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
 	return &Handler{
 		baseConfig:   cfg,
+		clientset:    clientset,
 		sessionStore: store,
 		authProvider: provider,
 		log:          log.WithName("api"),
@@ -79,15 +86,12 @@ func (h *Handler) clientFor(r *http.Request) (dynamic.Interface, error) {
 // Uses the BFF's own service-account credentials so the check is immune to
 // any active session-level impersonation override.
 func (h *Handler) isAdminUser(ctx context.Context, sess *session.Data) bool {
-	clientset, err := kubernetes.NewForConfig(h.baseConfig)
-	if err != nil {
-		return false
-	}
-
-	bindingList, err := clientset.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{
+	bindingList, err := h.clientset.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{
 		LabelSelector: adminLabel + "=true",
 	})
 	if err != nil {
+		h.log.Error(err, "failed to list admin ClusterRoleBindings")
+
 		return false
 	}
 
@@ -373,12 +377,7 @@ type ImpersonationTarget struct {
 // resourceNames in those rules define the username and group membership of the
 // persona respectively.
 func (h *Handler) listImpersonationTargets(ctx context.Context) ([]ImpersonationTarget, error) {
-	clientset, err := kubernetes.NewForConfig(h.baseConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
-	}
-
-	roleList, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
+	roleList, err := h.clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
 		LabelSelector: impersonatableLabel + "=true",
 	})
 	if err != nil {
@@ -476,7 +475,12 @@ func (h *Handler) HandleImpersonate() http.HandlerFunc {
 			return
 		}
 
-		h.sessionStore.SetImpersonation(r, target.Username, target.Groups)
+		if !h.sessionStore.SetImpersonation(r, target.Username, target.Groups) {
+			http.Error(w, "no session found", http.StatusUnauthorized)
+
+			return
+		}
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
@@ -484,7 +488,12 @@ func (h *Handler) HandleImpersonate() http.HandlerFunc {
 // HandleClearImpersonation removes the impersonation override from the session.
 func (h *Handler) HandleClearImpersonation() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		h.sessionStore.ClearImpersonation(r)
+		if !h.sessionStore.ClearImpersonation(r) {
+			http.Error(w, "no session found", http.StatusUnauthorized)
+
+			return
+		}
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/pkg/ui/api/handler.go
+++ b/pkg/ui/api/handler.go
@@ -4,13 +4,18 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/go-logr/logr"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -69,10 +74,82 @@ func (h *Handler) clientFor(r *http.Request) (dynamic.Interface, error) {
 	return dynamic.NewForConfig(cfg)
 }
 
-// HandleMe returns the current user info.
+// isAdminUser returns true when the session user is a subject of any
+// ClusterRoleBinding labeled solar.opendefense.cloud/admin=true.
+// Uses the BFF's own service-account credentials so the check is immune to
+// any active session-level impersonation override.
+func (h *Handler) isAdminUser(ctx context.Context, sess *session.Data) bool {
+	clientset, err := kubernetes.NewForConfig(h.baseConfig)
+	if err != nil {
+		return false
+	}
+
+	bindingList, err := clientset.RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{
+		LabelSelector: adminLabel + "=true",
+	})
+	if err != nil {
+		return false
+	}
+
+	for _, binding := range bindingList.Items {
+		for _, subject := range binding.Subjects {
+			switch subject.Kind {
+			case "User":
+				if subject.Name == sess.Username {
+					return true
+				}
+			case "Group":
+				if slices.Contains(sess.Groups, subject.Name) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// RequireAdmin returns a middleware that rejects requests from users who are not
+// listed as subjects in a ClusterRoleBinding labeled solar.opendefense.cloud/admin=true.
+func (h *Handler) RequireAdmin(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sess := h.sessionStore.Get(r)
+		if sess == nil || !h.isAdminUser(r.Context(), sess) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+// HandleMe returns the current user info, including an isAdmin flag derived
+// from a SelfSubjectAccessReview (can the user impersonate other users in K8s).
 func (h *Handler) HandleMe() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		h.sessionStore.GetJSON(w, r)
+		data := h.sessionStore.Get(r)
+		if data == nil {
+			writeJSON(w, map[string]any{"authenticated": false})
+
+			return
+		}
+
+		resp := map[string]any{
+			"authenticated": true,
+			"username":      data.Username,
+			"groups":        data.Groups,
+			"isAdmin":       h.isAdminUser(r.Context(), data),
+		}
+
+		if data.ImpersonatingAs != "" {
+			resp["impersonating"] = map[string]any{
+				"username": data.ImpersonatingAs,
+				"groups":   data.ImpersonatingGroups,
+			}
+		}
+
+		writeJSON(w, resp)
 	}
 }
 
@@ -175,8 +252,8 @@ func (h *Handler) HandleSSE() http.HandlerFunc {
 		events := make(chan sseEvent, 64)
 
 		for resourceName, gvr := range resourceMap {
-			go func() {
-				watcher, err := client.Resource(gvr).Namespace(namespace).Watch(r.Context(), watchOptions())
+			go func(ctx context.Context) {
+				watcher, err := client.Resource(gvr).Namespace(namespace).Watch(ctx, watchOptions())
 				if err != nil {
 					h.log.Error(err, "failed to watch", "resource", resourceName)
 
@@ -191,11 +268,11 @@ func (h *Handler) HandleSSE() http.HandlerFunc {
 						Resource:  resourceName,
 						Namespace: namespace,
 					}:
-					case <-r.Context().Done():
+					case <-ctx.Done():
 						return
 					}
 				}
-			}()
+			}(r.Context())
 		}
 
 		// Single writer goroutine — serializes all writes and respects client disconnect
@@ -209,5 +286,205 @@ func (h *Handler) HandleSSE() http.HandlerFunc {
 				return
 			}
 		}
+	}
+}
+
+// permissionRule is the JSON representation of a Kubernetes ResourceRule.
+type permissionRule struct {
+	Verbs     []string `json:"verbs"`
+	APIGroups []string `json:"apiGroups"`
+	Resources []string `json:"resources"`
+}
+
+// permissionsResponse is the response body for HandlePermissions.
+type permissionsResponse struct {
+	Incomplete bool             `json:"incomplete"`
+	Rules      []permissionRule `json:"rules"`
+}
+
+// HandlePermissions calls SelfSubjectRulesReview using the caller's own
+// credentials and returns the resulting resource rules for the namespace.
+// The frontend uses this to show/hide pages based on RBAC permissions.
+func (h *Handler) HandlePermissions() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		namespace := r.PathValue("namespace")
+
+		sess := h.sessionStore.Get(r)
+		cfg := h.authProvider.WrapConfig(h.baseConfig, sess)
+
+		clientset, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			h.log.Error(err, "failed to create kubernetes clientset")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		review := &authorizationv1.SelfSubjectRulesReview{
+			Spec: authorizationv1.SelfSubjectRulesReviewSpec{
+				Namespace: namespace,
+			},
+		}
+
+		result, err := clientset.AuthorizationV1().SelfSubjectRulesReviews().Create(
+			r.Context(), review, metav1.CreateOptions{},
+		)
+		if err != nil {
+			h.log.Error(err, "failed to evaluate self-subject rules", "namespace", namespace)
+			writeK8sError(w, err)
+
+			return
+		}
+
+		rules := make([]permissionRule, 0, len(result.Status.ResourceRules))
+		for _, rr := range result.Status.ResourceRules {
+			rules = append(rules, permissionRule{
+				Verbs:     rr.Verbs,
+				APIGroups: rr.APIGroups,
+				Resources: rr.Resources,
+			})
+		}
+
+		writeJSON(w, permissionsResponse{
+			Incomplete: result.Status.Incomplete,
+			Rules:      rules,
+		})
+	}
+}
+
+// impersonatableLabel is the well-known label that marks a ClusterRole as
+// defining an impersonatable user persona.
+const impersonatableLabel = "solar.opendefense.cloud/impersonatable"
+
+// adminLabel is the well-known label that marks a ClusterRoleBinding as
+// granting solar-ui admin access.
+const adminLabel = "solar.opendefense.cloud/admin"
+
+// ImpersonationTarget describes a user persona that an admin can preview as.
+type ImpersonationTarget struct {
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
+
+// listImpersonationTargets reads ClusterRoles labeled
+// solar.opendefense.cloud/impersonatable=true using the BFF's own service
+// account credentials (not the logged-in user's). Each ClusterRole is expected
+// to grant the impersonate verb on both the "users" and "groups" resources; the
+// resourceNames in those rules define the username and group membership of the
+// persona respectively.
+func (h *Handler) listImpersonationTargets(ctx context.Context) ([]ImpersonationTarget, error) {
+	clientset, err := kubernetes.NewForConfig(h.baseConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	roleList, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
+		LabelSelector: impersonatableLabel + "=true",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list impersonation ClusterRoles: %w", err)
+	}
+
+	targets := make([]ImpersonationTarget, 0, len(roleList.Items))
+
+	for _, role := range roleList.Items {
+		var username string
+		var groups []string
+
+		for _, rule := range role.Rules {
+			if !slices.Contains(rule.Verbs, "impersonate") && !slices.Contains(rule.Verbs, "*") {
+				continue
+			}
+
+			for _, resource := range rule.Resources {
+				switch resource {
+				case "users":
+					// FIXME: currently only the first resourceName is used if multiple are present.
+					// we could support multiple users per ClusterRole if needed
+					if len(rule.ResourceNames) > 0 {
+						username = rule.ResourceNames[0]
+					}
+				case "groups":
+					groups = append(groups, rule.ResourceNames...)
+				}
+			}
+		}
+
+		if username != "" {
+			targets = append(targets, ImpersonationTarget{
+				Username: username,
+				Groups:   groups,
+			})
+		}
+	}
+
+	return targets, nil
+}
+
+// HandleListImpersonationTargets returns the available impersonation personas
+// for the admin "preview as" feature. Requires admin privileges (enforced by
+// the server-level middleware); the lookup itself uses BFF credentials.
+func (h *Handler) HandleListImpersonationTargets() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		targets, err := h.listImpersonationTargets(r.Context())
+		if err != nil {
+			h.log.Error(err, "failed to list impersonation targets")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		writeJSON(w, targets)
+	}
+}
+
+// HandleImpersonate validates the requested username against the ClusterRole-
+// defined impersonation personas and activates the override on the session.
+func (h *Handler) HandleImpersonate() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Username string `json:"username"`
+		}
+
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Username == "" {
+			http.Error(w, "invalid request body: username is required", http.StatusBadRequest)
+
+			return
+		}
+
+		targets, err := h.listImpersonationTargets(r.Context())
+		if err != nil {
+			h.log.Error(err, "failed to list impersonation targets")
+			http.Error(w, "internal error", http.StatusInternalServerError)
+
+			return
+		}
+
+		var target *ImpersonationTarget
+
+		for i := range targets {
+			if targets[i].Username == req.Username {
+				target = &targets[i]
+
+				break
+			}
+		}
+
+		if target == nil {
+			http.Error(w, "unknown impersonation target", http.StatusBadRequest)
+
+			return
+		}
+
+		h.sessionStore.SetImpersonation(r, target.Username, target.Groups)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// HandleClearImpersonation removes the impersonation override from the session.
+func (h *Handler) HandleClearImpersonation() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h.sessionStore.ClearImpersonation(r)
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/pkg/ui/api/handler.go
+++ b/pkg/ui/api/handler.go
@@ -125,7 +125,7 @@ func (h *Handler) RequireAdmin(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // HandleMe returns the current user info, including an isAdmin flag derived
-// from a SelfSubjectAccessReview (can the user impersonate other users in K8s).
+// from membership in a ClusterRoleBinding labeled solar.opendefense.cloud/admin=true
 func (h *Handler) HandleMe() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := h.sessionStore.Get(r)

--- a/pkg/ui/auth/oidc.go
+++ b/pkg/ui/auth/oidc.go
@@ -157,8 +157,20 @@ func (p *OIDCProvider) HandleCallback(store *session.Store) http.HandlerFunc {
 // WrapConfig returns a rest.Config that authenticates as the session's user.
 // In token mode, the OIDC id_token is forwarded as a bearer token.
 // In impersonate mode, K8s user impersonation is used.
+// When the session has an active impersonation override (admin previewing as
+// another user), impersonation headers are always used regardless of authMode.
 func (p *OIDCProvider) WrapConfig(base *rest.Config, sess *session.Data) *rest.Config {
 	cfg := rest.CopyConfig(base)
+
+	// Session-level impersonation (admin "preview as" feature) takes precedence over the global authMode
+	if sess.ImpersonatingAs != "" {
+		cfg.Impersonate = rest.ImpersonationConfig{
+			UserName: sess.ImpersonatingAs,
+			Groups:   sess.ImpersonatingGroups,
+		}
+
+		return cfg
+	}
 
 	switch p.authMode {
 	case AuthModeImpersonate:
@@ -169,6 +181,14 @@ func (p *OIDCProvider) WrapConfig(base *rest.Config, sess *session.Data) *rest.C
 	default: // token
 		cfg.BearerToken = sess.IDToken
 		cfg.BearerTokenFile = ""
+		// Clear client certificate credentials so the K8s API server
+		// authenticates via the OIDC bearer token only. Without this,
+		// kubeconfigs that use client cert auth (e.g. Kind) would have
+		// the cert take precedence and bypass per-user RBAC enforcement.
+		cfg.CertData = nil
+		cfg.CertFile = ""
+		cfg.KeyData = nil
+		cfg.KeyFile = ""
 	}
 
 	return cfg

--- a/pkg/ui/auth/provider.go
+++ b/pkg/ui/auth/provider.go
@@ -17,6 +17,7 @@ type Provider interface {
 	HandleLogin(store *session.Store) http.HandlerFunc
 	// HandleCallback handles the authentication callback (e.g. OIDC redirect).
 	HandleCallback(store *session.Store) http.HandlerFunc
-	// WrapConfig returns a rest.Config that authenticates as the session's user.
+	// WrapConfig returns a rest.Config that authenticates as the session's user,
+	// applying any active impersonation override.
 	WrapConfig(base *rest.Config, sess *session.Data) *rest.Config
 }

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -96,7 +96,7 @@ func NewServer(cfg Config, log logr.Logger) (*Server, error) {
 	mux.Handle("GET /api/namespaces/{namespace}/permissions", requireAuth(k8sHandler.HandlePermissions()))
 
 	// Impersonation
-	// Admin check is SAR-based (impersonate verb on users), matching isAdmin in /auth/me.
+	// Admin check is based on presence of ClusterRoleBinding with solar.opendefense.cloud/admin=true label
 	// Available personas are discovered from ClusterRoles labeled
 	// solar.opendefense.cloud/impersonatable=true (see Helm chart values.ui.impersonationTargets).
 	mux.Handle("GET /api/auth/impersonation-targets", requireAuth(k8sHandler.RequireAdmin(k8sHandler.HandleListImpersonationTargets())))

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -92,6 +92,17 @@ func NewServer(cfg Config, log logr.Logger) (*Server, error) {
 	// SSE events
 	mux.Handle("GET /api/namespaces/{namespace}/events", requireAuth(k8sHandler.HandleSSE()))
 
+	// Permissions — uses SelfSubjectRulesReview with caller's own credentials
+	mux.Handle("GET /api/namespaces/{namespace}/permissions", requireAuth(k8sHandler.HandlePermissions()))
+
+	// Impersonation
+	// Admin check is SAR-based (impersonate verb on users), matching isAdmin in /auth/me.
+	// Available personas are discovered from ClusterRoles labeled
+	// solar.opendefense.cloud/impersonatable=true (see Helm chart values.ui.impersonationTargets).
+	mux.Handle("GET /api/auth/impersonation-targets", requireAuth(k8sHandler.RequireAdmin(k8sHandler.HandleListImpersonationTargets())))
+	mux.Handle("PUT /api/auth/impersonate", requireAuth(k8sHandler.RequireAdmin(k8sHandler.HandleImpersonate())))
+	mux.Handle("DELETE /api/auth/impersonate", requireAuth(k8sHandler.RequireAdmin(k8sHandler.HandleClearImpersonation())))
+
 	// SPA — either proxy to Vite dev server or serve embedded static files
 	if cfg.DevViteURL != "" {
 		viteURL, err := url.Parse(cfg.DevViteURL)

--- a/pkg/ui/session/store.go
+++ b/pkg/ui/session/store.go
@@ -25,6 +25,11 @@ type Data struct {
 	Groups      []string `json:"groups"`
 	IDToken     string   `json:"id_token,omitempty"`     //nolint:gosec // not a hardcoded credential
 	AccessToken string   `json:"access_token,omitempty"` //nolint:gosec // not a hardcoded credential
+
+	// ImpersonatingAs is set when an admin is previewing as another user.
+	// The BE will forward K8s requests with Impersonate-User headers.
+	ImpersonatingAs     string   `json:"impersonating_as,omitempty"`
+	ImpersonatingGroups []string `json:"impersonating_groups,omitempty"`
 }
 
 // Store manages encrypted cookie-based sessions.
@@ -110,6 +115,46 @@ func (s *Store) Clear(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// SetImpersonation updates ImpersonatingAs/Groups in the existing session in-place.
+func (s *Store) SetImpersonation(r *http.Request, username string, groups []string) bool {
+	cookie, err := r.Cookie(cookieName)
+	if err != nil {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if sess, ok := s.sessions[cookie.Value]; ok {
+		sess.ImpersonatingAs = username
+		sess.ImpersonatingGroups = groups
+
+		return true
+	}
+
+	return false
+}
+
+// ClearImpersonation removes the impersonation override from the existing session.
+func (s *Store) ClearImpersonation(r *http.Request) bool {
+	cookie, err := r.Cookie(cookieName)
+	if err != nil {
+		return false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if sess, ok := s.sessions[cookie.Value]; ok {
+		sess.ImpersonatingAs = ""
+		sess.ImpersonatingGroups = nil
+
+		return true
+	}
+
+	return false
+}
+
 // SetState stores the OIDC state parameter in a short-lived cookie.
 func (s *Store) SetState(w http.ResponseWriter, state string) {
 	http.SetCookie(w, &http.Cookie{
@@ -162,6 +207,12 @@ func (s *Store) GetJSON(w http.ResponseWriter, r *http.Request) {
 		"authenticated": true,
 		"username":      data.Username,
 		"groups":        data.Groups,
+	}
+	if data.ImpersonatingAs != "" {
+		resp["impersonating"] = map[string]any{
+			"username": data.ImpersonatingAs,
+			"groups":   data.ImpersonatingGroups,
+		}
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		log.Printf("failed to encode session JSON: %v", err)

--- a/pkg/ui/session/store.go
+++ b/pkg/ui/session/store.go
@@ -6,9 +6,7 @@ package session
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -203,35 +201,6 @@ func (s *Store) ClearState(w http.ResponseWriter) {
 		Secure:   true,
 		MaxAge:   -1,
 	})
-}
-
-// GetJSON writes session data as JSON to the writer.
-func (s *Store) GetJSON(w http.ResponseWriter, r *http.Request) {
-	data := s.Get(r)
-	if data == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"authenticated":false}`))
-
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-
-	resp := map[string]any{
-		"authenticated": true,
-		"username":      data.Username,
-		"groups":        data.Groups,
-	}
-	if data.ImpersonatingAs != "" {
-		resp["impersonating"] = map[string]any{
-			"username": data.ImpersonatingAs,
-			"groups":   data.ImpersonatingGroups,
-		}
-	}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		log.Printf("failed to encode session JSON: %v", err)
-	}
 }
 
 func generateSessionID() string {

--- a/pkg/ui/session/store.go
+++ b/pkg/ui/session/store.go
@@ -65,7 +65,11 @@ func NewStore(hexKey string) (*Store, error) {
 	}, nil
 }
 
-// Get retrieves session data from the request.
+// Get retrieves a copy of the session data from the request.
+// A copy is returned so that callers can read fields
+// without holding the store lock. This prevents data races with
+// SetImpersonation / ClearImpersonation, which mutate the stored object
+// under the write lock while concurrent requests may be reading it.
 func (s *Store) Get(r *http.Request) *Data {
 	cookie, err := r.Cookie(cookieName)
 	if err != nil {
@@ -75,7 +79,18 @@ func (s *Store) Get(r *http.Request) *Data {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.sessions[cookie.Value]
+	sess, ok := s.sessions[cookie.Value]
+	if !ok {
+		return nil
+	}
+
+	// Return a shallow copy of the struct with independently-allocated slices
+	// so the caller owns the data and no lock is needed after this point.
+	cp := *sess
+	cp.Groups = append([]string(nil), sess.Groups...)
+	cp.ImpersonatingGroups = append([]string(nil), sess.ImpersonatingGroups...)
+
+	return &cp
 }
 
 // Set stores session data and sets the cookie.

--- a/test/fixtures/e2e/dex/dev-solar-rbac.yaml
+++ b/test/fixtures/e2e/dex/dev-solar-rbac.yaml
@@ -1,0 +1,141 @@
+# Dev-only RBAC fixtures for solar-ui impersonation testing.
+#
+# Two personas are defined:
+#   maintainer@solar.local — solution maintainer: read-only access to components/versions
+#   coordinator@solar.local — deployment coordinator: read-only access to targets, releases, profiles
+#
+# These users do NOT need Dex entries; they exist only as K8s impersonation targets.
+# The admin user (admin@solar.local) is granted solar-ui admin access via the
+# solar-ui:admin ClusterRoleBinding below (labeled solar.opendefense.cloud/admin=true).
+# The solar-ui BFF lists ClusterRoleBindings with this label using its own kubeconfig
+# credentials to derive isAdmin — it does NOT use a SelfSubjectAccessReview.
+#
+# The solar-ui process runs with the Kind admin kubeconfig so it can always list
+# these ClusterRoles and perform the impersonation on behalf of the admin user.
+
+---
+# solar-ui:admin — grants admin@solar.local access to impersonation management endpoints.
+# The solar-ui BFF discovers this via the solar.opendefense.cloud/admin=true label.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar-ui:admin
+  labels:
+    solar.opendefense.cloud/admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: solar-ui:admin
+  labels:
+    solar.opendefense.cloud/admin: "true"
+subjects:
+  - kind: User
+    name: admin@solar.local
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar-ui:admin
+
+---
+# ClusterRole: solution maintainer
+# Read access to catalog resources only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:maintainer
+rules:
+  - apiGroups: ["solar.opendefense.cloud"]
+    resources:
+      - components
+      - componentversions
+      - registries
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: solar:maintainer
+subjects:
+  - kind: User
+    name: maintainer@solar.local
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:maintainer
+
+---
+# ClusterRole: deployment coordinator
+# Read access to deployment resources only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:coordinator
+rules:
+  - apiGroups: ["solar.opendefense.cloud"]
+    resources:
+      - targets
+      - releases
+      - releasebindings
+      - profiles
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: solar:coordinator
+subjects:
+  - kind: User
+    name: coordinator@solar.local
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:coordinator
+
+---
+# Impersonation ClusterRole for maintainer@solar.local.
+# Labeled solar.opendefense.cloud/impersonatable=true so the solar-ui BFF
+# discovers it via label selector and surfaces it in the "Preview as" dropdown.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar-ui:impersonate:maintainer-solar-local
+  labels:
+    solar.opendefense.cloud/impersonatable: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+    resourceNames:
+      - maintainer@solar.local
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+    resourceNames:
+      - maintainer
+
+---
+# Impersonation ClusterRole for coordinator@solar.local.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar-ui:impersonate:coordinator-solar-local
+  labels:
+    solar.opendefense.cloud/impersonatable: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["users"]
+    verbs: ["impersonate"]
+    resourceNames:
+      - coordinator@solar.local
+  - apiGroups: [""]
+    resources: ["groups"]
+    verbs: ["impersonate"]
+    resourceNames:
+      - coordinator

--- a/test/fixtures/solar.values.yaml
+++ b/test/fixtures/solar.values.yaml
@@ -19,3 +19,18 @@ renderer:
 discovery:
   image:
     repository: localhost/local/solar-discovery-worker
+
+ui:
+  admin:
+    subjects:
+      - kind: User
+        name: admin@solar.local
+        apiGroup: rbac.authorization.k8s.io
+  impersonation:
+    targets:
+      - username: maintainer@solar.local
+        groups:
+          - maintainer
+      - username: coordinator@solar.local
+        groups:
+          - coordinator

--- a/web/e2e/impersonation.spec.ts
+++ b/web/e2e/impersonation.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("Impersonation — unauthenticated access", () => {
   // storageState: undefined overrides the project-level stored session so
   // these contexts have no cookies and are treated as unauthenticated.
+
   test("GET /api/auth/impersonation-targets returns 401 when not logged in", async ({
     browser,
   }) => {
@@ -26,6 +27,11 @@ test.describe("Impersonation — unauthenticated access", () => {
 
 test.describe("Impersonation — admin user", () => {
   // Session from auth.setup.ts: logged in as admin@solar.local (isAdmin=true).
+
+  test.afterEach(async ({ request }) => {
+    // Best-effort: ensure no test leaves the shared session impersonating.
+    await request.delete("/api/auth/impersonate").catch(() => {});
+  });
 
   test("GET /api/auth/me reports isAdmin=true for admin user", async ({
     request,

--- a/web/e2e/impersonation.spec.ts
+++ b/web/e2e/impersonation.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Impersonation — unauthenticated access", () => {
+  // storageState: undefined overrides the project-level stored session so
+  // these contexts have no cookies and are treated as unauthenticated.
+  test("GET /api/auth/impersonation-targets returns 401 when not logged in", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ storageState: undefined });
+    const response = await ctx.request.get("/api/auth/impersonation-targets");
+    expect(response.status()).toBe(401);
+    await ctx.close();
+  });
+
+  test("PUT /api/auth/impersonate returns 401 when not logged in", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ storageState: undefined });
+    const response = await ctx.request.put("/api/auth/impersonate", {
+      data: { username: "maintainer@solar.local" },
+    });
+    expect(response.status()).toBe(401);
+    await ctx.close();
+  });
+});
+
+test.describe("Impersonation — admin user", () => {
+  // Session from auth.setup.ts: logged in as admin@solar.local (isAdmin=true).
+
+  test("GET /api/auth/me reports isAdmin=true for admin user", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/auth/me");
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.authenticated).toBe(true);
+    expect(body.username).toBe("admin@solar.local");
+    expect(body.isAdmin).toBe(true);
+  });
+
+  test("GET /api/auth/impersonation-targets returns available personas", async ({
+    request,
+  }) => {
+    const response = await request.get("/api/auth/impersonation-targets");
+    expect(response.status()).toBe(200);
+    const targets: { username: string; groups: string[] }[] =
+      await response.json();
+    expect(Array.isArray(targets)).toBe(true);
+    expect(targets.length).toBeGreaterThan(0);
+
+    const usernames = targets.map((t) => t.username);
+    expect(usernames).toContain("maintainer@solar.local");
+    expect(usernames).toContain("coordinator@solar.local");
+  });
+
+  test("can activate impersonation, sees persona permissions, then clear it", async ({
+    request,
+  }) => {
+    // Activate impersonation as coordinator
+    const impersonate = await request.put("/api/auth/impersonate", {
+      data: { username: "coordinator@solar.local" },
+    });
+    expect(impersonate.status()).toBe(204);
+
+    // /auth/me should reflect impersonating state
+    const meImpersonating = await request.get("/api/auth/me");
+    expect(meImpersonating.status()).toBe(200);
+    const meBody = await meImpersonating.json();
+    expect(meBody.impersonating?.username).toBe("coordinator@solar.local");
+    expect(meBody.impersonating?.groups).toContain("coordinator");
+    // isAdmin must still reflect the real admin identity, not the persona's
+    expect(meBody.isAdmin).toBe(true);
+
+    // Permissions endpoint should return the coordinator's rules only
+    const perms = await request.get("/api/namespaces/default/permissions");
+    expect(perms.status()).toBe(200);
+    const { rules } = await perms.json();
+    const solarRules = (
+      rules as { apiGroups: string[]; resources: string[]; verbs: string[] }[]
+    ).filter((r) => r.apiGroups.includes("solar.opendefense.cloud"));
+    // coordinator has get/list/watch on targets, releases, releasebindings, profiles
+    expect(
+      solarRules.some((r) => r.resources.includes("targets")),
+    ).toBe(true);
+    // coordinator does NOT have write verbs on any solar resource
+    const hasWrite = solarRules.some((r) =>
+      r.verbs.some((v) => ["create", "update", "patch", "delete"].includes(v)),
+    );
+    expect(hasWrite).toBe(false);
+
+    // Clear impersonation
+    const clear = await request.delete("/api/auth/impersonate");
+    expect(clear.status()).toBe(204);
+
+    // /auth/me should no longer show impersonating
+    const meCleared = await request.get("/api/auth/me");
+    const meClearedBody = await meCleared.json();
+    expect(meClearedBody.impersonating).toBeUndefined();
+  });
+
+  test("PUT /api/auth/impersonate rejects unknown username", async ({
+    request,
+  }) => {
+    const response = await request.put("/api/auth/impersonate", {
+      data: { username: "nobody@solar.local" },
+    });
+    expect(response.status()).toBe(400);
+  });
+
+  test("PUT /api/auth/impersonate rejects missing username", async ({
+    request,
+  }) => {
+    const response = await request.put("/api/auth/impersonate", {
+      data: {},
+    });
+    expect(response.status()).toBe(400);
+  });
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -51,5 +51,14 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
       },
     },
+    {
+      name: "impersonation",
+      testMatch: /impersonation\.spec\.ts/,
+      dependencies: ["setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "e2e/.auth/session.json",
+      },
+    },
   ],
 });

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -11,6 +11,8 @@ import type {
   RenderTask,
   ResourceList,
   UserInfo,
+  PermissionsResponse,
+  ImpersonationTarget,
 } from "./types";
 
 export const authQueries = {
@@ -22,12 +24,40 @@ export const authQueries = {
     }),
 };
 
+export const permissionQueries = {
+  rules: (namespace: string) =>
+    queryOptions({
+      queryKey: ["permissions", namespace],
+      queryFn: () =>
+        api.get<PermissionsResponse>(`/namespaces/${namespace}/permissions`),
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }),
+};
+
+export const impersonationQueries = {
+  targets: () =>
+    queryOptions({
+      queryKey: ["impersonation", "targets"],
+      queryFn: () => api.get<ImpersonationTarget[]>("/auth/impersonation-targets"),
+      staleTime: 5 * 60 * 1000,
+      retry: false,
+    }),
+};
+
+export const impersonationMutations = {
+  impersonate: (username: string) =>
+    api.put<void>("/auth/impersonate", { username }),
+  clear: () => api.delete<void>("/auth/impersonate"),
+};
+
 export const targetQueries = {
   list: (namespace: string) =>
     queryOptions({
       queryKey: ["targets", namespace],
       queryFn: () =>
         api.get<ResourceList<Target>>(`/namespaces/${namespace}/targets`),
+      staleTime: 60 * 1000,
     }),
   detail: (namespace: string, name: string) =>
     queryOptions({

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -134,6 +134,30 @@ export interface UserInfo {
   username: string;
   groups: string[];
   authenticated: boolean;
+  /** True when the user has the K8s impersonate verb on users (computed by BFF). */
+  isAdmin?: boolean;
+  impersonating?: {
+    username: string;
+    groups: string[];
+  };
+}
+
+// Admin impersonation persona
+export interface ImpersonationTarget {
+  username: string;
+  groups: string[];
+}
+
+// Permissions — derived from SelfSubjectRulesReview
+export interface PolicyRule {
+  verbs: string[];
+  apiGroups: string[];
+  resources: string[];
+}
+
+export interface PermissionsResponse {
+  incomplete: boolean;
+  rules: PolicyRule[];
 }
 
 // SSE event

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -38,6 +38,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
     const { data: user } = useQuery(authQueries.me());
     const router = useRouterState();
     const currentPath = router.location.pathname;
+    // potentially check permissions in specific namespaces in the future, but for now just check at the cluster level
     const permissions = usePermissions(DEFAULT_NAMESPACE);
     const { targets, impersonatedUsername, isImpersonating, impersonate, clearImpersonation } =
         useImpersonation();
@@ -109,11 +110,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     {/* Preview as — only shown to platform admins */}
                     {user?.authenticated && permissions.isAdmin && (
                         <div className="space-y-1">
-                            <p className="px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
-                                <Eye className="h-3 w-3" />
+                            <label
+                                htmlFor="impersonation-select"
+                                className="px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1"
+                            >
+                                <Eye className="h-3 w-3" aria-hidden="true" />
                                 Preview as
-                            </p>
+                            </label>
                             <select
+                                id="impersonation-select"
                                 className={cn(
                                     "w-full rounded-md border px-2 py-1.5 text-xs bg-background text-foreground",
                                     isImpersonating
@@ -138,7 +143,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                                 ))}
                             </select>
                             {isImpersonating && (
-                                <p className="px-1 text-[10px] text-amber-600 dark:text-amber-400">
+                                <p role="status" className="px-1 text-[10px] text-amber-600 dark:text-amber-400">
                                     K8s requests run as {impersonatedUsername}
                                 </p>
                             )}

--- a/web/src/components/layout.tsx
+++ b/web/src/components/layout.tsx
@@ -8,22 +8,44 @@ import {
     Boxes,
     Users,
     LogOut,
+    Eye,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { usePermissions } from "@/hooks/usePermissions";
+import { useImpersonation } from "@/hooks/useImpersonation";
 
-const navItems = [
-    { to: "/", label: "Dashboard", icon: LayoutDashboard },
-    { to: "/targets", label: "Targets", icon: Server },
-    { to: "/releases", label: "Releases", icon: Package },
-    { to: "/components", label: "Components", icon: Boxes },
-    { to: "/profiles", label: "Profiles", icon: Users },
-] as const;
+const SOLAR_GROUP = "solar.opendefense.cloud";
+const DEFAULT_NAMESPACE = "default";
+
+// Each guarded nav item declares which verb+resource the user must have.
+type NavItem = {
+    to: string;
+    label: string;
+    icon: React.ElementType;
+    guard: { verb: string; resource: string } | null;
+};
+
+const navItems: NavItem[] = [
+    { to: "/", label: "Dashboard", icon: LayoutDashboard, guard: null },
+    { to: "/targets", label: "Targets", icon: Server, guard: { verb: "list", resource: "targets" } },
+    { to: "/releases", label: "Releases", icon: Package, guard: { verb: "list", resource: "releases" } },
+    { to: "/components", label: "Components", icon: Boxes, guard: { verb: "list", resource: "components" } },
+    { to: "/profiles", label: "Profiles", icon: Users, guard: { verb: "list", resource: "profiles" } },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
     const { data: user } = useQuery(authQueries.me());
     const router = useRouterState();
     const currentPath = router.location.pathname;
+    const permissions = usePermissions(DEFAULT_NAMESPACE);
+    const { targets, impersonatedUsername, isImpersonating, impersonate, clearImpersonation } =
+        useImpersonation();
+
+    const visibleNavItems = navItems.filter(({ guard }) => {
+        if (!guard) return true;
+        return permissions.can(guard.verb, guard.resource, SOLAR_GROUP);
+    });
 
     return (
         <div className="flex h-screen bg-background">
@@ -47,7 +69,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     <p className="mb-2 px-3 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
                         Navigation
                     </p>
-                    {navItems.map(({ to, label, icon: Icon }) => {
+                    {visibleNavItems.map(({ to, label, icon: Icon }) => {
                         const isActive =
                             currentPath === to ||
                             (to !== "/" && currentPath.startsWith(to));
@@ -76,13 +98,53 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 </nav>
 
                 {/* Footer: theme toggle + user */}
-                <div className="border-t border-sidebar-border p-3">
-                    <div className="mb-3 flex items-center justify-between px-1">
+                <div className="border-t border-sidebar-border p-3 space-y-3">
+                    <div className="flex items-center justify-between px-1">
                         <span className="text-[11px] font-medium text-muted-foreground">
                             Theme
                         </span>
                         <ThemeToggle />
                     </div>
+
+                    {/* Preview as — only shown to platform admins */}
+                    {user?.authenticated && permissions.isAdmin && (
+                        <div className="space-y-1">
+                            <p className="px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1">
+                                <Eye className="h-3 w-3" />
+                                Preview as
+                            </p>
+                            <select
+                                className={cn(
+                                    "w-full rounded-md border px-2 py-1.5 text-xs bg-background text-foreground",
+                                    isImpersonating
+                                        ? "border-amber-500 text-amber-600 dark:text-amber-400"
+                                        : "border-border",
+                                )}
+                                value={impersonatedUsername ?? ""}
+                                onChange={(e) => {
+                                    const val = e.target.value;
+                                    if (val === "") {
+                                        clearImpersonation();
+                                    } else {
+                                        impersonate(val);
+                                    }
+                                }}
+                            >
+                                <option value="">Myself (admin)</option>
+                                {targets.map((t) => (
+                                    <option key={t.username} value={t.username}>
+                                        {t.username}
+                                    </option>
+                                ))}
+                            </select>
+                            {isImpersonating && (
+                                <p className="px-1 text-[10px] text-amber-600 dark:text-amber-400">
+                                    K8s requests run as {impersonatedUsername}
+                                </p>
+                            )}
+                        </div>
+                    )}
+
                     {user?.authenticated && (
                         <div className="flex items-center justify-between rounded-md bg-accent/50 px-3 py-2">
                             <div className="min-w-0">

--- a/web/src/hooks/useImpersonation.ts
+++ b/web/src/hooks/useImpersonation.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { authQueries, impersonationQueries, impersonationMutations } from "@/api/queries";
+
+export interface UseImpersonationResult {
+  /** Available personas fetched from the BFF (empty until loaded). */
+  targets: { username: string; groups: string[] }[];
+  /** Username currently being impersonated, or null when acting as self. */
+  impersonatedUsername: string | null;
+  isImpersonating: boolean;
+  /** Activate impersonation for the given username (must be a known target). */
+  impersonate: (username: string) => void;
+  /** Revert to acting as the real admin user. */
+  clearImpersonation: () => void;
+}
+
+export function useImpersonation(): UseImpersonationResult {
+  const queryClient = useQueryClient();
+  const { data: user } = useQuery(authQueries.me());
+  const { data: targets = [] } = useQuery(impersonationQueries.targets());
+
+  const impersonatedUsername = user?.impersonating?.username ?? null;
+
+  // After either mutation resolves, invalidate /auth/me and permissions so the
+  // UI immediately reflects the new effective identity.
+  const onSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: ["auth", "me"] });
+    queryClient.invalidateQueries({ queryKey: ["permissions"] });
+  };
+
+  const impersonateMutation = useMutation({
+    mutationFn: (username: string) => impersonationMutations.impersonate(username),
+    onSuccess,
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: () => impersonationMutations.clear(),
+    onSuccess,
+  });
+
+  return {
+    targets,
+    impersonatedUsername,
+    isImpersonating: impersonatedUsername !== null,
+    impersonate: (username) => impersonateMutation.mutate(username),
+    clearImpersonation: () => clearMutation.mutate(),
+  };
+}

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -47,11 +47,11 @@ export type UsePermissionsResult =
  */
 export function usePermissions(namespace: string): UsePermissionsResult {
   const { data } = useQuery(permissionQueries.rules(namespace));
-  const { data: user } = useQuery(authQueries.me());
+  const { data: user, isPending } = useQuery(authQueries.me());
   // isAdmin is determined by the BFF 
   const isAdmin = user?.isAdmin ?? false;
 
-  if (!data) {
+  if (!data || isPending) {
     return { ready: false, isAdmin: false, can: () => false };
   }
 

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { authQueries, permissionQueries } from "@/api/queries";
+import type { PermissionsResponse, PolicyRule } from "@/api/types";
+
+/**
+ * Returns true if any rule in the list grants `verb` on `resource` in `apiGroup`.
+ * Wildcards ("*") in verbs, resources, or apiGroups are honoured.
+ *
+ * When `apiGroup` is omitted the check is group-agnostic (matches any rule that
+ * grants the verb+resource regardless of group).
+ */
+export function canDo(
+  rules: PolicyRule[],
+  verb: string,
+  resource: string,
+  apiGroup?: string,
+): boolean {
+  for (const rule of rules) {
+    const verbMatch =
+      rule.verbs.includes("*") || rule.verbs.includes(verb);
+    const resourceMatch =
+      rule.resources.includes("*") || rule.resources.includes(resource);
+    const groupMatch =
+      apiGroup === undefined ||
+      rule.apiGroups.includes("*") ||
+      rule.apiGroups.includes(apiGroup);
+
+    if (verbMatch && resourceMatch && groupMatch) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export type UsePermissionsResult =
+  | { ready: false; isAdmin: false; can: () => false }
+  | {
+      ready: true;
+      incomplete: boolean;
+      isAdmin: boolean;
+      /** Check whether the current user may perform `verb` on `resource`. */
+      can: (verb: string, resource: string, apiGroup?: string) => boolean;
+    };
+
+/**
+ * Fetches and exposes the current user's RBAC permissions for `namespace`.
+ */
+export function usePermissions(namespace: string): UsePermissionsResult {
+  const { data } = useQuery(permissionQueries.rules(namespace));
+  const { data: user } = useQuery(authQueries.me());
+  // isAdmin is determined by the BFF 
+  const isAdmin = user?.isAdmin ?? false;
+
+  if (!data) {
+    return { ready: false, isAdmin: false, can: () => false };
+  }
+
+  return {
+    ready: true,
+    isAdmin,
+    incomplete: data.incomplete,
+    can: (verb, resource, apiGroup) =>
+      canDo(data.rules, verb, resource, apiGroup),
+  };
+}
+
+/**
+ * Checks permissions from an already-fetched PermissionsResponse.
+ * Used in TanStack Router `beforeLoad` where we have the raw data.
+ */
+export function permissionsFromResponse(
+  data: PermissionsResponse,
+): (verb: string, resource: string, apiGroup?: string) => boolean {
+  return (verb, resource, apiGroup) =>
+    canDo(data.rules, verb, resource, apiGroup);
+}

--- a/web/src/routeTree.tsx
+++ b/web/src/routeTree.tsx
@@ -2,6 +2,7 @@ import {
   createRootRouteWithContext,
   createRoute,
   Outlet,
+  redirect,
 } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
 import { Layout } from "@/components/layout";
@@ -10,10 +11,18 @@ import { TargetsPage } from "@/pages/targets";
 import { ReleasesPage } from "@/pages/releases";
 import { ComponentsPage } from "@/pages/components";
 import { ProfilesPage } from "@/pages/profiles";
+import { permissionQueries } from "@/api/queries";
+import { permissionsFromResponse } from "@/hooks/usePermissions";
 
 interface RouterContext {
   queryClient: QueryClient;
 }
+
+// All guarded routes operate on this namespace.
+// When a namespace selector is added this should come from router context.
+const DEFAULT_NAMESPACE = "default";
+
+const SOLAR_GROUP = "solar.opendefense.cloud";
 
 const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: () => (
@@ -32,24 +41,60 @@ const dashboardRoute = createRoute({
 const targetsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/targets",
+  beforeLoad: async ({ context }) => {
+    const data = await context.queryClient.ensureQueryData(
+      permissionQueries.rules(DEFAULT_NAMESPACE),
+    );
+    const can = permissionsFromResponse(data);
+    if (!can("list", "targets", SOLAR_GROUP)) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: TargetsPage,
 });
 
 const releasesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/releases",
+  beforeLoad: async ({ context }) => {
+    const data = await context.queryClient.ensureQueryData(
+      permissionQueries.rules(DEFAULT_NAMESPACE),
+    );
+    const can = permissionsFromResponse(data);
+    if (!can("list", "releases", SOLAR_GROUP)) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: ReleasesPage,
 });
 
 const componentsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/components",
+  beforeLoad: async ({ context }) => {
+    const data = await context.queryClient.ensureQueryData(
+      permissionQueries.rules(DEFAULT_NAMESPACE),
+    );
+    const can = permissionsFromResponse(data);
+    if (!can("list", "components", SOLAR_GROUP)) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: ComponentsPage,
 });
 
 const profilesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/profiles",
+  beforeLoad: async ({ context }) => {
+    const data = await context.queryClient.ensureQueryData(
+      permissionQueries.rules(DEFAULT_NAMESPACE),
+    );
+    const can = permissionsFromResponse(data);
+    if (!can("list", "profiles", SOLAR_GROUP)) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: ProfilesPage,
 });
 


### PR DESCRIPTION
… helm-template and ui-e2e test

## What
Implements user impersonation ("Preview as") in the solar-ui BFF and frontend.
Closes #432 

## Why
Platform admins need to preview the UI as other users to validate that RBAC restrictions are working correctly, without logging out and back in as a different user.

## Testing
- Manual: logged in as admin@solar.local against `make ui-dev` cluster, verified /api/auth/impersonation-targets returns the configured personas, impersonation activates/clears correctly, permissions reflect the persona's RBAC, and isAdmin remains true on the real identity while impersonating
- Playwright e2e: new impersonation.spec.ts covering unauthenticated 401s, admin access, the activate → check permissions → clear lifecycle, and invalid input rejection. run via `make ui-test-e2e`

## Notes for reviewers
**How admin access works:**
The BFF uses its own service-account credentials to list ClusterRoleBindings labeled solar.opendefense.cloud/admin=true and checks the session's username/groups against subjects. This avoids issuing a SelfSubjectAccessReview as the logged-in user (which would fail in impersonate auth-mode) and is immune to active impersonation state.
**New RBAC resources (via Helm):**
- admin-clusterrolebinding.yaml: solar-ui:admin ClusterRole + CRB, populated from values.ui.admin.subjects with admin label used to distinguish admins in the BFF
- impersonation-clusterrolebinding.yaml: solar-ui:impersonate:$username ClusterRoles + CRBs, populated from values.ui.impersonation.targets with impersonatable label
- rbac.yaml: grants the BFF SA list on clusterroles and clusterrolebindings (needed for admin check and impersonatable discovery)

## Checklist
- [*] Tests added/updated
- [*] No breaking changes (or upgrade path documented above)
- [*] Readable commit history (squashed and cleaned up as desired)
- [*] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now impersonate other users to preview and test their experience
  * Admin role support integrated with Kubernetes RBAC
  * Routes and navigation now protected based on user permissions

* **Documentation**
  * Added UI access control configuration guide

* **Tests**
  * Added impersonation workflow tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->