### PR TITLE
fix(controller): silently dropped cross-namespace releases in bootstrap chart

### DIFF
--- a/docs/developer-guide/adrs/004-Unique-Release-Name.md
+++ b/docs/developer-guide/adrs/004-Unique-Release-Name.md
@@ -53,6 +53,7 @@ flowchart LR
     - If priorities are equal, the conflict is broken deterministically by the namespace-qualified ReleaseBinding name in ascending alphabetical order.
 - Releases can define `AntiAffinity` rules (label selectors). If another Release already accepted for a Target matches the selector — or vice versa — the lower-priority Release is excluded.
 - The resolver runs in the Target controller after all ReleaseBindings are collected and before any RenderTask is created.
+- The `uniqueName` doubles as the identity of a release within a Target's bootstrap chart: it is the map key under which the release is registered in the bootstrap input (and thus the suffix of the generated FluxCD resource names). The Kubernetes Release object name is **not** suitable here because it is not unique across namespaces — with cross-namespace ReleaseBindings, two namespaces can each define a `my-release`, and keying on the object name would let one silently overwrite the other in the bootstrap. Keying on `uniqueName` is safe because the resolver guarantees it is unique among accepted releases.
 
 ## Solution
 

--- a/docs/developer-guide/rendering-pipeline.md
+++ b/docs/developer-guide/rendering-pipeline.md
@@ -73,6 +73,8 @@ The bootstrap chart template iterates over all releases and creates, for each on
 
 These are the **inner HelmReleases** — they are managed by the **outer HelmRelease** (the bootstrap itself).
 
+Each release is keyed in the bootstrap input by its **`uniqueName`** — the same deduplication key the release resolver uses (`Release.Spec.UniqueName`, or the parent Component name when unset; see [ADR 004](./adrs/004-Unique-Release-Name.md)). This is deliberate: the Kubernetes release object name is **not** unique across namespaces, so two same-named releases bound from different namespaces (possible with cross-namespace ReleaseBindings) would otherwise collide and silently overwrite each other in the bootstrap map. Because the resolver guarantees `uniqueName` is unique among accepted releases, keying on it keeps every release distinct.
+
 ### Bootstrap Versioning
 
 The bootstrap chart version is `v0.0.<bootstrapVersion>`, where `bootstrapVersion` is a counter stored in `target.status.bootstrapVersion`. It is incremented each time the set of bound releases changes (e.g. a Profile creates a new ReleaseBinding). This ensures a new chart version is pushed to the registry whenever the bootstrap content changes.
@@ -102,7 +104,7 @@ Outer HelmRelease (solar-bootstrap)
 
 ### Name Truncation
 
-Inner HelmRelease names are constructed as `<bootstrap-release-name>-<release-key>`. Since Kubernetes object names are limited to 253 characters (and Helm release names to 53), names exceeding 53 characters are truncated and suffixed with a short SHA-256 hash to preserve uniqueness.
+Inner HelmRelease names are constructed as `<bootstrap-release-name>-<release-key>`, where `<release-key>` is the release's `uniqueName` (the bootstrap map key described in Stage 2). Since Kubernetes object names are limited to 253 characters (and Helm release names to 53), names exceeding 53 characters are truncated and suffixed with a short SHA-256 hash to preserve uniqueness.
 
 ## Data Flow: From ReleaseBinding to Deployment
 

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -77,6 +77,17 @@ func mapRenderTaskToOwner(kind string) handler.MapFunc {
 	}
 }
 
+// effectiveUniqueName returns the deduplication key for a release: Spec.UniqueName
+// when set, otherwise the parent Component name from the referenced ComponentVersion.
+// This mirrors the logic in the Release controller that writes Status.EffectiveUniqueName.
+func effectiveUniqueName(rel *solarv1alpha1.Release, cv *solarv1alpha1.ComponentVersion) string {
+	if rel.Spec.UniqueName != "" {
+		return rel.Spec.UniqueName
+	}
+
+	return cv.Spec.ComponentRef.Name
+}
+
 // releaseRenderTaskName returns a deterministic name for a per-release RenderTask
 // scoped to a specific target. Each target creates its own release RenderTasks;
 // the renderer job handles deduplication by skipping rendering if the chart

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -122,10 +122,7 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// ComponentVersion found — set resolved condition and effective unique name.
-	effectiveUniqueName := res.Spec.UniqueName
-	if effectiveUniqueName == "" {
-		effectiveUniqueName = cv.Spec.ComponentRef.Name
-	}
+	uname := effectiveUniqueName(res, cv)
 
 	condChanged := apimeta.SetStatusCondition(&res.Status.Conditions, metav1.Condition{
 		Type:               ConditionTypeComponentVersionResolved,
@@ -134,9 +131,9 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Reason:             "Resolved",
 		Message:            "ComponentVersion resolved: " + cv.Name,
 	})
-	nameChanged := res.Status.EffectiveUniqueName != effectiveUniqueName
+	nameChanged := res.Status.EffectiveUniqueName != uname
 	if condChanged || nameChanged {
-		res.Status.EffectiveUniqueName = effectiveUniqueName
+		res.Status.EffectiveUniqueName = uname
 		if err := r.Status().Update(ctx, res); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to update status")
 		}

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -48,6 +48,11 @@ type releaseInfo struct {
 	// deterministic tiebreaker when two releases share the same priority.
 	bindingKey string
 	name       string
+	// uniqueName is the deduplication key computed by resolveReleaseConflicts:
+	// Spec.UniqueName when set, otherwise the parent Component name from the CV.
+	// It is guaranteed unique across all surviving releases and used as the
+	// bootstrap map key to avoid collisions between same-named cross-namespace releases.
+	uniqueName string
 	release    *solarv1alpha1.Release
 	cv         *solarv1alpha1.ComponentVersion
 	rtName     string
@@ -589,13 +594,10 @@ func resolveReleaseConflicts(releases []releaseInfo) ([]releaseInfo, []string) {
 	// When UniqueName is empty, fall back to the parent Component name from the CV.
 	namedGroups := map[string][]releaseInfo{}
 
-	for _, ri := range releases {
-		uniqueName := ri.release.Spec.UniqueName
-		if uniqueName == "" {
-			uniqueName = ri.cv.Spec.ComponentRef.Name
-		}
-
-		namedGroups[uniqueName] = append(namedGroups[uniqueName], ri)
+	for i, ri := range releases {
+		uname := effectiveUniqueName(ri.release, ri.cv)
+		releases[i].uniqueName = uname
+		namedGroups[uname] = append(namedGroups[uname], releases[i])
 	}
 
 	var accepted []releaseInfo
@@ -800,6 +802,10 @@ func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, r
 	resolvedReleases := map[string]solarv1alpha1.ResolvedResourceAccess{}
 
 	for _, ri := range releases {
+		if ri.uniqueName == "" {
+			return solarv1alpha1.BootstrapInput{}, fmt.Errorf("release %q has empty uniqueName; resolveReleaseConflicts must run before buildBootstrapInput", ri.name)
+		}
+
 		ref, err := ociname.ParseReference(ri.chartURL)
 		if err != nil {
 			return solarv1alpha1.BootstrapInput{}, fmt.Errorf("failed to parse chartURL %s: %w", ri.chartURL, err)
@@ -810,7 +816,7 @@ func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, r
 			return solarv1alpha1.BootstrapInput{}, err
 		}
 
-		resolvedReleases[ri.name] = solarv1alpha1.ResolvedResourceAccess{
+		resolvedReleases[ri.uniqueName] = solarv1alpha1.ResolvedResourceAccess{
 			Repository:     strings.TrimPrefix(repo, "oci://"),
 			Tag:            ref.Identifier(),
 			PullSecretName: renderRegistryPullSecret,

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -1488,3 +1488,64 @@ var _ = Describe("resolveReleaseConflicts", func() {
 		})
 	})
 })
+
+var _ = Describe("buildBootstrapInput", func() {
+	target := &solarv1alpha1.Target{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "some-ns"},
+	}
+
+	makeRelease := func(uniqueName string) *solarv1alpha1.Release {
+		return &solarv1alpha1.Release{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-release"},
+			Spec:       solarv1alpha1.ReleaseSpec{UniqueName: uniqueName},
+		}
+	}
+
+	makeCVFor := func(componentName string) *solarv1alpha1.ComponentVersion {
+		return &solarv1alpha1.ComponentVersion{
+			Spec: solarv1alpha1.ComponentVersionSpec{
+				ComponentRef: corev1.LocalObjectReference{Name: componentName},
+			},
+		}
+	}
+
+	It("returns an error when uniqueName is empty (resolveReleaseConflicts was not called)", func() {
+		releases := []releaseInfo{{name: "my-release", chartURL: "registry.example.com/ns/my-release:v1.0.0"}}
+		_, err := buildBootstrapInput(target, releases, "")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty uniqueName"))
+	})
+
+	It("both same-named cross-namespace releases appear after resolveReleaseConflicts populates uniqueName", func() {
+		// Two releases with the same K8s object name from different namespaces.
+		// No UniqueName set — the resolver must derive it from the CV component name.
+		releases := []releaseInfo{
+			{
+				name:       "my-release",
+				bindingKey: "ns-a/binding-a",
+				release:    makeRelease(""),
+				cv:         makeCVFor("component-a"),
+				chartURL:   "registry.example.com/ns-a/my-release:v1.0.0",
+			},
+			{
+				name:       "my-release",
+				bindingKey: "ns-b/binding-b",
+				release:    makeRelease(""),
+				cv:         makeCVFor("component-b"),
+				chartURL:   "registry.example.com/ns-b/my-release:v1.0.0",
+			},
+		}
+
+		resolved, skipped := resolveReleaseConflicts(releases)
+		Expect(skipped).To(BeEmpty())
+		// Confirm the resolver derived uniqueName from the CV component name.
+		resolvedUniqueNames := []string{resolved[0].uniqueName, resolved[1].uniqueName}
+		Expect(resolvedUniqueNames).To(ConsistOf("component-a", "component-b"))
+
+		input, err := buildBootstrapInput(target, resolved, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(input.Releases).To(HaveLen(2), "both releases must appear; same ri.name must not cause a collision")
+		Expect(input.Releases).To(HaveKey("component-a"))
+		Expect(input.Releases).To(HaveKey("component-b"))
+	})
+})


### PR DESCRIPTION
## What
Fix a bug where two same-named Releases from different namespaces silently overwrite each other in the bootstrap chart.

## Why
`buildBootstrapInput` keyed the bootstrap `Releases` map on `ri.name` — the bare Kubernetes Release object name. With cross-namespace ReleaseBindings (#541) two Releases named `my-release` from different namespaces can both survive conflict resolution and target the same Target, colliding on the map key and dropping one deployment silently.

Fix: key on `uniqueName` instead — already guaranteed unique among accepted releases by the resolver. Also extract the derivation rule into a shared `effectiveUniqueName()` helper (was duplicated in both controllers), and add a guard that returns an explicit error if `uniqueName` is empty.

## Testing
- New `buildBootstrapInput` tests: cross-namespace collision (via full `resolveReleaseConflicts` path) and explicit error on empty `uniqueName`.
- `make test` / `make lint` — clean.

## Notes for reviewers
- **Upgrade path:** bootstrap map keys change from the Release object name to `uniqueName`. Existing Targets where the two differ will have inner FluxCD HelmReleases recreated on next bootstrap render.
- `effectiveUniqueName(rel, cv)` lives in `helpers.go`; both controllers use it.
- Docs updated: `rendering-pipeline.md` and ADR-004 now document why `uniqueName` is the bootstrap identity and why the object name is unsuitable.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented release overwrites when releases share the same Kubernetes object name across namespaces by keying bootstrap inputs by a stable per-release unique name.
* **Documentation**
  * Clarified how release unique names are determined and how bootstrap/Helm release names are derived to avoid collisions.
* **Tests**
  * Added tests confirming unique-name enforcement and collision-free bootstrap input generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->