### PR TITLE
chore: inherit renovate config from shared renovate config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,74 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "postUpdateOptions": ["gomodTidy"],
-  "packageRules": [
-    {
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchDatasources": ["docker", "golang-version"],
-      "matchPackageNames": ["go", "golang"],
-      "groupName": "golang version sync",
-      "groupSlug": "go-version"
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/)flake\\.nix$/"],
-      "matchStrings": [
-        "goVersion\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
-      ],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "Makefile"
-      ],
-      "matchStrings": [
-        "ENVTEST_K8S_VERSION \\?= (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "kubernetes/kubernetes",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "^v(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "Makefile"
-      ],
-      "matchStrings": [
-        "DEV_KIT_VERSION := (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "opendefensecloud/dev-kit",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "tools.lock"
-      ],
-      "matchStrings": [
-        "(?<depName>[^\\s]+) (?<packageName>[^@]+)@(?<currentValue>v?[^\\s]+)"
-      ],
-      "versioningTemplate": "semver",
-      "datasourceTemplate": "go"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/(^|/).github/workflows/[^/]+\\.ya?ml$/"],
-      "matchStrings": [
-        "runs-on:\\s*(?<depName>\\w+)-(?<currentValue>[\\d.]+)"
-      ],
-      "datasourceTemplate": "github-runners",
-      "versioningTemplate": "docker"
-    }
+  "extends": [
+    "github>opendefensecloud/renovate-config",
+    "github>opendefensecloud/renovate-config:go",
+    "github>opendefensecloud/renovate-config:k8s"
   ]
 }


### PR DESCRIPTION
## What
Relates to https://github.com/opendefensecloud/odd-internal/issues/32.

## Why
We created a new repo renovate-config with shared Renovate configurations: https://github.com/opendefensecloud/renovate-config/pull/2.

Instead of duplicating the renovate configs in our repos, we start creating shared Renovate configs in there and only keep repo-specific Renovate configs. For solution-arsenal, there is no repo-specific Renovate config.

## Testing
After this PR has been merged, I gonna check Renovate's "Dependency Dashboard" ticket for detected dependencies.

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
