### PR TITLE
fix: update componentversion version in e2e test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -349,7 +349,7 @@ var _ = Describe("solar", Ordered, func() {
 				filepath.Join(dir, "test", "fixtures", "e2e", "release.yaml"),
 				fmt.Sprintf(`[
 					{"op": "replace", "path": "/metadata/name", "value": "cross-ns-cv-release"},
-					{"op": "replace", "path": "/spec/componentVersionRef/name", "value": "test-opendefense-cloud-ocm-demo-v26-4-1"},
+					{"op": "replace", "path": "/spec/componentVersionRef/name", "value": "test-opendefense-cloud-ocm-demo-v26-4-2"},
 					{"op": "replace", "path": "/spec/targetNamespace", "value": %q},
 					{"op": "add", "path": "/spec/componentVersionNamespace", "value": %q}
 				]`, deployns, catalogNs),


### PR DESCRIPTION
## What
Fixed failing e2e test for cross ns ComponentVersions after demo chart was updated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration reference for cross-namespace component testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->