### PR TITLE
chore: update release checksum

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,8 +75,7 @@ jobs:
 
       - name: Create checksums
         run: |
-          cd bin
-          sha256sum * > checksums.txt
+          find bin -type f ! -name checksums.txt | sort | xargs sha256sum > bin/checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3


### PR DESCRIPTION
## What
Fixes the checksum step in release

go build outputs directories inside bin, which cases sha256sum to fail. we find and hash regular files only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow's checksum generation process to compute SHA-256 hashes with deterministic ordering, improving the reproducibility and reliability of generated checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->