### PR TITLE
docs: add manifests for RBAC model

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -19,6 +19,8 @@ nav:
   - developer-guide/rendering-pipeline.md
   - developer-guide/dev-cluster-with-kind.md
   - developer-guide/working-with-docs.md
+  - developer-guide/user-stories.md
+  - developer-guide/roles.md
   - Discovery:
     - developer-guide/discovery_pipeline.md
   - Controllers:

--- a/docs/developer-guide/manifests/app-catalog-maintainer.yaml
+++ b/docs/developer-guide/manifests/app-catalog-maintainer.yaml
@@ -1,0 +1,55 @@
+# CRUD permissions for Components, ComponentVersions, and ReferenceGrants
+# in the App Catalog Maintainer's own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:app-catalog-maintainer
+rules:
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - components
+  - componentversions
+  - referencegrants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Bind the ClusterRole to the App Catalog Maintainer's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:app-catalog-maintainer
+  namespace: app-catalog-maintainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:app-catalog-maintainer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: app-catalog-maintainer
+---
+# Allow Releases in the K8s Cluster Provider and K8s Cluster User namespaces to
+# reference ComponentVersions in the App Catalog Maintainer's namespace.
+apiVersion: solar.opendefense.cloud/v1alpha1
+kind: ReferenceGrant
+metadata:
+  name: allow-release-cv-access
+  namespace: app-catalog-maintainer
+spec:
+  from:
+  - group: solar.opendefense.cloud
+    kind: Release
+    namespace: k8s-cluster-provider
+  - group: solar.opendefense.cloud
+    kind: Release
+    namespace: k8s-cluster-user
+  to:
+  - group: solar.opendefense.cloud
+    kind: ComponentVersion

--- a/docs/developer-guide/manifests/k8s-cluster-provider.yaml
+++ b/docs/developer-guide/manifests/k8s-cluster-provider.yaml
@@ -1,0 +1,122 @@
+# CRUD permissions for all K8s Cluster Provider resources in their own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:k8s-cluster-provider
+rules:
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - components
+  - componentversions
+  - profiles
+  - registries
+  - registrybindings
+  - releasebindings
+  - releases
+  - referencegrants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Bind the ClusterRole to the K8s Cluster Provider's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:k8s-cluster-provider
+  namespace: k8s-cluster-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:k8s-cluster-provider
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-cluster-provider
+---
+# Read access to Components and ComponentVersions in App Catalog Maintainer namespaces.
+# Also used by the K8s Cluster User role (see k8s-cluster-user.yaml).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:acm-reader
+rules:
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - components
+  - componentversions
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Bind the read access to the App Catalog Maintainer's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:k8s-cluster-provider-acm-reader
+  namespace: app-catalog-maintainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:acm-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-cluster-provider
+---
+# CRUD access to Targets in K8s Cluster User namespaces.
+# The K8s Cluster Provider manages the Target lifecycle on behalf of cluster users.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:k8s-cluster-provider-target-manager
+rules:
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - targets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Bind the Target management access to the K8s Cluster User's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:k8s-cluster-provider-target-manager
+  namespace: k8s-cluster-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:k8s-cluster-provider-target-manager
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-cluster-provider
+---
+# Allow Targets in the K8s Cluster User namespace to reference Registries in this namespace.
+apiVersion: solar.opendefense.cloud/v1alpha1
+kind: ReferenceGrant
+metadata:
+  name: allow-target-registry-access
+  namespace: k8s-cluster-provider
+spec:
+  from:
+  - group: solar.opendefense.cloud
+    kind: Target
+    namespace: k8s-cluster-user
+  to:
+  - group: solar.opendefense.cloud
+    kind: Registry

--- a/docs/developer-guide/manifests/k8s-cluster-user.yaml
+++ b/docs/developer-guide/manifests/k8s-cluster-user.yaml
@@ -1,0 +1,89 @@
+# CRUD permissions for all K8s Cluster User resources in their own namespace.
+# Targets are read/update only — the K8s Cluster Provider manages their lifecycle.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: solar:k8s-cluster-user
+rules:
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - components
+  - componentversions
+  - profiles
+  - registries
+  - registrybindings
+  - releasebindings
+  - releases
+  - referencegrants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - targets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Bind the ClusterRole to the K8s Cluster User's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:k8s-cluster-user
+  namespace: k8s-cluster-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:k8s-cluster-user
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-cluster-user
+---
+# Read access to Components and ComponentVersions in App Catalog Maintainer namespaces.
+# Requires ClusterRole solar:acm-reader defined in k8s-cluster-provider.yaml.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: solar:k8s-cluster-user-acm-reader
+  namespace: app-catalog-maintainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: solar:acm-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: k8s-cluster-user
+---
+# Allow ReleaseBindings, RegistryBindings, and Profiles in the K8s Cluster Provider
+# namespace to reference Targets in this namespace.
+apiVersion: solar.opendefense.cloud/v1alpha1
+kind: ReferenceGrant
+metadata:
+  name: allow-provider-target-access
+  namespace: k8s-cluster-user
+spec:
+  from:
+  - group: solar.opendefense.cloud
+    kind: ReleaseBinding
+    namespace: k8s-cluster-provider
+  - group: solar.opendefense.cloud
+    kind: RegistryBinding
+    namespace: k8s-cluster-provider
+  - group: solar.opendefense.cloud
+    kind: Profile
+    namespace: k8s-cluster-provider
+  to:
+  - group: solar.opendefense.cloud
+    kind: Target

--- a/docs/developer-guide/roles.md
+++ b/docs/developer-guide/roles.md
@@ -54,3 +54,25 @@ The roles serve as a blueprint for the intended usage scenario of Solar. These d
 The diagram shows an example of Solar resources and its dependencies. It doesn't cover all variations.
 
 ![Solar Resources and Roles](./img/solar-roles-and-resources.svg)
+
+## Manifests
+
+Below are the ClusterRole, RoleBinding, and ReferenceGrant manifests that establish the permissions and cross-namespace requirements previously described. Note: `k8s-cluster-provider.yaml` needs to be applied before `k8s-cluster-user.yaml`.
+
+### App Catalog Maintainer
+
+```yaml
+--8<-- "docs/developer-guide/manifests/app-catalog-maintainer.yaml"
+```
+
+### K8s Cluster Provider
+
+```yaml
+--8<-- "docs/developer-guide/manifests/k8s-cluster-provider.yaml"
+```
+
+### K8s Cluster User
+
+```yaml
+--8<-- "docs/developer-guide/manifests/k8s-cluster-user.yaml"
+```


### PR DESCRIPTION
## What
Closes #415 

## Why
The manifests serve as a blueprint for the reference RBAC model we've defined.

## Testing
```
kubectl apply -f app-catalog-maintainer.yaml
kubectl apply -f k8s-cluster-provider.yaml
kubectl apply -f k8s-cluster-user.yaml
```

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Developer Guide with new pages documenting user stories and role-based access control.
  * Added Kubernetes manifest examples showing configurations for App Catalog Maintainer, K8s Cluster Provider, and K8s Cluster User roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->