### PR TITLE
test: fix coverage filter and cover api/solar REST boilerplate + render funcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test: $(SETUP_ENVTEST) $(GINKGO) ocm-transfer-demo ## Run all tests
 	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile --keep-separate-coverprofiles $(testargs)
 	@echo 'mode: count' > $(BUILD_PATH)/solar.full.coverprofile && \
 	 cat $(BUILD_PATH)/*_solar.full.coverprofile 2>/dev/null | grep -v '^mode:' >> $(BUILD_PATH)/solar.full.coverprofile || true
-	@grep -v /solar/api $(BUILD_PATH)/solar.full.coverprofile > solar.coverprofile || true
+	@grep -v 'zz_generated' $(BUILD_PATH)/solar.full.coverprofile > solar.coverprofile || true
 
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/api/solar/rest_test.go
+++ b/api/solar/rest_test.go
@@ -18,22 +18,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// testResourceObject exercises the REST storage boilerplate that every
-// resource.Object implementation provides: metadata access, scoping,
-// factory methods, group/resource identity, naming, and the
+// resourceObjectCase describes the REST storage boilerplate to exercise for
+// a single resource.Object implementation: metadata access, scoping, factory
+// methods, group/resource identity, naming, and the
 // PrepareForCreate/PrepareForUpdate generation bookkeeping.
-func testResourceObject[T resource.Object](
-	name string,
-	newObj func() T,
-	resourceName string,
-	newListType runtime.Object,
-	singularName string,
-	shortNames []string,
-	mutateSpec func(old T),
-) {
-	Describe(name, func() {
+type resourceObjectCase[T resource.Object] struct {
+	// name is the Describe label for this resource type, e.g. "Component".
+	name string
+	// newObj returns a fresh zero-value instance of the resource type.
+	newObj func() T
+	// resourceName is the plural REST resource name, e.g. "components".
+	resourceName string
+	// newListType is a zero-value instance of the resource's list type.
+	newListType runtime.Object
+	// singularName is the expected GetSingularName() value, e.g. "component".
+	singularName string
+	// shortNames is the expected ShortNames() value, e.g. []string{"comp"}.
+	shortNames []string
+	// mutateSpec mutates old's spec so it differs from a fresh newObj(),
+	// used to verify generation bumping on update.
+	mutateSpec func(old T)
+}
+
+func testResourceObject[T resource.Object](c resourceObjectCase[T]) {
+	Describe(c.name, func() {
 		It("exposes its ObjectMeta, scope, factories, and group resource", func() {
-			obj := newObj()
+			obj := c.newObj()
 
 			om := obj.GetObjectMeta()
 			om.Name = "test-name"
@@ -41,36 +51,36 @@ func testResourceObject[T resource.Object](
 
 			Expect(obj.NamespaceScoped()).To(BeTrue())
 			Expect(obj.New()).To(BeAssignableToTypeOf(obj))
-			Expect(obj.NewList()).To(BeAssignableToTypeOf(newListType))
-			Expect(obj.GetGroupResource()).To(Equal(solar.SchemeGroupVersion.WithResource(resourceName).GroupResource()))
+			Expect(obj.NewList()).To(BeAssignableToTypeOf(c.newListType))
+			Expect(obj.GetGroupResource()).To(Equal(solar.SchemeGroupVersion.WithResource(c.resourceName).GroupResource()))
 		})
 
 		It("returns its singular name and short names", func() {
-			provider := any(newObj()).(interface {
+			provider := any(c.newObj()).(interface {
 				GetSingularName() string
 				ShortNames() []string
 			})
-			Expect(provider.GetSingularName()).To(Equal(singularName))
-			Expect(provider.ShortNames()).To(Equal(shortNames))
+			Expect(provider.GetSingularName()).To(Equal(c.singularName))
+			Expect(provider.ShortNames()).To(Equal(c.shortNames))
 		})
 
 		It("sets the generation to 1 on PrepareForCreate", func() {
-			obj := newObj()
+			obj := c.newObj()
 			any(obj).(rest.PrepareForCreater).PrepareForCreate(context.Background())
 			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(1)))
 		})
 
 		It("leaves the generation unchanged when the spec is unchanged", func() {
-			obj := newObj()
-			old := newObj()
+			obj := c.newObj()
+			old := c.newObj()
 			any(obj).(rest.PrepareForUpdater).PrepareForUpdate(context.Background(), old)
 			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(0)))
 		})
 
 		It("increments the generation when the spec changes", func() {
-			obj := newObj()
-			old := newObj()
-			mutateSpec(old)
+			obj := c.newObj()
+			old := c.newObj()
+			c.mutateSpec(old)
 			any(obj).(rest.PrepareForUpdater).PrepareForUpdate(context.Background(), old)
 			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(1)))
 		})
@@ -78,79 +88,127 @@ func testResourceObject[T resource.Object](
 }
 
 var _ = Describe("REST storage boilerplate", func() {
-	testResourceObject("Component",
-		func() *solar.Component { return &solar.Component{} },
-		"components", &solar.ComponentList{}, "component", []string{"comp"},
-		func(o *solar.Component) { o.Spec.Registry = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.Component]{
+		name:         "Component",
+		newObj:       func() *solar.Component { return &solar.Component{} },
+		resourceName: "components",
+		newListType:  &solar.ComponentList{},
+		singularName: "component",
+		shortNames:   []string{"comp"},
+		mutateSpec:   func(o *solar.Component) { o.Spec.Registry = "changed" },
+	})
 
-	testResourceObject("ComponentVersion",
-		func() *solar.ComponentVersion { return &solar.ComponentVersion{} },
-		"componentversions", &solar.ComponentVersionList{}, "componentversion", []string{"cv"},
-		func(o *solar.ComponentVersion) { o.Spec.Tag = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.ComponentVersion]{
+		name:         "ComponentVersion",
+		newObj:       func() *solar.ComponentVersion { return &solar.ComponentVersion{} },
+		resourceName: "componentversions",
+		newListType:  &solar.ComponentVersionList{},
+		singularName: "componentversion",
+		shortNames:   []string{"cv"},
+		mutateSpec:   func(o *solar.ComponentVersion) { o.Spec.Tag = "changed" },
+	})
 
-	testResourceObject("Profile",
-		func() *solar.Profile { return &solar.Profile{} },
-		"profiles", &solar.ProfileList{}, "profile", []string{"prf"},
-		func(o *solar.Profile) { o.Spec.ReleaseRef.Name = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.Profile]{
+		name:         "Profile",
+		newObj:       func() *solar.Profile { return &solar.Profile{} },
+		resourceName: "profiles",
+		newListType:  &solar.ProfileList{},
+		singularName: "profile",
+		shortNames:   []string{"prf"},
+		mutateSpec:   func(o *solar.Profile) { o.Spec.ReleaseRef.Name = "changed" },
+	})
 
-	testResourceObject("ReferenceGrant",
-		func() *solar.ReferenceGrant { return &solar.ReferenceGrant{} },
-		"referencegrants", &solar.ReferenceGrantList{}, "referencegrant", []string{"rg"},
-		func(o *solar.ReferenceGrant) {
+	testResourceObject(resourceObjectCase[*solar.ReferenceGrant]{
+		name:         "ReferenceGrant",
+		newObj:       func() *solar.ReferenceGrant { return &solar.ReferenceGrant{} },
+		resourceName: "referencegrants",
+		newListType:  &solar.ReferenceGrantList{},
+		singularName: "referencegrant",
+		shortNames:   []string{"rg"},
+		mutateSpec: func(o *solar.ReferenceGrant) {
 			o.Spec.From = []solar.ReferenceGrantFromSubject{{Group: "g", Kind: "k", Namespace: "ns"}}
 		},
-	)
+	})
 
-	testResourceObject("RegistryBinding",
-		func() *solar.RegistryBinding { return &solar.RegistryBinding{} },
-		"registrybindings", &solar.RegistryBindingList{}, "registrybinding", []string{"rb"},
-		func(o *solar.RegistryBinding) { o.Spec.TargetRef.Name = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.RegistryBinding]{
+		name:         "RegistryBinding",
+		newObj:       func() *solar.RegistryBinding { return &solar.RegistryBinding{} },
+		resourceName: "registrybindings",
+		newListType:  &solar.RegistryBindingList{},
+		singularName: "registrybinding",
+		shortNames:   []string{"rb"},
+		mutateSpec:   func(o *solar.RegistryBinding) { o.Spec.TargetRef.Name = "changed" },
+	})
 
-	testResourceObject("Registry",
-		func() *solar.Registry { return &solar.Registry{} },
-		"registries", &solar.RegistryList{}, "registry", []string{"reg"},
-		func(o *solar.Registry) { o.Spec.Hostname = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.Registry]{
+		name:         "Registry",
+		newObj:       func() *solar.Registry { return &solar.Registry{} },
+		resourceName: "registries",
+		newListType:  &solar.RegistryList{},
+		singularName: "registry",
+		shortNames:   []string{"reg"},
+		mutateSpec:   func(o *solar.Registry) { o.Spec.Hostname = "changed" },
+	})
 
-	testResourceObject("ReleaseBinding",
-		func() *solar.ReleaseBinding { return &solar.ReleaseBinding{} },
-		"releasebindings", &solar.ReleaseBindingList{}, "releasebinding", []string{"rlb"},
-		func(o *solar.ReleaseBinding) { o.Spec.TargetRef.Name = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.ReleaseBinding]{
+		name:         "ReleaseBinding",
+		newObj:       func() *solar.ReleaseBinding { return &solar.ReleaseBinding{} },
+		resourceName: "releasebindings",
+		newListType:  &solar.ReleaseBindingList{},
+		singularName: "releasebinding",
+		shortNames:   []string{"rlb"},
+		mutateSpec:   func(o *solar.ReleaseBinding) { o.Spec.TargetRef.Name = "changed" },
+	})
 
-	testResourceObject("Release",
-		func() *solar.Release { return &solar.Release{} },
-		"releases", &solar.ReleaseList{}, "release", []string{"rel"},
-		func(o *solar.Release) { o.Spec.UniqueName = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.Release]{
+		name:         "Release",
+		newObj:       func() *solar.Release { return &solar.Release{} },
+		resourceName: "releases",
+		newListType:  &solar.ReleaseList{},
+		singularName: "release",
+		shortNames:   []string{"rel"},
+		mutateSpec:   func(o *solar.Release) { o.Spec.UniqueName = "changed" },
+	})
 
-	testResourceObject("RenderArtifact",
-		func() *solar.RenderArtifact { return &solar.RenderArtifact{} },
-		"renderartifacts", &solar.RenderArtifactList{}, "renderartifact", []string{"ra"},
-		func(o *solar.RenderArtifact) { o.Spec.Tag = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.RenderArtifact]{
+		name:         "RenderArtifact",
+		newObj:       func() *solar.RenderArtifact { return &solar.RenderArtifact{} },
+		resourceName: "renderartifacts",
+		newListType:  &solar.RenderArtifactList{},
+		singularName: "renderartifact",
+		shortNames:   []string{"ra"},
+		mutateSpec:   func(o *solar.RenderArtifact) { o.Spec.Tag = "changed" },
+	})
 
-	testResourceObject("RenderBinding",
-		func() *solar.RenderBinding { return &solar.RenderBinding{} },
-		"renderbindings", &solar.RenderBindingList{}, "renderbinding", []string{"rbin"},
-		func(o *solar.RenderBinding) { o.Spec.OwnerKind = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.RenderBinding]{
+		name:         "RenderBinding",
+		newObj:       func() *solar.RenderBinding { return &solar.RenderBinding{} },
+		resourceName: "renderbindings",
+		newListType:  &solar.RenderBindingList{},
+		singularName: "renderbinding",
+		shortNames:   []string{"rbin"},
+		mutateSpec:   func(o *solar.RenderBinding) { o.Spec.OwnerKind = "changed" },
+	})
 
-	testResourceObject("RenderTask",
-		func() *solar.RenderTask { return &solar.RenderTask{} },
-		"rendertasks", &solar.RenderTaskList{}, "rendertask", []string{"rt"},
-		func(o *solar.RenderTask) { o.Spec.Tag = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.RenderTask]{
+		name:         "RenderTask",
+		newObj:       func() *solar.RenderTask { return &solar.RenderTask{} },
+		resourceName: "rendertasks",
+		newListType:  &solar.RenderTaskList{},
+		singularName: "rendertask",
+		shortNames:   []string{"rt"},
+		mutateSpec:   func(o *solar.RenderTask) { o.Spec.Tag = "changed" },
+	})
 
-	testResourceObject("Target",
-		func() *solar.Target { return &solar.Target{} },
-		"targets", &solar.TargetList{}, "target", []string{"tgt"},
-		func(o *solar.Target) { o.Spec.RenderRegistryNamespace = "changed" },
-	)
+	testResourceObject(resourceObjectCase[*solar.Target]{
+		name:         "Target",
+		newObj:       func() *solar.Target { return &solar.Target{} },
+		resourceName: "targets",
+		newListType:  &solar.TargetList{},
+		singularName: "target",
+		shortNames:   []string{"tgt"},
+		mutateSpec:   func(o *solar.Target) { o.Spec.RenderRegistryNamespace = "changed" },
+	})
 })
 
 var _ = Describe("CopyStatusTo", func() {

--- a/api/solar/rest_test.go
+++ b/api/solar/rest_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package solar_test
+
+import (
+	"context"
+	"os"
+
+	"go.opendefense.cloud/kit/apiserver/resource"
+	"go.opendefense.cloud/kit/apiserver/rest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"go.opendefense.cloud/solar/api/solar"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// testResourceObject exercises the REST storage boilerplate that every
+// resource.Object implementation provides: metadata access, scoping,
+// factory methods, group/resource identity, naming, and the
+// PrepareForCreate/PrepareForUpdate generation bookkeeping.
+func testResourceObject[T resource.Object](
+	name string,
+	newObj func() T,
+	resourceName string,
+	newListType runtime.Object,
+	singularName string,
+	shortNames []string,
+	mutateSpec func(old T),
+) {
+	Describe(name, func() {
+		It("exposes its ObjectMeta, scope, factories, and group resource", func() {
+			obj := newObj()
+
+			om := obj.GetObjectMeta()
+			om.Name = "test-name"
+			Expect(obj.GetObjectMeta().Name).To(Equal("test-name"))
+
+			Expect(obj.NamespaceScoped()).To(BeTrue())
+			Expect(obj.New()).To(BeAssignableToTypeOf(obj))
+			Expect(obj.NewList()).To(BeAssignableToTypeOf(newListType))
+			Expect(obj.GetGroupResource()).To(Equal(solar.SchemeGroupVersion.WithResource(resourceName).GroupResource()))
+		})
+
+		It("returns its singular name and short names", func() {
+			provider := any(newObj()).(interface {
+				GetSingularName() string
+				ShortNames() []string
+			})
+			Expect(provider.GetSingularName()).To(Equal(singularName))
+			Expect(provider.ShortNames()).To(Equal(shortNames))
+		})
+
+		It("sets the generation to 1 on PrepareForCreate", func() {
+			obj := newObj()
+			any(obj).(rest.PrepareForCreater).PrepareForCreate(context.Background())
+			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(1)))
+		})
+
+		It("leaves the generation unchanged when the spec is unchanged", func() {
+			obj := newObj()
+			old := newObj()
+			any(obj).(rest.PrepareForUpdater).PrepareForUpdate(context.Background(), old)
+			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(0)))
+		})
+
+		It("increments the generation when the spec changes", func() {
+			obj := newObj()
+			old := newObj()
+			mutateSpec(old)
+			any(obj).(rest.PrepareForUpdater).PrepareForUpdate(context.Background(), old)
+			Expect(obj.GetObjectMeta().Generation).To(Equal(int64(1)))
+		})
+	})
+}
+
+var _ = Describe("REST storage boilerplate", func() {
+	testResourceObject("Component",
+		func() *solar.Component { return &solar.Component{} },
+		"components", &solar.ComponentList{}, "component", []string{"comp"},
+		func(o *solar.Component) { o.Spec.Registry = "changed" },
+	)
+
+	testResourceObject("ComponentVersion",
+		func() *solar.ComponentVersion { return &solar.ComponentVersion{} },
+		"componentversions", &solar.ComponentVersionList{}, "componentversion", []string{"cv"},
+		func(o *solar.ComponentVersion) { o.Spec.Tag = "changed" },
+	)
+
+	testResourceObject("Profile",
+		func() *solar.Profile { return &solar.Profile{} },
+		"profiles", &solar.ProfileList{}, "profile", []string{"prf"},
+		func(o *solar.Profile) { o.Spec.ReleaseRef.Name = "changed" },
+	)
+
+	testResourceObject("ReferenceGrant",
+		func() *solar.ReferenceGrant { return &solar.ReferenceGrant{} },
+		"referencegrants", &solar.ReferenceGrantList{}, "referencegrant", []string{"rg"},
+		func(o *solar.ReferenceGrant) {
+			o.Spec.From = []solar.ReferenceGrantFromSubject{{Group: "g", Kind: "k", Namespace: "ns"}}
+		},
+	)
+
+	testResourceObject("RegistryBinding",
+		func() *solar.RegistryBinding { return &solar.RegistryBinding{} },
+		"registrybindings", &solar.RegistryBindingList{}, "registrybinding", []string{"rb"},
+		func(o *solar.RegistryBinding) { o.Spec.TargetRef.Name = "changed" },
+	)
+
+	testResourceObject("Registry",
+		func() *solar.Registry { return &solar.Registry{} },
+		"registries", &solar.RegistryList{}, "registry", []string{"reg"},
+		func(o *solar.Registry) { o.Spec.Hostname = "changed" },
+	)
+
+	testResourceObject("ReleaseBinding",
+		func() *solar.ReleaseBinding { return &solar.ReleaseBinding{} },
+		"releasebindings", &solar.ReleaseBindingList{}, "releasebinding", []string{"rlb"},
+		func(o *solar.ReleaseBinding) { o.Spec.TargetRef.Name = "changed" },
+	)
+
+	testResourceObject("Release",
+		func() *solar.Release { return &solar.Release{} },
+		"releases", &solar.ReleaseList{}, "release", []string{"rel"},
+		func(o *solar.Release) { o.Spec.UniqueName = "changed" },
+	)
+
+	testResourceObject("RenderArtifact",
+		func() *solar.RenderArtifact { return &solar.RenderArtifact{} },
+		"renderartifacts", &solar.RenderArtifactList{}, "renderartifact", []string{"ra"},
+		func(o *solar.RenderArtifact) { o.Spec.Tag = "changed" },
+	)
+
+	testResourceObject("RenderBinding",
+		func() *solar.RenderBinding { return &solar.RenderBinding{} },
+		"renderbindings", &solar.RenderBindingList{}, "renderbinding", []string{"rbin"},
+		func(o *solar.RenderBinding) { o.Spec.OwnerKind = "changed" },
+	)
+
+	testResourceObject("RenderTask",
+		func() *solar.RenderTask { return &solar.RenderTask{} },
+		"rendertasks", &solar.RenderTaskList{}, "rendertask", []string{"rt"},
+		func(o *solar.RenderTask) { o.Spec.Tag = "changed" },
+	)
+
+	testResourceObject("Target",
+		func() *solar.Target { return &solar.Target{} },
+		"targets", &solar.TargetList{}, "target", []string{"tgt"},
+		func(o *solar.Target) { o.Spec.RenderRegistryNamespace = "changed" },
+	)
+})
+
+var _ = Describe("CopyStatusTo", func() {
+	condition := metav1.Condition{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Done"}
+
+	It("copies Status from a Release", func() {
+		src := &solar.Release{Status: solar.ReleaseStatus{Conditions: []metav1.Condition{condition}}}
+		dst := &solar.Release{}
+		src.CopyStatusTo(dst)
+		Expect(dst.Status).To(Equal(src.Status))
+	})
+
+	It("copies Status from a Profile", func() {
+		src := &solar.Profile{Status: solar.ProfileStatus{MatchedTargets: 3}}
+		dst := &solar.Profile{}
+		src.CopyStatusTo(dst)
+		Expect(dst.Status).To(Equal(src.Status))
+	})
+
+	It("copies Status from a RenderArtifact", func() {
+		src := &solar.RenderArtifact{Status: solar.RenderArtifactStatus{ChartURL: "oci://example.com/chart:v1"}}
+		dst := &solar.RenderArtifact{}
+		src.CopyStatusTo(dst)
+		Expect(dst.Status).To(Equal(src.Status))
+	})
+
+	It("copies Status from a RenderTask", func() {
+		src := &solar.RenderTask{Status: solar.RenderTaskStatus{Conditions: []metav1.Condition{condition}}}
+		dst := &solar.RenderTask{}
+		src.CopyStatusTo(dst)
+		Expect(dst.Status).To(Equal(src.Status))
+	})
+
+	It("copies Status from a Target", func() {
+		src := &solar.Target{Status: solar.TargetStatus{BootstrapVersion: 7}}
+		dst := &solar.Target{}
+		src.CopyStatusTo(dst)
+		Expect(dst.Status).To(Equal(src.Status))
+	})
+})
+
+var _ = Describe("Registry GetURL", func() {
+	It("returns an https URL by default", func() {
+		r := &solar.Registry{Spec: solar.RegistrySpec{Hostname: "registry.example.com:5000"}}
+		Expect(r.GetURL()).To(Equal("https://registry.example.com:5000"))
+	})
+
+	It("returns an http URL when PlainHTTP is set", func() {
+		r := &solar.Registry{Spec: solar.RegistrySpec{Hostname: "registry.example.com:5000", PlainHTTP: true}}
+		Expect(r.GetURL()).To(Equal("http://registry.example.com:5000"))
+	})
+})
+
+var _ = Describe("RenderResult", func() {
+	It("removes its directory on Close", func() {
+		dir, err := os.MkdirTemp("", "render-result-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		result := &solar.RenderResult{Dir: dir}
+		Expect(result.Close()).To(Succeed())
+
+		_, err = os.Stat(dir)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+	})
+})
+
+var _ = Describe("register.go", func() {
+	It("Kind returns a group-qualified GroupKind", func() {
+		Expect(solar.Kind("Component")).To(Equal(solar.SchemeGroupVersion.WithKind("Component").GroupKind()))
+	})
+
+	It("Resource returns a group-qualified GroupResource", func() {
+		Expect(solar.Resource("components")).To(Equal(solar.SchemeGroupVersion.WithResource("components").GroupResource()))
+	})
+
+	It("AddToScheme registers all known types", func() {
+		scheme := runtime.NewScheme()
+		Expect(solar.AddToScheme(scheme)).To(Succeed())
+		Expect(scheme.Recognizes(solar.SchemeGroupVersion.WithKind("Component"))).To(BeTrue())
+		Expect(scheme.Recognizes(solar.SchemeGroupVersion.WithKind("Target"))).To(BeTrue())
+		Expect(scheme.Recognizes(solar.SchemeGroupVersion.WithKind("RenderArtifact"))).To(BeTrue())
+	})
+})

--- a/pkg/renderer/funcs_test.go
+++ b/pkg/renderer/funcs_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package renderer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("template helper functions", func() {
+	Describe("toYAML", func() {
+		It("marshals a value to YAML without a trailing newline", func() {
+			Expect(toYAML(map[string]string{"foo": "bar"})).To(Equal("foo: bar"))
+		})
+
+		It("returns an empty string for values that cannot be marshaled", func() {
+			Expect(toYAML(make(chan int))).To(Equal(""))
+		})
+	})
+
+	Describe("mustToYAML", func() {
+		It("marshals a value to YAML without a trailing newline", func() {
+			Expect(mustToYAML(map[string]string{"foo": "bar"})).To(Equal("foo: bar"))
+		})
+
+		It("panics for values that cannot be marshaled", func() {
+			Expect(func() { mustToYAML(make(chan int)) }).To(Panic())
+		})
+	})
+
+	Describe("fromYAML", func() {
+		It("unmarshals valid YAML into a map", func() {
+			Expect(fromYAML("foo: bar")).To(Equal(map[string]any{"foo": "bar"}))
+		})
+
+		It("returns the error under the Error key for invalid YAML", func() {
+			result := fromYAML("foo: [bar")
+			Expect(result).To(HaveKey("Error"))
+		})
+	})
+
+	Describe("fromYAMLArray", func() {
+		It("unmarshals a valid YAML array", func() {
+			Expect(fromYAMLArray("- foo\n- bar")).To(Equal([]any{"foo", "bar"}))
+		})
+
+		It("returns the error as a single-element slice for invalid YAML", func() {
+			result := fromYAMLArray("- [bar")
+			Expect(result).To(HaveLen(1))
+		})
+	})
+
+	Describe("toJSON", func() {
+		It("marshals a value to JSON", func() {
+			Expect(toJSON(map[string]string{"foo": "bar"})).To(Equal(`{"foo":"bar"}`))
+		})
+
+		It("returns an empty string for values that cannot be marshaled", func() {
+			Expect(toJSON(make(chan int))).To(Equal(""))
+		})
+	})
+
+	Describe("mustToJSON", func() {
+		It("marshals a value to JSON", func() {
+			Expect(mustToJSON(map[string]string{"foo": "bar"})).To(Equal(`{"foo":"bar"}`))
+		})
+
+		It("panics for values that cannot be marshaled", func() {
+			Expect(func() { mustToJSON(make(chan int)) }).To(Panic())
+		})
+	})
+
+	Describe("fromJSON", func() {
+		It("unmarshals valid JSON into a map", func() {
+			Expect(fromJSON(`{"foo":"bar"}`)).To(Equal(map[string]any{"foo": "bar"}))
+		})
+
+		It("returns the error under the Error key for invalid JSON", func() {
+			result := fromJSON("{not valid json")
+			Expect(result).To(HaveKey("Error"))
+		})
+	})
+
+	Describe("fromJSONArray", func() {
+		It("unmarshals a valid JSON array", func() {
+			Expect(fromJSONArray(`["foo","bar"]`)).To(Equal([]any{"foo", "bar"}))
+		})
+
+		It("returns the error as a single-element slice for invalid JSON", func() {
+			result := fromJSONArray("[not valid")
+			Expect(result).To(HaveLen(1))
+		})
+	})
+
+	Describe("funcMap", func() {
+		It("registers the template helper functions and removes env/expandenv", func() {
+			fm := funcMap()
+
+			for _, name := range []string{
+				"toYaml", "mustToYaml", "fromYaml", "fromYamlArray",
+				"toJson", "mustToJson", "fromJson", "fromJsonArray",
+			} {
+				Expect(fm).To(HaveKey(name))
+			}
+
+			Expect(fm).NotTo(HaveKey("env"))
+			Expect(fm).NotTo(HaveKey("expandenv"))
+		})
+	})
+})


### PR DESCRIPTION
## What
Fix the `make test` coverage-exclusion filter so it only excludes generated code, and add the tests that this exposes were missing in `api/solar` and `pkg/renderer`.

## Why
The coverage filter in the Makefile used `grep -v /solar/api`, which matches the entire `api/solar` import path (it contains the literal substring `/solar/api`) and therefore excluded ~900 statements of hand-written, already-tested REST code from the reported coverage - not just the generated `zz_generated*.go` files it was meant to exclude. Narrowing the filter to `zz_generated` correctly excludes only generated code, but this also dropped the headline coverage number because `api/solar`'s REST boilerplate (`NamespaceScoped`/`New`/`NewList`/`GetGroupResource`/`PrepareForCreate`/`PrepareForUpdate`/etc.) and `pkg/renderer/funcs.go`'s template helpers had no tests at all. This PR adds both.

## Testing
- `make test` - all 17 Ginkgo suites pass.
- `api/solar` (excluding generated code) goes from 16.7% to 81.4% coverage via the new table-driven `api/solar/rest_test.go`, covering all 12 resource types' REST storage boilerplate, `CopyStatusTo`, `Registry.GetURL`, `RenderResult.Close`, and `register.go`.
- `pkg/renderer/funcs.go` goes from 0% to 100% coverage via the new `pkg/renderer/funcs_test.go`, covering the YAML/JSON template helper functions.
- Overall reported coverage moves from ~69% (after the filter fix alone) to 75.6%.

## Notes for reviewers
The remaining 0%-covered items in `api/solar` (`Validate`/`ValidateUpdate`/`ConvertToTable` for `Registry`, `RenderArtifact`, `RenderBinding`, and `RenderTask`) and the cross-namespace `Registry`/`ReferenceGrant` paths in `pkg/controller/target_controller.go` are intentionally left for a follow-up issue.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded REST storage testing across multiple Solar resource types, covering metadata exposure, namespace scoping, factory methods, identity fields, generation handling, and status-copy behavior.
  * Added template helper tests validating YAML/JSON serialization and deserialization behavior, including expected newline handling, error outputs, and panic cases for “must” variants.
* **Chores**
  * Improved test coverage profile filtering for more accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->