### PR TITLE
fix: define CA certificate for ocm transfer in ocm config

### DIFF
--- a/docs/walk-through/01-discovery.md
+++ b/docs/walk-through/01-discovery.md
@@ -87,6 +87,9 @@ kubectl get secrets -n cert-manager selfsigned-ca-secret -oyaml \
 # ocmconfig
 type: generic.config.ocm.software/v1
 configurations:
+  - type: rootcerts.config.ocm.software
+    rootCertificates:
+      - path: ./test/fixtures/ca.crt
   - type: credentials.config.ocm.software
     consumers:
       - identity:
@@ -104,7 +107,7 @@ configurations:
 ```
 
 ```bash
-SSL_CERT_FILE=./ca.crt ./bin/go/ocm --config ./ocmconfig transfer ctf ./test/fixtures/ocm-demo-ctf https://localhost:4443/test
+./bin/go/ocm --config ./ocmconfig transfer ctf ./test/fixtures/ocm-demo-ctf https://localhost:4443/test
 ```
 
 Take a look at the discovery registry: <https://localhost:4443/explore>. The

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -265,9 +265,7 @@ var _ = Describe("solar", Ordered, func() {
 
 			ocmconfig := filepath.Join(dir, "test", "fixtures", "e2e", "ocmconfig")
 			ocmDemoCtf := filepath.Join(dir, "test", "fixtures", "ocm-demo-ctf")
-			caCrt := filepath.Join(dir, "test", "fixtures", "ca.crt")
 			cmd := exec.Command(ocmBinary, "--config", ocmconfig, "transfer", "ctf", ocmDemoCtf, fmt.Sprintf("localhost:%d/test", localport))
-			cmd.Env = append(cmd.Env, "SSL_CERT_FILE="+caCrt)
 			_, err := run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -364,7 +362,6 @@ var _ = Describe("solar", Ordered, func() {
 
 			By("re-pushing the OCM package for scan discovery")
 			cmd = exec.Command(ocmBinary, "--config", ocmconfig, "transfer", "ctf", ocmDemoCtf, fmt.Sprintf("localhost:%d/test", localport))
-			cmd.Env = append(cmd.Env, "SSL_CERT_FILE="+caCrt)
 			_, err = run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/fixtures/e2e/ocmconfig
+++ b/test/fixtures/e2e/ocmconfig
@@ -1,5 +1,8 @@
 type: generic.config.ocm.software/v1
 configurations:
+  - type: rootcerts.config.ocm.software
+    rootCertificates:
+      - path: ./test/fixtures/ca.crt
   - type: credentials.config.ocm.software
     consumers:
       - identity:

--- a/test/fixtures/setup-discovery.sh
+++ b/test/fixtures/setup-discovery.sh
@@ -16,8 +16,7 @@ $KUBECTL -n zot port-forward svc/zot-discovery 4443:443 &
 echo "Waiting for port-forward to establish..."
 sleep 2
 echo "Transferring ocm-demo component via OCM..."
-SSL_CERT_FILE=test/fixtures/ca.crt $OCM \
-    --config test/fixtures/ocmconfig \
+$OCM --config ./test/fixtures/ocmconfig \
     transfer ctf "$OCM_DEMO_DIR" https://localhost:4443/test
 echo "Cleaning up port-forward..."
 pkill -f "port-forward.*4443:443" || true


### PR DESCRIPTION
## What
Instead of passing the CA certificate of Zot that is needed for `ocm transfer` as an environment variable, it is defined in the already existing ocm config file.

## Why
x509.SystemCertPool() ignores SSL_CERT_FILE on macOS. The e2e tests failed on macOS for that reason.

## Testing
`make test-e2e` on macOS

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated walkthrough command examples to use revised configuration approach.

* **Tests**
  * Modified e2e test infrastructure to handle certificate configuration through fixture updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->