### PR TITLE
chore: sideload k8s releases for envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ OCM_DEMO_VERSION ?= v26.4.2
 
 ENVTEST_K8S_VERSION ?= 1.36.0
 
+# Kind node image for e2e — defaults to track ENVTEST_K8S_VERSION so envtest
+# (`make test`) and Kind-based e2e (`make test-e2e`) target the same K8s
+# release. Override KIND_NODE_IMAGE directly if you need to decouple them.
+# The patsubst tolerates both "1.36.0" and "v1.36.0" inputs.
+KIND_NODE_IMAGE ?= kindest/node:v$(patsubst v%,%,$(ENVTEST_K8S_VERSION))
+
 export CERTMANAGER_VERSION := v1.20.2
 export TRUSTMANAGER_VERSION := v0.23.0
 export ZOT_VERSION := 0.1.116
@@ -63,12 +69,17 @@ lint-no-golangci: $(ADDLICENSE) shellcheck  ## Run linters but not golangci-lint
 	git ls-files | grep '.*\.go$$' | xargs $(ADDLICENSE) -check -l apache -s=only -check
 	bash hack/check-crd-ref-docs-templates.sh
 
+.PHONY: envtest-binaries-sideload
+envtest-binaries-sideload: $(SETUP_ENVTEST)  ## Populate the envtest cache for ENVTEST_K8S_VERSION from upstream K8s/etcd releases when controller-tools hasn't packaged it. No-op if already cached. See hack/envtest-sideload.sh.
+	@SETUP_ENVTEST=$(SETUP_ENVTEST) BIN_DIR=$(LOCALBIN) YQ=$(YQ) \
+		bash hack/envtest-sideload.sh $(ENVTEST_K8S_VERSION)
+
 .PHONY: test
-test: $(SETUP_ENVTEST) $(GINKGO) ocm-transfer-demo ## Run all tests
+test: $(SETUP_ENVTEST) $(GINKGO) envtest-binaries-sideload ocm-transfer-demo ## Run all tests
 	mkdir -p $(BUILD_PATH)/coverdata
 	OCM=$(OCM) \
 	GOCOVERDIR=$(BUILD_PATH)/coverdata \
-	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -i -p path)" \
 	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile --keep-separate-coverprofiles $(testargs)
 	@echo 'mode: count' > $(BUILD_PATH)/solar.full.coverprofile && \
 	 cat $(BUILD_PATH)/*_solar.full.coverprofile 2>/dev/null | grep -v '^mode:' >> $(BUILD_PATH)/solar.full.coverprofile || true
@@ -101,7 +112,9 @@ kind-load-local-images:
 	$(KIND) load docker-image $(UI_IMG) --name $(KIND_CLUSTER)
 
 .PHONY: e2e-cluster
-e2e-cluster: ocm-transfer-demo ## Create a e2e test cluster (Contains everything as a dev-cluster except the solar-api itself)
+e2e-cluster: ocm-transfer-demo ## Create a e2e test cluster (Contains everything as a dev-cluster except the solar-api itself). Pin K8s via KIND_NODE_IMAGE (defaults from ENVTEST_K8S_VERSION). Pass KIND_RECREATE=1 to delete + recreate on image mismatch.
+	@KIND=$(KIND) DOCKER=$(DOCKER) KIND_RECREATE=$(KIND_RECREATE) \
+		bash hack/ensure-kind-cluster.sh $(KIND_CLUSTER_E2E) $(KIND_NODE_IMAGE)
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_E2E)
 	@if [ "$(E2E_IMAGE_SOURCE)" = "local" ]; then \
 		$(MAKE) docker-build-local-images TAG=e2e REGISTRY=$(REGISTRY); \
@@ -114,7 +127,9 @@ cleanup-e2e-cluster: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER_E2E)
 
 .PHONY: dev-cluster
-dev-cluster: ocm-transfer-demo ## Create a kind cluster for local development / testing
+dev-cluster: ocm-transfer-demo ## Create a kind cluster for local development / testing. Pin K8s via KIND_NODE_IMAGE (defaults from ENVTEST_K8S_VERSION). Pass KIND_RECREATE=1 to delete + recreate on image mismatch.
+	@KIND=$(KIND) DOCKER=$(DOCKER) KIND_RECREATE=$(KIND_RECREATE) \
+		bash hack/ensure-kind-cluster.sh $(KIND_CLUSTER_DEV) $(KIND_NODE_IMAGE)
 	$(MAKE) setup-local-cluster KIND_CLUSTER=$(KIND_CLUSTER_DEV)
 	$(MAKE) docker-build-local-images TAG=$(DEV_TAG)
 	$(MAKE) kind-load-local-images TAG=$(DEV_TAG) KIND_CLUSTER=$(KIND_CLUSTER_DEV)

--- a/hack/ensure-kind-cluster.sh
+++ b/hack/ensure-kind-cluster.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Ensure a Kind cluster with a specific node image exists, then exit 0.
+#
+# Three outcomes:
+#   1. Cluster doesn't exist               → create with the requested image.
+#   2. Cluster exists with the right image → reuse silently (idempotent).
+#   3. Cluster exists with a different image:
+#      - KIND_RECREATE=1  → delete + recreate with the requested image.
+#      - otherwise        → fail loudly with an actionable message.
+#
+# Required args:
+#   $1   Kind cluster name (e.g. solar-test-e2e)
+#   $2   Kind node image   (e.g. kindest/node:v1.33.0)
+#
+# Optional env:
+#   KIND            path to kind binary    (default: kind)
+#   DOCKER          path to docker binary  (default: docker)
+#   KIND_RECREATE   set to "1" to delete + recreate on image mismatch
+#                   instead of failing
+
+set -euo pipefail
+
+CLUSTER_NAME="${1:?Usage: $0 <cluster-name> <node-image>}"
+NODE_IMAGE="${2:?Usage: $0 <cluster-name> <node-image>}"
+KIND="${KIND:-kind}"
+DOCKER="${DOCKER:-docker}"
+KIND_RECREATE="${KIND_RECREATE:-}"
+
+# Outcome 1 — cluster doesn't exist. Exact-line match (-qx) avoids false
+# positives when one cluster name is a substring of another.
+if ! "$KIND" get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  echo "Creating Kind cluster '$CLUSTER_NAME' with image $NODE_IMAGE..."
+  "$KIND" create cluster --name "$CLUSTER_NAME" --image "$NODE_IMAGE"
+  exit 0
+fi
+
+# kind names the control-plane container "<cluster-name>-control-plane" by
+# convention; Config.Image reflects the original --image argument verbatim,
+# so a direct string compare works without parsing.
+existing=$("$DOCKER" inspect "${CLUSTER_NAME}-control-plane" \
+  --format '{{.Config.Image}}' 2>/dev/null || true)
+
+# Outcome 2 — match, reuse.
+if [ "$existing" = "$NODE_IMAGE" ]; then
+  echo "Kind cluster '$CLUSTER_NAME' already exists with $NODE_IMAGE; reusing."
+  exit 0
+fi
+
+# Outcome 3a — mismatch, KIND_RECREATE=1, delete + recreate.
+if [ "$KIND_RECREATE" = "1" ]; then
+  echo "Kind cluster '$CLUSTER_NAME' has image '$existing' but '$NODE_IMAGE' requested;" \
+       "KIND_RECREATE=1, deleting + recreating..."
+  "$KIND" delete cluster --name "$CLUSTER_NAME"
+  "$KIND" create cluster --name "$CLUSTER_NAME" --image "$NODE_IMAGE"
+  exit 0
+fi
+
+# Outcome 3b — mismatch, no opt-in, fail loud.
+cat >&2 <<EOF
+ERROR: Kind cluster '$CLUSTER_NAME' has image '$existing' but '$NODE_IMAGE' was requested.
+       Delete the cluster first ('$KIND delete cluster --name $CLUSTER_NAME')
+       then retry, or pass KIND_RECREATE=1 to delete + recreate automatically.
+EOF
+exit 1

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -31,19 +31,36 @@ if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/nul
   exit 0
 fi
 
-# Detect platform. K8s server tarballs and etcd archives both publish under
-# matching ${os}-${arch} names, so the only branching is uname -m → amd64|arm64.
+# Detect platform. Only linux is supported: dl.k8s.io publishes kube-apiserver
+# only for linux server platforms (darwin returns 404). envtest's own darwin
+# archives must be cross-compiled by controller-tools, which we can't
+# replicate here. macOS devs can still rely on `setup-envtest use` against
+# whatever versions controller-tools has packaged.
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
+if [ "$os" != "linux" ]; then
+  echo "envtest-sideload: only linux is supported (host is '${os}'); upstream dl.k8s.io has no kube-apiserver binary for darwin." >&2
+  exit 1
+fi
 case "$(uname -m)" in
   x86_64)        arch=amd64 ;;
   aarch64|arm64) arch=arm64 ;;
   *) echo "envtest-sideload: unsupported arch $(uname -m)" >&2; exit 1 ;;
 esac
 
+# Wrap curl with retries + timeouts so transient network blips don't fail
+# the whole sideload. --retry-all-errors covers HTTP 5xx (curl 7.71+, 2020).
+# --max-time bounds a single request; bytes are ~150 MB max (kube-apiserver),
+# 300 s is plenty even on slow runners.
+fetch() {
+  curl --fail --silent --show-error --location \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 10 --max-time 300 "$@"
+}
+
 # Look up the etcd version K8s ships with from its build/dependencies.yaml.
 # Self-updating per K8s release.
 deps_url="https://raw.githubusercontent.com/kubernetes/kubernetes/v${K8S_VERSION}/build/dependencies.yaml"
-etcd_version=$(curl -sSfL "$deps_url" \
+etcd_version=$(fetch "$deps_url" \
   | "$YQ" '.dependencies[] | select(.name == "etcd") | .version')
 if [[ -z "$etcd_version" ]]; then
   echo "envtest-sideload: could not resolve etcd version from $deps_url" >&2
@@ -71,8 +88,8 @@ k8s_base="https://dl.k8s.io/release/v${K8S_VERSION}/bin/${os}/${arch}"
 mkdir -p "$stage/k8s-bin"
 for bin in kube-apiserver kubectl; do
   echo "envtest-sideload: downloading ${k8s_base}/${bin}"
-  curl -sSfL -o "$stage/k8s-bin/$bin"        "$k8s_base/$bin"
-  curl -sSfL -o "$stage/k8s-bin/$bin.sha256" "$k8s_base/$bin.sha256"
+  fetch -o "$stage/k8s-bin/$bin"        "$k8s_base/$bin"
+  fetch -o "$stage/k8s-bin/$bin.sha256" "$k8s_base/$bin.sha256"
   # The .sha256 sibling is just the hex digest; pair with the filename ourselves.
   ( cd "$stage/k8s-bin" && printf '%s  %s\n' "$(cat "$bin.sha256")" "$bin" | sha256sum -c - )
   chmod +x "$stage/k8s-bin/$bin"
@@ -83,8 +100,8 @@ etcd_dir="etcd-v${etcd_version}-${os}-${arch}"
 etcd_tar="${etcd_dir}.tar.gz"
 etcd_base="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}"
 echo "envtest-sideload: downloading ${etcd_base}/${etcd_tar}"
-curl -sSfL -o "$stage/$etcd_tar"    "$etcd_base/$etcd_tar"
-curl -sSfL -o "$stage/SHA256SUMS"   "$etcd_base/SHA256SUMS"
+fetch -o "$stage/$etcd_tar"    "$etcd_base/$etcd_tar"
+fetch -o "$stage/SHA256SUMS"   "$etcd_base/SHA256SUMS"
 # etcd's SHA256SUMS lists `<hash>  <filename>` for every platform tarball;
 # grep our specific filename and pass to sha256sum -c.
 ( cd "$stage" && grep "  ${etcd_tar}\$" SHA256SUMS | sha256sum -c - )

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Sideload envtest binaries from canonical upstream sources (dl.k8s.io and
+# etcd-io GitHub releases) for K8s versions that controller-tools hasn't
+# packaged into its envtest-releases index yet. See TODO-556 / issue #556 for
+# the rationale (envtest's release cadence lags K8s releases sporadically;
+# upstream is closed-as-not-planned).
+#
+# Idempotent — exits 0 immediately if setup-envtest already has the version
+# cached, so this is safe as a `test` prerequisite that runs every invocation.
+#
+# Required env / args:
+#   $1                 K8s version (e.g. 1.36.0)
+#   SETUP_ENVTEST      path to setup-envtest binary
+#   BIN_DIR            cache directory (matches the Makefile's $(LOCALBIN))
+#
+# Optional env:
+#   YQ                 path to yq (defaults to `yq` on PATH)
+
+set -euo pipefail
+
+K8S_VERSION="${1:?Usage: $0 <k8s-version>}"
+# Accept either "1.32.1" or "v1.32.1" — strip an optional leading "v" so
+# URL construction (which adds its own "v") doesn't end up with "vv1.32.1".
+K8S_VERSION="${K8S_VERSION#v}"
+: "${SETUP_ENVTEST:?SETUP_ENVTEST must be set}"
+: "${BIN_DIR:?BIN_DIR must be set}"
+YQ="${YQ:-yq}"
+
+# Idempotency — bail out if setup-envtest already finds this version in cache.
+if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Detect platform. K8s server tarballs and etcd archives both publish under
+# matching ${os}-${arch} names, so the only branching is uname -m → amd64|arm64.
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+  x86_64)        arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) echo "envtest-sideload: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Look up the etcd version K8s ships with from its build/dependencies.yaml.
+# Self-updating per K8s release.
+deps_url="https://raw.githubusercontent.com/kubernetes/kubernetes/v${K8S_VERSION}/build/dependencies.yaml"
+etcd_version=$(curl -sSfL "$deps_url" \
+  | "$YQ" '.dependencies[] | select(.name == "etcd") | .version')
+if [[ -z "$etcd_version" ]]; then
+  echo "envtest-sideload: could not resolve etcd version from $deps_url" >&2
+  exit 1
+fi
+
+echo "envtest-sideload: K8s ${K8S_VERSION} ships with etcd ${etcd_version} (${os}/${arch})"
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+
+# --- K8s binaries (kube-apiserver, kubectl) --------------------------------
+# Direct per-binary downloads avoid pulling the ~600 MB server tarball when we
+# only need two binaries (~150 MB + ~50 MB combined).
+#
+# NOTE: If a future K8s release ships a new server binary that envtest
+# expects (e.g. some hypothetical "super-controller-thing"), envtest will
+# fail to start the control plane and the test run will surface the missing
+# binary. Add the new name to the loop below — the server tarball at
+# dl.k8s.io/v${VER}/kubernetes-server-${os}-${arch}.tar.gz is the canonical
+# index of what's available per release if you need to discover the exact
+# filename. Same applies if envtest itself ever adds a required binary
+# beyond kube-apiserver/etcd/kubectl.
+k8s_base="https://dl.k8s.io/release/v${K8S_VERSION}/bin/${os}/${arch}"
+mkdir -p "$stage/k8s-bin"
+for bin in kube-apiserver kubectl; do
+  echo "envtest-sideload: downloading ${k8s_base}/${bin}"
+  curl -sSfL -o "$stage/k8s-bin/$bin"        "$k8s_base/$bin"
+  curl -sSfL -o "$stage/k8s-bin/$bin.sha256" "$k8s_base/$bin.sha256"
+  # The .sha256 sibling is just the hex digest; pair with the filename ourselves.
+  ( cd "$stage/k8s-bin" && printf '%s  %s\n' "$(cat "$bin.sha256")" "$bin" | sha256sum -c - )
+  chmod +x "$stage/k8s-bin/$bin"
+done
+
+# --- etcd tarball (etcd binary) --------------------------------------------
+etcd_dir="etcd-v${etcd_version}-${os}-${arch}"
+etcd_tar="${etcd_dir}.tar.gz"
+etcd_base="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}"
+echo "envtest-sideload: downloading ${etcd_base}/${etcd_tar}"
+curl -sSfL -o "$stage/$etcd_tar"    "$etcd_base/$etcd_tar"
+curl -sSfL -o "$stage/SHA256SUMS"   "$etcd_base/SHA256SUMS"
+# etcd's SHA256SUMS lists `<hash>  <filename>` for every platform tarball;
+# grep our specific filename and pass to sha256sum -c.
+( cd "$stage" && grep "  ${etcd_tar}\$" SHA256SUMS | sha256sum -c - )
+tar -C "$stage" -xzf "$stage/$etcd_tar" "$etcd_dir/etcd"
+
+# --- Assemble the sideload tarball with the three binaries at top level ---
+sideload_tar="$stage/sideload.tar.gz"
+tar -czf "$sideload_tar" \
+  -C "$stage/k8s-bin"     kube-apiserver kubectl \
+  -C "$stage/$etcd_dir"   etcd
+
+# Feed it to setup-envtest. --os/--arch matter — sideload writes the cache
+# entry keyed on platform.
+echo "envtest-sideload: sideloading ${K8S_VERSION} into ${BIN_DIR}"
+"$SETUP_ENVTEST" sideload "$K8S_VERSION" \
+  --os "$os" --arch "$arch" --bin-dir "$BIN_DIR" \
+  < "$sideload_tar"
+
+# Sanity-check that setup-envtest can now find it.
+"$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/null
+echo "envtest-sideload: done"

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 # Sideload envtest binaries from canonical upstream sources (dl.k8s.io and
 # etcd-io GitHub releases) for K8s versions that controller-tools hasn't
-# packaged into its envtest-releases index yet. See TODO-556 / issue #556 for
+# packaged into its envtest-releases index yet. See issue #556 for
 # the rationale (envtest's release cadence lags K8s releases sporadically;
 # upstream is closed-as-not-planned).
+#
+# dl.k8s.io has all versions but only Linux builds. controller-tools has 
+# Darwin builds, but not for all versions of Kubernetes and etcd.
+# To run a specific version under Darwin might not be possible, 
+# 
+# So it should:
+#   - check K8S_VERSION, use envtest-setup binaries if available
+#   - if not, fall back to dl.k8s.io(which has no Darwin builds)
 #
 # Idempotent — exits 0 immediately if setup-envtest already has the version
 # cached, so this is safe as a `test` prerequisite that runs every invocation.
@@ -38,6 +46,7 @@ fi
 # `setup-envtest use` (which downloads from controller-tools' index). It
 # succeeds whenever the requested version is in the index; only when the
 # index has no entry do we have to give up and ask the dev to pin.
+# 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [ "$os" != "linux" ]; then
   if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -31,14 +31,26 @@ if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/nul
   exit 0
 fi
 
-# Detect platform. Only linux is supported: dl.k8s.io publishes kube-apiserver
-# only for linux server platforms (darwin returns 404). envtest's own darwin
-# archives must be cross-compiled by controller-tools, which we can't
-# replicate here. macOS devs can still rely on `setup-envtest use` against
-# whatever versions controller-tools has packaged.
+# Detect host. dl.k8s.io publishes kube-apiserver only for linux server
+# platforms (darwin/windows return 404). controller-tools cross-compiles its
+# own darwin/windows envtest archives from K8s source — we can't replicate
+# that from a shell script, so on non-linux hosts we defer to vanilla
+# `setup-envtest use` (which downloads from controller-tools' index). It
+# succeeds whenever the requested version is in the index; only when the
+# index has no entry do we have to give up and ask the dev to pin.
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [ "$os" != "linux" ]; then
-  echo "envtest-sideload: only linux is supported (host is '${os}'); upstream dl.k8s.io has no kube-apiserver binary for darwin." >&2
+  if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then
+    exit 0
+  fi
+  cat >&2 <<EOF
+envtest-sideload: ${os} is supported via controller-tools' pre-packaged
+  archives, but '${K8S_VERSION}' is not in their index and dl.k8s.io has
+  no kube-apiserver binary for non-linux platforms.
+  List available versions:    ${SETUP_ENVTEST} list
+  Then pin ENVTEST_K8S_VERSION to one of those, or run on Linux where
+  this script can sideload the upstream K8s/etcd binaries directly.
+EOF
   exit 1
 fi
 case "$(uname -m)" in


### PR DESCRIPTION
## What

[Not all K8s versions are supported by envtest](https://github.com/kubernetes-sigs/controller-tools/issues/1320), download from `dl.k8s.io` directly, if possible.


## Testing
Manual against some K8s versions.

E2E tests can be run like `make test-e2e ENVTEST_K8S_VERSION=1.33.0` against any version, Kind and K8s binaries will match.

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a helper to sideload `envtest` binaries for Kubernetes versions not already cached.
  * Introduced configurable Kubernetes node image pinning for Kind-based testing.

* **Bug Fixes**
  * Improved cluster reuse behavior by detecting node image mismatches and recreating when requested.

* **Chores**
  * Updated test and cluster setup flows to use the new helpers for more consistent end-to-end and envtest execution.
  * Enhanced help text and usage guidance for cluster creation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->