### PR TITLE
chore: prevent cached results for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using
 	KUBECTL=$(KUBECTL) \
 	MAKE=$(MAKE) \
 	OCM=$(OCM) \
-	$(GO) test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	$(GO) test -count=1 -tags=e2e ./test/e2e/ -v -ginkgo.v
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) ## Generate ClusterRole and CustomResourceDefinition objects.


### PR DESCRIPTION
## What
Closes #457 

## Why
Go's test cache works by hashing the test binary plus any other state it can observe. For the e2e tests, the results depend on external world state that Go can't observe and so can't hash.             

## Testing
`make test-e2e`

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test configuration for consistent test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->