### PR TITLE
fix: remove stale rbac declaration for old events API

### DIFF
--- a/charts/solar/files/role.yaml
+++ b/charts/solar/files/role.yaml
@@ -17,14 +17,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
   - batch
   resources:
   - jobs
@@ -36,6 +28,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - solar.opendefense.cloud
   resources:

--- a/pkg/controller/profile_controller.go
+++ b/pkg/controller/profile_controller.go
@@ -114,7 +114,6 @@ type ProfileReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releasebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=referencegrants,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile evaluates the Profile's TargetSelector and ensures matching ReleaseBindings exist.

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -42,7 +42,6 @@ type ReleaseReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=referencegrants,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile validates the Release by resolving its ComponentVersion reference.

--- a/pkg/controller/rendertask_controller.go
+++ b/pkg/controller/rendertask_controller.go
@@ -59,7 +59,6 @@ type RenderTaskReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=rendertasks/finalizers,verbs=update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile moves the current state of the cluster closer to the desired state

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -73,7 +73,6 @@ type TargetReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=referencegrants,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=rendertasks,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile collects ReleaseBindings, resolves the render registry, creates per-release


### PR DESCRIPTION
## What
Remove stale rbac declarations. They got stale after we've migrated to the new events API.

## Why
See similar change for ARC: https://github.com/opendefensecloud/artifact-conduit/pull/358

## Testing
n/a

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes event permissions configuration across system components. Migrated event management permissions from the core API group to the dedicated events.k8s.io API group in role definitions and multiple controllers to maintain compatibility with Kubernetes standards. This improves system reliability and aligns infrastructure with current best practices for event handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opendefensecloud/solution-arsenal/pull/523)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->