### PR TITLE
feat: solar client options

### DIFF
--- a/cmd/solar-discovery/main.go
+++ b/cmd/solar-discovery/main.go
@@ -71,7 +71,7 @@ func runE(cmd *cobra.Command, _ []string) error {
 
 	errChan := make(chan discovery.ErrorEvent, 1)
 
-	p, err := pipeline.NewPipeline(namespace, registries, addr, errChan, log)
+	p, err := pipeline.NewPipeline(namespace, registries, addr, errChan, log, solarClient)
 	if err != nil {
 		return fmt.Errorf("failed to create discovery pipeline: %w", err)
 	}

--- a/pkg/discovery/pipeline/pipeline.go
+++ b/pkg/discovery/pipeline/pipeline.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	solarclient "go.opendefense.cloud/solar/client-go/clientset/versioned/typed/solar/v1alpha1"
 	"go.opendefense.cloud/solar/pkg/discovery"
@@ -32,16 +31,15 @@ type Pipeline struct {
 	log           logr.Logger
 }
 
+// Option overrides pipeline components after construction (e.g. WithFilterProcessor).
 type Option func(*Pipeline)
 
-func NewPipeline(namespace string, registries *discovery.RegistryProvider, webhookLstnAddr string, errChan chan<- discovery.ErrorEvent, log logr.Logger, opts ...Option) (*Pipeline, error) {
+func NewPipeline(namespace string, registries *discovery.RegistryProvider, webhookLstnAddr string, errChan chan<- discovery.ErrorEvent, log logr.Logger, solarClient solarclient.SolarV1alpha1Interface, opts ...Option) (*Pipeline, error) {
 
 	repoEvents := make(chan discovery.RepositoryEvent, 1000)
 	filterInput := make(chan discovery.ComponentVersionEvent, 1000)
 	handlerInput := make(chan discovery.ComponentVersionEvent, 1000)
 	writerInput := make(chan discovery.WriteAPIResourceEvent, 1000)
-
-	clientset := solarclient.NewForConfigOrDie(config.GetConfigOrDie())
 
 	var httpRouter *webhook.WebhookRouter
 
@@ -72,24 +70,20 @@ func NewPipeline(namespace string, registries *discovery.RegistryProvider, webho
 		webhookServer = webhook.NewWebhookServer(webhookLstnAddr, httpRouter, errChan, log)
 	}
 
-	qualifier := qualifier.NewQualifier(registries, namespace, repoEvents, filterInput, errChan, discovery.WithLogger[discovery.RepositoryEvent, discovery.ComponentVersionEvent](log))
-
-	filter := handler.NewFilter(clientset, namespace, filterInput, handlerInput, errChan, discovery.WithLogger[discovery.ComponentVersionEvent, discovery.ComponentVersionEvent](log))
-
-	handler := handler.NewHandler(registries, handlerInput, writerInput, errChan, discovery.WithLogger[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent](log), discovery.WithRateLimiter[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent](time.Second, 1))
-
-	writer := apiwriter.NewAPIWriter(clientset, namespace, registries, writerInput, errChan, discovery.WithLogger[discovery.WriteAPIResourceEvent, any](log))
-
 	p := &Pipeline{
 		regScanners:   regScanners,
 		webhookServer: webhookServer,
-		qualifier:     qualifier,
-		filter:        filter,
-		handler:       handler,
-		writer:        writer,
 		errChan:       errChan,
 		log:           log,
 	}
+
+	p.qualifier = qualifier.NewQualifier(registries, namespace, repoEvents, filterInput, errChan, discovery.WithLogger[discovery.RepositoryEvent, discovery.ComponentVersionEvent](log))
+
+	p.filter = handler.NewFilter(solarClient, namespace, filterInput, handlerInput, errChan, discovery.WithLogger[discovery.ComponentVersionEvent, discovery.ComponentVersionEvent](log))
+
+	p.handler = handler.NewHandler(registries, handlerInput, writerInput, errChan, discovery.WithLogger[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent](log), discovery.WithRateLimiter[discovery.ComponentVersionEvent, discovery.WriteAPIResourceEvent](time.Second, 1))
+
+	p.writer = apiwriter.NewAPIWriter(solarClient, namespace, registries, writerInput, errChan, discovery.WithLogger[discovery.WriteAPIResourceEvent, any](log))
 
 	for _, opt := range opts {
 		opt(p)
@@ -153,7 +147,9 @@ func (p *Pipeline) Stop(ctx context.Context) error {
 
 func WithScanner(s scanner.Scanner) Option {
 	return func(p *Pipeline) {
-		p.regScanners[0].Scanner = s
+		if len(p.regScanners) > 0 {
+			p.regScanners[0].Scanner = s
+		}
 	}
 }
 

--- a/pkg/discovery/pipeline/pipeline_test.go
+++ b/pkg/discovery/pipeline/pipeline_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Pipeline", Ordered, func() {
 
 			errChan := make(chan discovery.ErrorEvent, 1)
 
-			p, err := NewPipeline("default", regProv, "127.0.0.1:0", errChan, log,
+			p, err := NewPipeline("default", regProv, "127.0.0.1:0", errChan, log, nil,
 				WithScanner(scanner),
 				WithQualifierProcessor(qualifier),
 				WithFilterProcessor(filter),


### PR DESCRIPTION
## What

Supports #497, tests and runtime need different SolarClient initialization.

## Why
Tests were failing while migrating to GitHub CI Runners

## Testing
Local tests and E2E tests.

## Notes for reviewers
Find also [original discussion](https://github.com/opendefensecloud/solution-arsenal/pull/497#pullrequestreview-4242152117)

## Checklist
- [X] Tests added/updated
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pipeline initialization now accepts an external Solar client so discovery components are wired from a caller-provided client, improving startup clarity and configuration alignment.
* **Bug Fixes**
  * Prevents errors when no registry scanners are configured, improving stability during discovery startup.
* **Tests**
  * Updated pipeline tests to accommodate the new initialization approach (including nil/fake clients).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/solution-arsenal/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->