### PR TITLE
fix: discover components at the root level of a registry

### DIFF
--- a/pkg/discovery/helpers.go
+++ b/pkg/discovery/helpers.go
@@ -22,17 +22,32 @@ var (
 	regexNonAlphaNumericString = regexp.MustCompile("[^a-z0-9]+")
 )
 
-// SplitRepository splits the repository into its base and component descriptor part.
+// SplitRepository splits the repository into its (optional) base and component descriptor part.
 func SplitRepository(repo string) (string, string, error) {
+	const prefix = "component-descriptors/"
 	const separator = "/component-descriptors/"
 
-	parts := strings.Split(repo, separator)
+	// exit early if it's obviosly no ocm repo
+	if !strings.Contains(repo, prefix) {
+		return "", "", fmt.Errorf("%w: repo '%s' is not an ocm repository", ErrNotComponentDescriptor, repo)
+	}
 
+	trimmed := strings.TrimPrefix(repo, prefix)
+	if trimmed != repo && len(trimmed) > 0 {
+		if strings.Contains(trimmed, separator) {
+			return "", "", fmt.Errorf(
+				"%w: repo '%s' has multiple 'component-descriptors' separators",
+				ErrNotComponentDescriptor, repo)
+		}
+
+		return "", trimmed, nil
+	}
+
+	parts := strings.Split(repo, separator)
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf(
-			"%w: splitting '%s' at '%s'"+
-				" returns %d parts, expected exactly 2", ErrNotComponentDescriptor, repo, separator, len(parts),
-		)
+			"%w: repo '%s' has multiple 'component-descriptors' separators",
+			ErrNotComponentDescriptor, repo)
 	}
 
 	return parts[0], parts[1], nil

--- a/pkg/discovery/helpers_test.go
+++ b/pkg/discovery/helpers_test.go
@@ -19,18 +19,32 @@ var _ = Describe("SplitRepository", func() {
 		Expect(comp).To(Equal("example.com/mycomp"))
 	})
 
+	It("should parse a valid OCM repository at the root level", func() {
+		base, comp, err := SplitRepository("component-descriptors/example.com/mycomp")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(base).To(Equal(""))
+		Expect(comp).To(Equal("example.com/mycomp"))
+	})
+
 	It("should return ErrNotComponentDescriptor for a non-OCM repository", func() {
 		_, _, err := SplitRepository("nginx")
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, ErrNotComponentDescriptor)).To(BeTrue())
-		Expect(err.Error()).To(ContainSubstring("returns 1 parts, expected exactly 2"))
+		Expect(err.Error()).To(ContainSubstring("is not an ocm repository"))
 	})
 
 	It("should return ErrNotComponentDescriptor for a repo with multiple component-descriptors segments", func() {
 		_, _, err := SplitRepository("a/component-descriptors/b/component-descriptors/c")
 		Expect(err).To(HaveOccurred())
 		Expect(errors.Is(err, ErrNotComponentDescriptor)).To(BeTrue())
-		Expect(err.Error()).To(ContainSubstring("returns 3 parts, expected exactly 2"))
+		Expect(err.Error()).To(ContainSubstring("has multiple 'component-descriptors' separators"))
+	})
+
+	It("should return ErrNotComponentDescriptor for a repo at the root level with multiple component-descriptors segments", func() {
+		_, _, err := SplitRepository("component-descriptors/b/component-descriptors/c")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrNotComponentDescriptor)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("has multiple 'component-descriptors' separators"))
 	})
 })
 

--- a/pkg/discovery/qualifier/qualifier_test.go
+++ b/pkg/discovery/qualifier/qualifier_test.go
@@ -182,5 +182,45 @@ var _ = Describe("Qualifier", Ordered, func() {
 			Eventually(outputEventsChan).Should(Receive(expected))
 			Consistently(errChan).ShouldNot(Receive())
 		})
+
+		It("should process events for root-level component descriptors", func() {
+			rootReg := registry.New()
+			rootServer := httptest.NewServer(rootReg.HandleFunc())
+			defer rootServer.Close()
+
+			rootServerURL, err := url.Parse(rootServer.URL)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootRegistry := &solarv1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{Name: "root-test-registry"},
+				Spec: solarv1alpha1.RegistrySpec{
+					Hostname:  rootServerURL.Host,
+					PlainHTTP: true,
+				},
+			}
+			Expect(registryProvider.Register(rootRegistry, nil)).To(Succeed())
+
+			_, err = test.Run(exec.Command(
+				test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf",
+				rootRegistry.GetURL(),
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			inputEventsChan <- discovery.RepositoryEvent{
+				Registry:   rootRegistry.Name,
+				Repository: "component-descriptors/opendefense.cloud/ocm-demo",
+			}
+
+			expected := SatisfyAll(
+				HaveField("Component", "opendefense.cloud/ocm-demo"),
+				HaveField("Namespace", ""),
+				HaveField("Source",
+					HaveField("Version", "v26.4.2"),
+				),
+			)
+
+			Eventually(outputEventsChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
+		})
 	})
 })

--- a/pkg/discovery/scanner/registry_scanner_test.go
+++ b/pkg/discovery/scanner/registry_scanner_test.go
@@ -159,6 +159,42 @@ var _ = Describe("RegistryScanner", Ordered, func() {
 			Eventually(eventsChan).Should(Receive(expected))
 			Consistently(errChan).ShouldNot(Receive())
 		})
+
+		It("should discover root-level component-descriptor repositories", func() {
+			rootReg := registry.New()
+			rootServer := httptest.NewServer(rootReg.HandleFunc())
+			defer rootServer.Close()
+
+			rootServerURL, err := url.Parse(rootServer.URL)
+			Expect(err).NotTo(HaveOccurred())
+			rootRegistryHost := rootServerURL.Host
+
+			_, err = test.Run(exec.Command(
+				test.EnvName("ocm"), "transfer", "ctf", "./test/fixtures/ocm-demo-ctf",
+				fmt.Sprintf("http://%s", rootRegistryHost),
+			))
+			Expect(err).NotTo(HaveOccurred())
+
+			rootTestReg := &solarv1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{Name: "root-test-registry"},
+				Spec: solarv1alpha1.RegistrySpec{
+					Hostname:  rootRegistryHost,
+					PlainHTTP: true,
+				},
+			}
+			scanner := NewRegistryScanner(rootTestReg, nil, eventsChan, errChan, scannerOptions...)
+
+			err = scanner.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer scanner.Stop()
+
+			expected := &discovery.RepositoryEvent{
+				Registry:   rootTestReg.Name,
+				Repository: "component-descriptors/opendefense.cloud/ocm-demo",
+			}
+			Eventually(eventsChan).Should(Receive(expected))
+			Consistently(errChan).ShouldNot(Receive())
+		})
 	})
 })
 


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #536 

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OCM repository path validation to provide clearer error messages for invalid formats and detect multiple separators more explicitly.
  * Added support for root-level component descriptor repositories.

* **Tests**
  * Expanded test coverage for component descriptor repository parsing, qualification, and discovery at root level with various error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->