### PR TITLE
fix: update go-overlay to support Go 1.26.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777353526,
-        "narHash": "sha256-lTHdOhBdeI7q6xJZY+K3KNwOfOzqu3wNiRth9vfSnbc=",
+        "lastModified": 1778186286,
+        "narHash": "sha256-Eq5rjmA9KSCXu4Vhnvcjv2+sfWRO80eDHRmMbGkHO1Y=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "39e0a2df70d1a7c6c79ffe96a4b40bee771d95f9",
+        "rev": "d7a51ed805e2d74022056654abda81c91a93719c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
Update `go-overlay` flake input to include Go 1.26.3

## Why
Renovate bumped the Go version to 1.26.3 in `go.mod` and `flake.nix`, but the pinned `go-overlay` revision only included Go up to 1.24.3, breaking the Nix dev shell for everyone (`error: attribute '"1.26.3"' missing`).

## Testing
Verified with `nix build .#devShells.x86_64-linux.default --dry-run` — resolves `go-1.26.3` correctly.

## Notes for reviewers
`flake.lock` only: `go-overlay` bumped from `39e0a2d` (2026-04-28) to `d7a51ed` (2026-05-07).

## Checklist
- [x] ~~Tests added/updated~~ N/A
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

