### PR TITLE
fix: gracefully handle non-ocm repositories

### DIFF
--- a/pkg/discovery/helpers.go
+++ b/pkg/discovery/helpers.go
@@ -5,6 +5,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -17,6 +18,7 @@ import (
 )
 
 var (
+	ErrNotComponentDescriptor  = errors.New("repository is not a component descriptor")
 	regexNonAlphaNumericString = regexp.MustCompile("[^a-z0-9]+")
 )
 
@@ -28,8 +30,8 @@ func SplitRepository(repo string) (string, string, error) {
 
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf(
-			"repository is not a component descriptor: splitting '%s' at '%s'"+
-				"returns %d parts, expected exactly 2", repo, separator, len(parts),
+			"%w: splitting '%s' at '%s'"+
+				" returns %d parts, expected exactly 2", ErrNotComponentDescriptor, repo, separator, len(parts),
 		)
 	}
 

--- a/pkg/discovery/helpers_test.go
+++ b/pkg/discovery/helpers_test.go
@@ -4,11 +4,35 @@
 package discovery
 
 import (
+	"errors"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("SplitRepository", func() {
+	It("should parse a valid OCM repository", func() {
+		base, comp, err := SplitRepository("myregistry/component-descriptors/example.com/mycomp")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(base).To(Equal("myregistry"))
+		Expect(comp).To(Equal("example.com/mycomp"))
+	})
+
+	It("should return ErrNotComponentDescriptor for a non-OCM repository", func() {
+		_, _, err := SplitRepository("nginx")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrNotComponentDescriptor)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("returns 1 parts, expected exactly 2"))
+	})
+
+	It("should return ErrNotComponentDescriptor for a repo with multiple component-descriptors segments", func() {
+		_, _, err := SplitRepository("a/component-descriptors/b/component-descriptors/c")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrNotComponentDescriptor)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("returns 3 parts, expected exactly 2"))
+	})
+})
 
 var _ = Describe("SanitizeDigestLabel", func() {
 	It("should strip the algorithm prefix", func() {

--- a/pkg/discovery/scanner/registry_scanner.go
+++ b/pkg/discovery/scanner/registry_scanner.go
@@ -164,7 +164,7 @@ func (rs *RegistryScanner) Scan(ctx context.Context, eventsChan chan<- discovery
 	err = client.Repositories(ctx, "", func(repos []string) error {
 		for _, repo := range repos {
 			if err := rs.processRepository(ctx, eventsChan, repo); err != nil {
-				rs.logger.Error(err, "processRepository returned error", "repo", repo)
+				rs.handleRepoError(repo, err)
 			}
 		}
 
@@ -197,6 +197,14 @@ func (rs *RegistryScanner) processRepository(_ context.Context, eventsChan chan<
 	discovery.Publish(&rs.logger, eventsChan, event)
 
 	return nil
+}
+
+func (rs *RegistryScanner) handleRepoError(repo string, err error) {
+	if errors.Is(err, discovery.ErrNotComponentDescriptor) {
+		rs.logger.V(1).Info("skipping non-OCM repository", "repo", repo)
+	} else {
+		rs.logger.Error(err, "processRepository returned error", "repo", repo)
+	}
 }
 
 // createRegistryClient creates a registry client authenticated with the configured credentials.

--- a/pkg/discovery/scanner/registry_scanner_test.go
+++ b/pkg/discovery/scanner/registry_scanner_test.go
@@ -4,7 +4,9 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -157,5 +159,64 @@ var _ = Describe("RegistryScanner", Ordered, func() {
 			Eventually(eventsChan).Should(Receive(expected))
 			Consistently(errChan).ShouldNot(Receive())
 		})
+	})
+})
+
+var _ = Describe("handleRepoError", func() {
+	var (
+		eventsChan chan discovery.RepositoryEvent
+		errChan    chan discovery.ErrorEvent
+	)
+
+	BeforeEach(func() {
+		eventsChan = make(chan discovery.RepositoryEvent, 100)
+		errChan = make(chan discovery.ErrorEvent, 100)
+	})
+
+	AfterEach(func() {
+		close(eventsChan)
+		close(errChan)
+	})
+
+	It("should demote ErrNotComponentDescriptor to V(1).Info", func() {
+		var logBuf bytes.Buffer
+		logger := zap.New(zap.WriteTo(&logBuf), zap.UseDevMode(true))
+
+		scanner := NewRegistryScanner(
+			&solarv1alpha1.Registry{
+				Spec: solarv1alpha1.RegistrySpec{
+					Hostname:  "registry.example.com",
+					PlainHTTP: true,
+				},
+			},
+			nil, eventsChan, errChan,
+			WithLogger(logger),
+		)
+
+		scanner.handleRepoError("nginx", discovery.ErrNotComponentDescriptor)
+		Expect(logBuf.String()).To(ContainSubstring("skipping non-OCM repository"))
+		Expect(logBuf.String()).NotTo(ContainSubstring("ERROR"))
+	})
+
+	It("should log real processing errors at Error level", func() {
+		var logBuf bytes.Buffer
+		logger := zap.New(zap.WriteTo(&logBuf), zap.UseDevMode(true))
+
+		scanner := NewRegistryScanner(
+			&solarv1alpha1.Registry{
+				Spec: solarv1alpha1.RegistrySpec{
+					Hostname:  "registry.example.com",
+					PlainHTTP: true,
+				},
+			},
+			nil, eventsChan, errChan,
+			WithLogger(logger),
+		)
+
+		realErr := errors.New("network timeout")
+		scanner.handleRepoError("test/component-descriptors/valid/comp", realErr)
+		Expect(logBuf.String()).To(ContainSubstring("ERROR"))
+		Expect(logBuf.String()).To(ContainSubstring("processRepository returned error"))
+		Expect(logBuf.String()).To(ContainSubstring("network timeout"))
 	})
 })


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #535

## Testing

reproduced error as described via:

```bash
make dev-cluster
kubectl port-forward -n zot svc/zot-discovery 5000:443 &
kubectl apply -n solar-system -f test/fixtures/e2e/zot-discovery-registry-scan.yaml
docker pull nginx:latest
docker tag docker.io/library/nginx:latest localhost:5000/nginx:latest
docker push localhost:5000/nginx:latest
kubectl rollout restart deployment -n solar-system solar-discovery
kubectl logs -n solar-system deployments/solar-discovery
# verbose errors

git checkout fix/535-non-ocm-discovery-errors
make dev-cluster-rebuild
kubectl rollout restart deployment -n solar-system solar-discovery
kubectl logs -n solar-system deployments/solar-discovery
# 1 debug line per skipped ocm repo
```

Unit tests were added as well.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging during repository scanning to reduce noise; repositories that don't match the expected format now log at verbose level instead of error level, making scan logs clearer.

* **Tests**
  * Added comprehensive test coverage for repository parsing and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->