### PR TITLE
feat(controller): implement deletion protection via controller-managed finalizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using
 	IMAGE_TAG=$(TAG) \
 	OCM=$(OCM) \
 	REGISTRY=$(REGISTRY) \
-	$(GO) test -count=1 -tags=e2e ./test/e2e/ -v -ginkgo.v
+	$(GO) test -count=1 -tags=e2e -timeout 15m ./test/e2e/ -v -ginkgo.v
 
 .PHONY: manifests
 manifests: $(CONTROLLER_GEN) ## Generate ClusterRole and CustomResourceDefinition objects.

--- a/api/solar/v1alpha1/profile_types.go
+++ b/api/solar/v1alpha1/profile_types.go
@@ -50,6 +50,11 @@ type ProfileStatus struct {
 
 // Profile represents the link between a Release and a set of matching Targets the Release is
 // intended to be deployed to.
+//
+// Deletion is a destructive, cascading operation: deleting a Profile deletes all owned
+// ReleaseBindings. To remove a Profile without triggering undeployment, first remove or relabel
+// all matching Targets so the Profile controller deletes the ReleaseBindings itself, then delete
+// the Profile once it has no owned bindings.
 type Profile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/charts/solar/files/role.yaml
+++ b/charts/solar/files/role.yaml
@@ -38,15 +38,32 @@ rules:
 - apiGroups:
   - solar.opendefense.cloud
   resources:
+  - components
   - componentversions
   - profiles
-  - referencegrants
   - registries
   - registrybindings
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - components/finalizers
+  - componentversions/finalizers
+  - profiles/finalizers
+  - registries/finalizers
+  - registrybindings/finalizers
+  - releasebindings/finalizers
+  - releases/finalizers
+  - renderartifacts/finalizers
+  - rendertasks/finalizers
+  - targets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - solar.opendefense.cloud
   resources:
@@ -59,6 +76,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - solar.opendefense.cloud
+  resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - solar.opendefense.cloud
   resources:
@@ -76,11 +101,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - solar.opendefense.cloud
-  resources:
-  - renderartifacts/finalizers
-  - rendertasks/finalizers
-  - targets/finalizers
-  verbs:
-  - update

--- a/client-go/applyconfigurations/solar/v1alpha1/profile.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/profile.go
@@ -16,6 +16,11 @@ import (
 //
 // Profile represents the link between a Release and a set of matching Targets the Release is
 // intended to be deployed to.
+//
+// Deletion is a destructive, cascading operation: deleting a Profile deletes all owned
+// ReleaseBindings. To remove a Profile without triggering undeployment, first remove or relabel
+// all matching Targets so the Profile controller deletes the ReleaseBindings itself, then delete
+// the Profile once it has no owned bindings.
 type ProfileApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -879,7 +879,7 @@ func schema_solar_api_solar_v1alpha1_Profile(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Profile represents the link between a Release and a set of matching Targets the Release is intended to be deployed to.",
+				Description: "Profile represents the link between a Release and a set of matching Targets the Release is intended to be deployed to.\n\nDeletion is a destructive, cascading operation: deleting a Profile deletes all owned ReleaseBindings. To remove a Profile without triggering undeployment, first remove or relabel all matching Targets so the Profile controller deletes the ReleaseBindings itself, then delete the Profile once it has no owned bindings.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/cmd/solar-controller-manager/main.go
+++ b/cmd/solar-controller-manager/main.go
@@ -269,6 +269,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := (&controller.ComponentVersionReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "componentversion")
+		os.Exit(1)
+	}
+
+	if err := (&controller.ReleaseBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "releasebinding")
+		os.Exit(1)
+	}
+
+	if err := (&controller.RegistryBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "registrybinding")
+		os.Exit(1)
+	}
+
 	// healthz / readyz setup
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -26,9 +26,12 @@ nav:
   - Discovery:
     - developer-guide/discovery_pipeline.md
   - Controllers:
+    - developer-guide/componentversion_controller.md
     - developer-guide/release_controller.md
+    - developer-guide/releasebinding_controller.md
     - developer-guide/profile_controller.md
     - developer-guide/target_controller.md
+    - developer-guide/registrybinding_controller.md
     - developer-guide/rendertask_controller.md
   - ADRs:
     - developer-guide/adrs/*.md

--- a/docs/developer-guide/componentversion_controller.md
+++ b/docs/developer-guide/componentversion_controller.md
@@ -1,0 +1,50 @@
+# ComponentVersion Controller Documentation
+
+## Overview
+
+The ComponentVersion controller manages the deletion-protection finalizer on the `Component` referenced by each `ComponentVersion`. It prevents a Component from being deleted while one or more ComponentVersions still reference it.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Kubernetes
+        Ctrl[ComponentVersion Controller]
+        CV[ComponentVersion]
+        Comp[Component]
+    end
+
+    Ctrl -->|reconciles| CV
+    CV -->|spec.componentRef| Comp
+    Ctrl -->|adds/removes componentRefFinalizer| Comp
+```
+
+## Finalizers
+
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/componentversion-finalizer` | ComponentVersion | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/component-ref` | Component | Prevents deletion of the referenced Component while any ComponentVersion references it |
+
+On deletion, the controller:
+
+1. Checks whether any other active ComponentVersion in the same namespace still references the same Component.
+2. If none remain, removes `solar.opendefense.cloud/component-ref` from the Component.
+3. Removes `solar.opendefense.cloud/componentversion-finalizer` from the ComponentVersion, allowing it to be garbage-collected.
+
+## Watch Triggers
+
+The ComponentVersion controller is triggered when:
+
+- A `ComponentVersion` resource is created, updated, or deleted.
+
+## Relationship to Other Controllers
+
+```mermaid
+flowchart LR
+    CVCtrl[ComponentVersion Controller] -->|protects| Component
+    Release -->|references| ComponentVersion
+    ReleaseCtrl[Release Controller] -->|protects| ComponentVersion
+```
+
+ComponentVersions are themselves protected from deletion by the Release controller — a ComponentVersion cannot be deleted while a Release references it. Once the last Release is removed, the ComponentVersion can be deleted, which in turn unblocks Component deletion if no other ComponentVersions exist.

--- a/docs/developer-guide/profile_controller.md
+++ b/docs/developer-guide/profile_controller.md
@@ -33,7 +33,42 @@ flowchart TD
 
     RB1 -->|binds Target A to| Rel
     RB2 -->|binds Target B to| Rel
+    Ctrl -->|adds/removes release-ref| Rel
 ```
+
+## Finalizers
+
+The Profile controller manages two finalizers:
+
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/profile-finalizer` | Profile | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/release-ref` | Release | Prevents deletion of the referenced Release while any Profile or ReleaseBinding references it |
+
+On deletion, the controller follows this sequence to ensure the Release is never left unprotected while bindings that reference it still exist:
+
+1. Explicitly deletes any owned ReleaseBindings that have not yet been deleted.
+2. Blocks (returns without removing finalizers) until every owned ReleaseBinding is fully gone from the API. The `Owns()` watch re-triggers the reconcile as each binding is removed.
+3. Once all owned bindings are gone, checks whether any other active Profile or ReleaseBinding still references the same Release.
+4. If none remain, removes `solar.opendefense.cloud/release-ref` from the Release.
+5. Removes `solar.opendefense.cloud/profile-finalizer` from the Profile, allowing it to be garbage-collected.
+
+Note: `solar.opendefense.cloud/release-ref` is a shared finalizer — both the Profile controller and the ReleaseBinding controller place it on a Release. The reference count check always considers both Profiles and ReleaseBindings before removing it.
+
+### Operational risk: Profile stuck in Terminating
+
+Because the Profile controller explicitly waits for every owned ReleaseBinding to be fully removed from the API before proceeding, a permanently stuck ReleaseBinding will block Profile deletion indefinitely. This can happen if the ReleaseBinding controller has a bug that prevents it from removing `solar.opendefense.cloud/releasebinding-finalizer` from a binding that has already been marked for deletion.
+
+There is no automatic timeout or retry limit — the `Owns()` watch only re-triggers the Profile reconcile when a binding *changes*, so a binding that never changes will leave the Profile waiting forever with no further events.
+
+**Escape hatch:** manually remove the stuck finalizer with kubectl:
+
+```bash
+kubectl patch releasebinding <name> -n <namespace> \
+  -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+
+This unblocks the Profile controller on the next reconcile triggered by the binding's deletion.
 
 ## Resource Owner References
 
@@ -80,6 +115,14 @@ ReleaseBindings are created with `generateName` using the pattern:
 
 Names are truncated to 57 characters before the suffix to stay within the 63-character Kubernetes label value limit.
 
+## Deletion Behavior
+
+> **Warning:** Deleting a Profile is a destructive, cascading operation.
+
+The Profile controller explicitly deletes all owned ReleaseBindings as part of its deletion path. There is no grace period or confirmation step.
+
+To remove a Profile without triggering undeployment, first remove or relabel all matching Targets so the Profile controller reconciles and removes the ReleaseBindings itself, then delete the Profile once it has no owned bindings.
+
 ## Relationship to Other Controllers
 
 ```mermaid
@@ -90,6 +133,7 @@ flowchart LR
 ```
 
 Deleting a Profile cascades into:
-1. Kubernetes GC removes owned ReleaseBindings.
+
+1. Profile controller explicitly deletes all owned ReleaseBindings and waits for them to be fully removed.
 2. Target controller notices the missing bindings and stops managing the corresponding RenderTasks.
 

--- a/docs/developer-guide/registrybinding_controller.md
+++ b/docs/developer-guide/registrybinding_controller.md
@@ -1,0 +1,52 @@
+# RegistryBinding Controller Documentation
+
+## Overview
+
+The RegistryBinding controller manages the deletion-protection finalizer on the `Registry` referenced by each `RegistryBinding`. It ensures that a Registry cannot be deleted while any active RegistryBinding or Target still references it.
+
+This controller complements the Target controller's registry protection: the Target controller places `solar.opendefense.cloud/registry-ref` on a Registry when it processes a Target, but RegistryBindings (which also reference registries for pull-credential resolution) are handled here.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Kubernetes
+        Ctrl[RegistryBinding Controller]
+        RegB[RegistryBinding]
+        Reg[Registry]
+    end
+
+    Ctrl -->|reconciles| RegB
+    RegB -->|spec.registryRef| Reg
+    Ctrl -->|adds/removes registryRefFinalizer| Reg
+```
+
+## Finalizers
+
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/registrybinding-finalizer` | RegistryBinding | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/registry-ref` | Registry | Prevents deletion of the referenced Registry while any Target or RegistryBinding references it |
+
+On deletion, the controller:
+
+1. Checks whether any other active Target (across all namespaces) or RegistryBinding still references the same Registry.
+2. If none remain, removes `solar.opendefense.cloud/registry-ref` from the Registry.
+3. Removes `solar.opendefense.cloud/registrybinding-finalizer` from the RegistryBinding, allowing it to be garbage-collected.
+
+`solar.opendefense.cloud/registry-ref` is a shared finalizer: both this controller and the Target controller place it on a Registry. The reference count check always considers both Targets and RegistryBindings before removing it.
+
+## Watch Triggers
+
+The RegistryBinding controller is triggered when:
+
+- A `RegistryBinding` resource is created, updated, or deleted.
+
+## Relationship to Other Controllers
+
+```mermaid
+flowchart LR
+    TargetCtrl[Target Controller] -->|also protects| Registry
+    RegBCtrl[RegistryBinding Controller] -->|protects| Registry
+    TargetCtrl -->|consumes| RegistryBinding
+```

--- a/docs/developer-guide/release_controller.md
+++ b/docs/developer-guide/release_controller.md
@@ -22,7 +22,25 @@ flowchart TD
     Rel -->|resolves| CV
     CV -->|ComponentRef.Name| Ctrl
     Ctrl -->|writes status.effectiveUniqueName| Rel
+    Ctrl -->|adds/removes componentversion-ref| CV
 ```
+
+## Finalizers
+
+The Release controller manages two finalizers:
+
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/release-finalizer` | Release | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/componentversion-ref` | ComponentVersion | Prevents deletion of the referenced ComponentVersion while any Release references it |
+
+On deletion, the controller:
+
+1. Checks whether any other active Release still references the same ComponentVersion.
+2. If none remain, removes `solar.opendefense.cloud/componentversion-ref` from the ComponentVersion.
+3. Removes `solar.opendefense.cloud/release-finalizer` from the Release, allowing it to be garbage-collected.
+
+Cross-namespace references (resolved via `ReferenceGrant`) are taken into account when counting active references.
 
 ## Status Conditions
 
@@ -31,7 +49,7 @@ stateDiagram-v2
     [*] --> Unresolved: Release created
     Unresolved --> ComponentVersionResolved: ComponentVersion found
     Unresolved --> Unresolved: ComponentVersion missing (requeues on CV change)
-    ComponentVersionResolved --> Unresolved: ComponentVersion deleted
+    ComponentVersionResolved --> Unresolved: ReferenceGrant revoked
     ComponentVersionResolved --> [*]
 ```
 

--- a/docs/developer-guide/release_controller.md
+++ b/docs/developer-guide/release_controller.md
@@ -40,7 +40,7 @@ On deletion, the controller:
 2. If none remain, removes `solar.opendefense.cloud/componentversion-ref` from the ComponentVersion.
 3. Removes `solar.opendefense.cloud/release-finalizer` from the Release, allowing it to be garbage-collected.
 
-Cross-namespace references (resolved via `ReferenceGrant`) are taken into account when counting active references.
+Cross-namespace references (resolved via `ReferenceGrant`) are considered when counting active references.
 
 ## Status Conditions
 

--- a/docs/developer-guide/releasebinding_controller.md
+++ b/docs/developer-guide/releasebinding_controller.md
@@ -1,0 +1,55 @@
+# ReleaseBinding Controller Documentation
+
+## Overview
+
+The ReleaseBinding controller manages the deletion-protection finalizer on the `Release` referenced by each `ReleaseBinding`. It ensures that a Release cannot be deleted while any active binding (Profile-created or manually created) still references it.
+
+This controller complements the Profile controller's release protection: the Profile controller places `solar.opendefense.cloud/release-ref` on a Release when it processes a Profile, but manually created ReleaseBindings (those without a Profile owner) are handled here.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Kubernetes
+        Ctrl[ReleaseBinding Controller]
+        RB[ReleaseBinding]
+        Rel[Release]
+    end
+
+    Ctrl -->|reconciles| RB
+    RB -->|spec.releaseRef| Rel
+    Ctrl -->|adds/removes releaseRefFinalizer| Rel
+```
+
+## Finalizers
+
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/releasebinding-finalizer` | ReleaseBinding | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/release-ref` | Release | Prevents deletion of the referenced Release while any Profile or ReleaseBinding references it |
+
+On deletion, the controller:
+
+1. Checks whether any other active Profile or ReleaseBinding still references the same Release.
+2. If none remain, removes `solar.opendefense.cloud/release-ref` from the Release.
+3. Removes `solar.opendefense.cloud/releasebinding-finalizer` from the ReleaseBinding, allowing it to be garbage-collected.
+
+`solar.opendefense.cloud/release-ref` is a shared finalizer: both this controller and the Profile controller place it on a Release. The reference count check always considers both Profiles and ReleaseBindings before removing it. ReleaseBindings owned by a Profile that is itself being deleted are excluded from the active count.
+
+There is one additional guard: if a Profile is in the process of deletion but still holds `solar.opendefense.cloud/profile-finalizer`, the ReleaseBinding controller skips removing `release-ref` entirely and defers to the Profile controller. The Profile controller removes `release-ref` only after all its owned ReleaseBindings are fully gone from the API, which closes the window where the Release could otherwise become deletable while active bindings still existed.
+
+## Watch Triggers
+
+The ReleaseBinding controller is triggered when:
+
+- A `ReleaseBinding` resource is created, updated, or deleted.
+
+## Relationship to Other Controllers
+
+```mermaid
+flowchart LR
+    ProfileCtrl[Profile Controller] -->|creates| ReleaseBinding
+    RBCtrl[ReleaseBinding Controller] -->|protects| Release
+    ProfileCtrl -->|also protects| Release
+    TargetCtrl[Target Controller] -->|consumes| ReleaseBinding
+```

--- a/docs/developer-guide/target_controller.md
+++ b/docs/developer-guide/target_controller.md
@@ -83,12 +83,23 @@ stateDiagram-v2
 | `BootstrapReady`     | `True`  | `Ready`                      | Bootstrap RenderTask succeeded; `ChartURL` populated                |
 | `BootstrapReady`     | `False` | `Failed`                     | Bootstrap RenderTask failed                                         |
 
-## Finalizer
+## Finalizers
 
-The Target controller adds the finalizer `solar.opendefense.cloud/target-finalizer` to every Target. On deletion, it:
+The Target controller manages two finalizers:
 
-1. Deletes all RenderTasks owned by the Target.
-2. Removes the finalizer to allow the Target to be garbage-collected.
+| Finalizer | On resource | Purpose |
+|---|---|---|
+| `solar.opendefense.cloud/target-finalizer` | Target | Allows the controller to observe deletion and run cleanup logic before the object is garbage-collected |
+| `solar.opendefense.cloud/registry-ref` | Registry | Prevents deletion of the referenced Registry while any Target or RegistryBinding references it |
+
+On deletion, the controller:
+
+1. Checks whether any other active Target or RegistryBinding still references the same Registry.
+2. If none remain, removes `solar.opendefense.cloud/registry-ref` from the Registry.
+3. Deletes all RenderTasks owned by the Target.
+4. Removes `solar.opendefense.cloud/target-finalizer` from the Target, allowing it to be garbage-collected.
+
+Note: `solar.opendefense.cloud/registry-ref` is a shared finalizer managed by both the Target controller and the RegistryBinding controller. The reference count check always considers both before removing it.
 
 ## RenderTask Naming
 
@@ -183,9 +194,13 @@ sequenceDiagram
 
     User->>K8s: Delete Target
     K8s->>TargetCtrl: Reconcile(Target) [DeletionTimestamp set]
+    TargetCtrl->>K8s: List active Targets + RegistryBindings referencing Registry
+    alt no other active referencers
+        TargetCtrl->>K8s: Remove registry-ref from Registry
+    end
     TargetCtrl->>K8s: List owned RenderTasks
     TargetCtrl->>K8s: Delete all owned RenderTasks
-    TargetCtrl->>K8s: Remove finalizer
+    TargetCtrl->>K8s: Remove target-finalizer
     Note over K8s: Target is garbage-collected
 ```
 

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -268,6 +268,11 @@ _Appears in:_
 Profile represents the link between a Release and a set of matching Targets the Release is
 intended to be deployed to.
 
+Deletion is a destructive, cascading operation: deleting a Profile deletes all owned
+ReleaseBindings. To remove a Profile without triggering undeployment, first remove or relabel
+all matching Targets so the Profile controller deletes the ReleaseBindings itself, then delete
+the Profile once it has no owned bindings.
+
 
 
 _Appears in:_

--- a/pkg/controller/componentversion_controller.go
+++ b/pkg/controller/componentversion_controller.go
@@ -84,10 +84,12 @@ func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ComponentVersion for finalizer addition")
 		}
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, componentVersionFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ComponentVersion")
+		if !slices.Contains(latest.Finalizers, componentVersionFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, componentVersionFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ComponentVersion")
+			}
 		}
 	}
 

--- a/pkg/controller/componentversion_controller.go
+++ b/pkg/controller/componentversion_controller.go
@@ -89,8 +89,6 @@ func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ComponentVersion")
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// Protect the referenced Component from deletion.

--- a/pkg/controller/componentversion_controller.go
+++ b/pkg/controller/componentversion_controller.go
@@ -1,0 +1,165 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+// ComponentVersionReconciler manages the deletion-protection finalizer on the Component
+// referenced by each ComponentVersion, preventing Component deletion while ComponentVersions exist.
+type ComponentVersionReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// WatchNamespace restricts reconciliation to this namespace.
+	// Should be empty in production (watches all namespaces).
+	// Intended for use in integration tests only.
+	WatchNamespace string
+}
+
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions/finalizers,verbs=update
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=components,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=components/finalizers,verbs=update
+
+func (r *ComponentVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	log.V(1).Info("ComponentVersion is being reconciled", "req", req)
+
+	if r.WatchNamespace != "" && req.Namespace != r.WatchNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	cv := &solarv1alpha1.ComponentVersion{}
+	if err := r.Get(ctx, req.NamespacedName, cv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, errLogAndWrap(log, err, "failed to get ComponentVersion")
+	}
+
+	// Handle deletion: remove componentRefFinalizer from Component if no other CV references it.
+	if !cv.DeletionTimestamp.IsZero() {
+		if cv.Spec.ComponentRef.Name != "" {
+			comp := &solarv1alpha1.Component{}
+			if err := r.Get(ctx, types.NamespacedName{Name: cv.Spec.ComponentRef.Name, Namespace: cv.Namespace}, comp); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Component for finalizer cleanup")
+				}
+			} else if err := r.removeComponentRefFinalizer(ctx, cv, comp); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		if slices.Contains(cv.Finalizers, componentVersionFinalizer) {
+			latest := &solarv1alpha1.ComponentVersion{}
+			if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ComponentVersion for finalizer removal")
+			}
+			original := latest.DeepCopy()
+			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool { return s == componentVersionFinalizer })
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to remove finalizer from ComponentVersion")
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure self-finalizer exists.
+	if !slices.Contains(cv.Finalizers, componentVersionFinalizer) {
+		latest := &solarv1alpha1.ComponentVersion{}
+		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ComponentVersion for finalizer addition")
+		}
+		original := latest.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, componentVersionFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ComponentVersion")
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Protect the referenced Component from deletion.
+	if cv.Spec.ComponentRef.Name != "" {
+		comp := &solarv1alpha1.Component{}
+		if err := r.Get(ctx, types.NamespacedName{Name: cv.Spec.ComponentRef.Name, Namespace: cv.Namespace}, comp); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Component for protection finalizer")
+			}
+		} else if !slices.Contains(comp.Finalizers, componentRefFinalizer) {
+			latest := comp.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, componentRefFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(comp)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Component")
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// removeComponentRefFinalizer removes componentRefFinalizer from comp when no other active
+// ComponentVersion still references it (excluding the CV currently being deleted).
+func (r *ComponentVersionReconciler) removeComponentRefFinalizer(ctx context.Context, deletingCV *solarv1alpha1.ComponentVersion, comp *solarv1alpha1.Component) error {
+	if !slices.Contains(comp.Finalizers, componentRefFinalizer) {
+		return nil
+	}
+
+	cvList := &solarv1alpha1.ComponentVersionList{}
+	if err := r.List(ctx, cvList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingFields{indexCVByComponentName: comp.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list ComponentVersions for Component finalizer check")
+	}
+
+	for _, cv := range cvList.Items {
+		if cv.Name == deletingCV.Name {
+			continue
+		}
+		if !cv.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		return nil // another active ComponentVersion still references this Component
+	}
+
+	freshComp := &solarv1alpha1.Component{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(comp), freshComp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to get latest Component for finalizer removal")
+	}
+	original := freshComp.DeepCopy()
+	freshComp.Finalizers = slices.DeleteFunc(freshComp.Finalizers, func(s string) bool { return s == componentRefFinalizer })
+	if err := r.Patch(ctx, freshComp, client.MergeFrom(original)); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Component")
+	}
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Removed protection finalizer from Component", "component", comp.Name)
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ComponentVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&solarv1alpha1.ComponentVersion{}).
+		Complete(r)
+}

--- a/pkg/controller/componentversion_controller_test.go
+++ b/pkg/controller/componentversion_controller_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ComponentVersionReconciler", Ordered, func() {
+	var (
+		validComponent = func(name string) *solarv1alpha1.Component {
+			return &solarv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.ComponentSpec{
+					Scheme:     "oci",
+					Registry:   "registry.example.com",
+					Repository: "example/component",
+				},
+			}
+		}
+
+		validCV = func(name string, componentName string) *solarv1alpha1.ComponentVersion {
+			return &solarv1alpha1.ComponentVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.ComponentVersionSpec{
+					ComponentRef: corev1.LocalObjectReference{Name: componentName},
+					Tag:          "v1.0.0",
+				},
+			}
+		}
+	)
+
+	Describe("protection finalizer on Component", func() {
+		It("adds componentVersionFinalizer to ComponentVersion and componentRefFinalizer to Component", func() {
+			comp := validComponent("dp-comp-a")
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, comp, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, comp))
+			})
+
+			cv := validCV("dp-cv-a", comp.Name)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, cv, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, cv))
+			})
+
+			Eventually(func(g Gomega) {
+				updatedCV := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updatedCV)).To(Succeed())
+				g.Expect(updatedCV.Finalizers).To(ContainElement(componentVersionFinalizer))
+
+				updatedComp := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updatedComp)).To(Succeed())
+				g.Expect(updatedComp.Finalizers).To(ContainElement(componentRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks Component deletion while ComponentVersion references it", func() {
+			comp := validComponent("dp-comp-blocked")
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+
+			cv := validCV("dp-cv-blocked", comp.Name)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			// Wait for the protection finalizer to be added.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete Component — it should be blocked (DeletionTimestamp set, not gone).
+			Expect(k8sClient.Delete(ctx, comp)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, consistentlyDuration).Should(Succeed())
+
+			// Delete the ComponentVersion — controller removes componentRefFinalizer from Component,
+			// then removes componentVersionFinalizer, unblocking Component deletion.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, cv))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), &solarv1alpha1.Component{}))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("removes componentRefFinalizer from Component when last ComponentVersion is deleted", func() {
+			comp := validComponent("dp-comp-last")
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, comp, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, comp))
+			})
+
+			cv := validCV("dp-cv-last", comp.Name)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			// Wait for protection finalizer.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete the ComponentVersion — the controller's deletion handler removes componentRefFinalizer
+			// from Component (no other references), then removes componentVersionFinalizer.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, cv))).To(Succeed())
+
+			// The componentRefFinalizer should eventually be removed from Component.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(componentRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("retains componentRefFinalizer when a second ComponentVersion still references the Component", func() {
+			comp := validComponent("dp-comp-multi")
+			Expect(k8sClient.Create(ctx, comp)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, comp, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, comp))
+			})
+
+			cv1 := validCV("dp-cv-multi-1", comp.Name)
+			Expect(k8sClient.Create(ctx, cv1)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, cv1, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, cv1))
+			})
+
+			cv2 := validCV("dp-cv-multi-2", comp.Name)
+			Expect(k8sClient.Create(ctx, cv2)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, cv2, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, cv2))
+			})
+
+			// Wait for the protection finalizer to be established.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete cv1 — cv2 still holds the reference, so component-ref must stay.
+			Expect(k8sClient.Delete(ctx, cv1)).To(Succeed())
+
+			// Wait for cv1 to be fully gone from the API.
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv1), &solarv1alpha1.ComponentVersion{}))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// component-ref must remain because cv2 still references the Component.
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Component{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentRefFinalizer))
+			}, consistentlyDuration).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/componentversion_controller_test.go
+++ b/pkg/controller/componentversion_controller_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -101,9 +102,9 @@ var _ = Describe("ComponentVersionReconciler", Ordered, func() {
 			// then removes componentVersionFinalizer, unblocking Component deletion.
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, cv))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), &solarv1alpha1.Component{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(comp), &solarv1alpha1.Component{}))
+			}, eventuallyTimeout).Should(BeTrue())
 		})
 
 		It("removes componentRefFinalizer from Component when last ComponentVersion is deleted", func() {
@@ -173,9 +174,9 @@ var _ = Describe("ComponentVersionReconciler", Ordered, func() {
 			Expect(k8sClient.Delete(ctx, cv1)).To(Succeed())
 
 			// Wait for cv1 to be fully gone from the API.
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv1), &solarv1alpha1.ComponentVersion{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv1), &solarv1alpha1.ComponentVersion{}))
+			}, eventuallyTimeout).Should(BeTrue())
 
 			// component-ref must remain because cv2 still references the Component.
 			Consistently(func(g Gomega) {

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -8,9 +8,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,8 +39,33 @@ const (
 	// Field index key for looking up RenderBindings by the RenderArtifact they reference.
 	indexRenderBindingArtifactName = "spec.renderArtifactRef.name"
 
+	// Field index keys for deletion-protection reference lookups.
+	// Release: composite "<cvNamespace>/<cvName>" resolving cross-namespace refs.
+	indexReleaseByCVRef = "dp.spec.componentVersionRef"
+	// ComponentVersion: same-namespace lookup by component name.
+	indexCVByComponentName = "dp.spec.componentRef.name"
+	// Profile: same-namespace lookup by release name.
+	indexProfileByReleaseName = "dp.spec.releaseRef.name"
+	// Target: composite "<registryNamespace>/<registryName>" resolving cross-namespace refs.
+	indexTargetByRegistryRef = "dp.spec.renderRegistryRef"
+	// RegistryBinding: same-namespace lookup by registry name.
+	indexRegistryBindingByRegistryName = "dp.spec.registryRef.name"
+
 	maxK8sObjectNameLen = 253
 	maxK8sLabelValueLen = 63
+
+	// Self-finalizers: added to the referencing resource so the controller can observe deletion.
+	releaseFinalizer          = "solar.opendefense.cloud/release-finalizer"
+	profileFinalizer          = "solar.opendefense.cloud/profile-finalizer"
+	releaseBindingFinalizer   = "solar.opendefense.cloud/releasebinding-finalizer"
+	componentVersionFinalizer = "solar.opendefense.cloud/componentversion-finalizer"
+	registryBindingFinalizer  = "solar.opendefense.cloud/registrybinding-finalizer"
+
+	// Protection finalizers: added to the referenced resource to block deletion while referenced.
+	componentVersionRefFinalizer = "solar.opendefense.cloud/componentversion-ref"
+	componentRefFinalizer        = "solar.opendefense.cloud/component-ref"
+	releaseRefFinalizer          = "solar.opendefense.cloud/release-ref"
+	registryRefFinalizer         = "solar.opendefense.cloud/registry-ref"
 )
 
 // truncateName truncates a name to maxLen characters. If truncation is needed,
@@ -215,7 +242,83 @@ func IndexFields(ctx context.Context, mgr ctrl.Manager) error {
 		return err
 	}
 
-	return indexRenderBindingFields(ctx, mgr)
+	if err := indexRenderBindingFields(ctx, mgr); err != nil {
+		return err
+	}
+
+	return indexDeletionProtectionFields(ctx, mgr)
+}
+
+// indexDeletionProtectionFields registers field indexers used to count active references
+// when deciding whether to remove a protection finalizer from a referenced resource.
+func indexDeletionProtectionFields(ctx context.Context, mgr ctrl.Manager) error {
+	indexer := mgr.GetFieldIndexer()
+
+	// Release → ComponentVersion: composite "<cvNamespace>/<cvName>" to handle cross-namespace refs.
+	if err := indexer.IndexField(ctx, &solarv1alpha1.Release{}, indexReleaseByCVRef, func(obj client.Object) []string {
+		rel := obj.(*solarv1alpha1.Release)
+		if rel.Spec.ComponentVersionRef.Name == "" {
+			return nil
+		}
+		cvNs := rel.Namespace
+		if rel.Spec.ComponentVersionNamespace != "" {
+			cvNs = rel.Spec.ComponentVersionNamespace
+		}
+
+		return []string{cvNs + "/" + rel.Spec.ComponentVersionRef.Name}
+	}); err != nil {
+		return err
+	}
+
+	// ComponentVersion → Component: same-namespace, index by component name.
+	if err := indexer.IndexField(ctx, &solarv1alpha1.ComponentVersion{}, indexCVByComponentName, func(obj client.Object) []string {
+		cv := obj.(*solarv1alpha1.ComponentVersion)
+		if cv.Spec.ComponentRef.Name == "" {
+			return nil
+		}
+
+		return []string{cv.Spec.ComponentRef.Name}
+	}); err != nil {
+		return err
+	}
+
+	// Profile → Release: same-namespace, index by release name.
+	if err := indexer.IndexField(ctx, &solarv1alpha1.Profile{}, indexProfileByReleaseName, func(obj client.Object) []string {
+		p := obj.(*solarv1alpha1.Profile)
+		if p.Spec.ReleaseRef.Name == "" {
+			return nil
+		}
+
+		return []string{p.Spec.ReleaseRef.Name}
+	}); err != nil {
+		return err
+	}
+
+	// Target → Registry: composite "<registryNamespace>/<registryName>" to handle cross-namespace refs.
+	if err := indexer.IndexField(ctx, &solarv1alpha1.Target{}, indexTargetByRegistryRef, func(obj client.Object) []string {
+		t := obj.(*solarv1alpha1.Target)
+		if t.Spec.RenderRegistryRef.Name == "" {
+			return nil
+		}
+		regNs := t.Namespace
+		if t.Spec.RenderRegistryNamespace != "" {
+			regNs = t.Spec.RenderRegistryNamespace
+		}
+
+		return []string{regNs + "/" + t.Spec.RenderRegistryRef.Name}
+	}); err != nil {
+		return err
+	}
+
+	// RegistryBinding → Registry: same-namespace, index by registry name.
+	return indexer.IndexField(ctx, &solarv1alpha1.RegistryBinding{}, indexRegistryBindingByRegistryName, func(obj client.Object) []string {
+		rb := obj.(*solarv1alpha1.RegistryBinding)
+		if rb.Spec.RegistryRef.Name == "" {
+			return nil
+		}
+
+		return []string{rb.Spec.RegistryRef.Name}
+	})
 }
 
 func indexReleaseBindingFields(ctx context.Context, mgr ctrl.Manager) error {
@@ -346,4 +449,68 @@ func indexRenderBindingFields(ctx context.Context, mgr ctrl.Manager) error {
 
 		return []string{rb.Spec.RenderArtifactRef.Name}
 	})
+}
+
+// removeRegistryRefFinalizer removes registryRefFinalizer from registry when no other active
+// Target (excluding skipTarget if non-nil) or RegistryBinding (excluding skipRegistryBinding
+// if non-nil) still references it.
+func removeRegistryRefFinalizer(ctx context.Context, c client.Client, skipTarget *solarv1alpha1.Target, skipRegistryBinding *solarv1alpha1.RegistryBinding, registry *solarv1alpha1.Registry) error {
+	if !slices.Contains(registry.Finalizers, registryRefFinalizer) {
+		return nil
+	}
+
+	refKey := registry.Namespace + "/" + registry.Name
+
+	targetList := &solarv1alpha1.TargetList{}
+	if err := c.List(ctx, targetList, client.MatchingFields{indexTargetByRegistryRef: refKey}); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list Targets for Registry finalizer check")
+	}
+
+	for _, t := range targetList.Items {
+		if skipTarget != nil && t.Name == skipTarget.Name && t.Namespace == skipTarget.Namespace {
+			continue
+		}
+		if !t.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		return nil
+	}
+
+	rbList := &solarv1alpha1.RegistryBindingList{}
+	if err := c.List(ctx, rbList,
+		client.InNamespace(registry.Namespace),
+		client.MatchingFields{indexRegistryBindingByRegistryName: registry.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list RegistryBindings for Registry finalizer check")
+	}
+
+	for _, rb := range rbList.Items {
+		if skipRegistryBinding != nil && rb.Name == skipRegistryBinding.Name {
+			continue
+		}
+		if !rb.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		return nil
+	}
+
+	freshRegistry := &solarv1alpha1.Registry{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(registry), freshRegistry); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to get latest Registry for finalizer removal")
+	}
+	original := freshRegistry.DeepCopy()
+	freshRegistry.Finalizers = slices.DeleteFunc(freshRegistry.Finalizers, func(s string) bool { return s == registryRefFinalizer })
+	if err := c.Patch(ctx, freshRegistry, client.MergeFrom(original)); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Registry")
+	}
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Removed protection finalizer from Registry", "registry", registry.Name)
+
+	return nil
 }

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -461,6 +461,9 @@ func removeRegistryRefFinalizer(ctx context.Context, c client.Client, skipTarget
 
 	refKey := registry.Namespace + "/" + registry.Name
 
+	// List results come from the informer cache, so a just-created referencer may not be
+	// visible yet. The referencer's own reconcile will re-add the protection finalizer in
+	// that case, making the window self-healing and safe to accept.
 	targetList := &solarv1alpha1.TargetList{}
 	if err := c.List(ctx, targetList, client.MatchingFields{indexTargetByRegistryRef: refKey}); err != nil {
 		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list Targets for Registry finalizer check")

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -509,7 +509,7 @@ func removeRegistryRefFinalizer(ctx context.Context, c client.Client, skipTarget
 	}
 	original := freshRegistry.DeepCopy()
 	freshRegistry.Finalizers = slices.DeleteFunc(freshRegistry.Finalizers, func(s string) bool { return s == registryRefFinalizer })
-	if err := c.Patch(ctx, freshRegistry, client.MergeFrom(original)); err != nil {
+	if err := c.Patch(ctx, freshRegistry, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
 		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Registry")
 	}
 

--- a/pkg/controller/profile_controller.go
+++ b/pkg/controller/profile_controller.go
@@ -224,7 +224,7 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		} else if !slices.Contains(release.Finalizers, releaseRefFinalizer) {
 			latest := release.DeepCopy()
 			latest.Finalizers = append(latest.Finalizers, releaseRefFinalizer)
-			if err := r.Patch(ctx, latest, client.MergeFrom(release)); err != nil {
+			if err := r.Patch(ctx, latest, client.MergeFromWithOptions(release, client.MergeFromWithOptimisticLock{})); err != nil {
 				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
 			}
 		}
@@ -565,7 +565,7 @@ func (r *ProfileReconciler) removeReleaseRefFinalizerIfUnreferenced(ctx context.
 	}
 	original := freshRelease.DeepCopy()
 	freshRelease.Finalizers = slices.DeleteFunc(freshRelease.Finalizers, func(s string) bool { return s == releaseRefFinalizer })
-	if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+	if err := r.Patch(ctx, freshRelease, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
 		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Release")
 	}
 

--- a/pkg/controller/profile_controller.go
+++ b/pkg/controller/profile_controller.go
@@ -6,12 +6,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,14 +111,18 @@ type ProfileReconciler struct {
 	WatchNamespace string
 }
 
-//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles,verbs=get;list;watch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles/finalizers,verbs=update
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releasebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases/finalizers,verbs=update
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=referencegrants,verbs=get;list;watch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile evaluates the Profile's TargetSelector and ensures matching ReleaseBindings exist.
+// It also manages a deletion-protection finalizer on the referenced Release.
 func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -134,6 +140,94 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Profile")
+	}
+
+	// Handle deletion.
+	if !profile.DeletionTimestamp.IsZero() {
+		// Block until all owned ReleaseBindings are fully gone from the API before unprotecting
+		// the Release. This ensures the Release is never deletable while bindings still reference it.
+		// The Owns() watch in SetupWithManager re-triggers this reconcile when each binding is removed.
+		allBindings := &solarv1alpha1.ReleaseBindingList{}
+		if err := r.List(ctx, allBindings, client.InNamespace(profile.Namespace)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to list owned ReleaseBindings for deletion")
+		}
+		ownedBindings := &solarv1alpha1.ReleaseBindingList{}
+		for i := range allBindings.Items {
+			if metav1.IsControlledBy(&allBindings.Items[i], profile) {
+				ownedBindings.Items = append(ownedBindings.Items, allBindings.Items[i])
+			}
+		}
+
+		var ownedExist bool
+		for i := range ownedBindings.Items {
+			rb := &ownedBindings.Items[i]
+			ownedExist = true
+			if rb.DeletionTimestamp.IsZero() {
+				if err := r.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to delete owned ReleaseBinding during Profile deletion")
+				}
+			}
+		}
+		if ownedExist {
+			// Re-triggered by Owns() watch when the last binding is fully removed.
+			return ctrl.Result{}, nil
+		}
+
+		if profile.Spec.ReleaseRef.Name != "" {
+			release := &solarv1alpha1.Release{}
+			if err := r.Get(ctx, types.NamespacedName{Name: profile.Spec.ReleaseRef.Name, Namespace: profile.Namespace}, release); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Release for finalizer cleanup")
+				}
+			} else if err := r.removeReleaseRefFinalizerIfUnreferenced(ctx, profile, release); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		if slices.Contains(profile.Finalizers, profileFinalizer) {
+			latest := &solarv1alpha1.Profile{}
+			if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest Profile for finalizer removal")
+			}
+			original := latest.DeepCopy()
+			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool { return s == profileFinalizer })
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to remove finalizer from Profile")
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure self-finalizer exists.
+	if !slices.Contains(profile.Finalizers, profileFinalizer) {
+		latest := &solarv1alpha1.Profile{}
+		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest Profile for finalizer addition")
+		}
+		original := latest.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, profileFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Profile")
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Protect the referenced Release from deletion.
+	if profile.Spec.ReleaseRef.Name != "" {
+		release := &solarv1alpha1.Release{}
+		if err := r.Get(ctx, types.NamespacedName{Name: profile.Spec.ReleaseRef.Name, Namespace: profile.Namespace}, release); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Release for protection finalizer")
+			}
+		} else if !slices.Contains(release.Finalizers, releaseRefFinalizer) {
+			latest := release.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, releaseRefFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(release)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
+			}
+		}
 	}
 
 	// Evaluate TargetSelector against all Targets
@@ -195,23 +289,14 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// List existing ReleaseBindings owned by this Profile
+	allBindings := &solarv1alpha1.ReleaseBindingList{}
+	if err := r.List(ctx, allBindings, client.InNamespace(profile.Namespace)); err != nil {
+		return ctrl.Result{}, errLogAndWrap(log, err, "failed to list ReleaseBindings")
+	}
 	existingBindings := &solarv1alpha1.ReleaseBindingList{}
-	if err := r.List(ctx, existingBindings,
-		client.InNamespace(profile.Namespace),
-		client.MatchingFields{"metadata.ownerReferences.name": profile.Name},
-	); err != nil {
-		// Field index may not be available; fall back to listing all and filtering
-		allBindings := &solarv1alpha1.ReleaseBindingList{}
-		if err := r.List(ctx, allBindings, client.InNamespace(profile.Namespace)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to list ReleaseBindings")
-		}
-
-		existingBindings = &solarv1alpha1.ReleaseBindingList{}
-
-		for i := range allBindings.Items {
-			if metav1.IsControlledBy(&allBindings.Items[i], profile) {
-				existingBindings.Items = append(existingBindings.Items, allBindings.Items[i])
-			}
+	for i := range allBindings.Items {
+		if metav1.IsControlledBy(&allBindings.Items[i], profile) {
+			existingBindings.Items = append(existingBindings.Items, allBindings.Items[i])
 		}
 	}
 
@@ -407,4 +492,84 @@ func (r *ProfileReconciler) mapReferenceGrantToProfiles(ctx context.Context, obj
 	}
 
 	return requests
+}
+
+// removeReleaseRefFinalizerIfUnreferenced removes releaseRefFinalizer from release when no active
+// Profile or ReleaseBinding (excluding the deleting Profile and its owned ReleaseBindings) still
+// references it.
+func (r *ProfileReconciler) removeReleaseRefFinalizerIfUnreferenced(ctx context.Context, deletingProfile *solarv1alpha1.Profile, release *solarv1alpha1.Release) error {
+	if !slices.Contains(release.Finalizers, releaseRefFinalizer) {
+		return nil
+	}
+
+	// Count Profiles (excluding self) referencing this Release.
+	profileList := &solarv1alpha1.ProfileList{}
+	if err := r.List(ctx, profileList,
+		client.InNamespace(release.Namespace),
+		client.MatchingFields{indexProfileByReleaseName: release.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list Profiles for Release finalizer check")
+	}
+
+	for _, p := range profileList.Items {
+		if p.Name == deletingProfile.Name {
+			continue
+		}
+		if !p.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		return nil
+	}
+
+	// Count ReleaseBindings (excluding those owned by the deleting Profile) referencing this Release.
+	bindingList := &solarv1alpha1.ReleaseBindingList{}
+	if err := r.List(ctx, bindingList,
+		client.InNamespace(release.Namespace),
+		client.MatchingFields{indexReleaseBindingReleaseName: release.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list ReleaseBindings for Release finalizer check")
+	}
+
+	for _, rb := range bindingList.Items {
+		if metav1.IsControlledBy(&rb, deletingProfile) {
+			continue // owned by the Profile being deleted; K8s GC will remove these
+		}
+		if !rb.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		// Check if this binding's owner Profile is also being deleted (concurrent deletion).
+		ownerRef := metav1.GetControllerOf(&rb)
+		if ownerRef != nil && ownerRef.Kind == "Profile" && ownerRef.APIVersion == solarv1alpha1.SchemeGroupVersion.String() {
+			ownerProfile := &solarv1alpha1.Profile{}
+			err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: rb.Namespace}, ownerProfile)
+			if apierrors.IsNotFound(err) || (err == nil && !ownerProfile.DeletionTimestamp.IsZero()) {
+				continue // owner Profile is gone or being deleted, this binding will be GC'd
+			}
+			if err != nil {
+				return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to check owner Profile for concurrent deletion")
+			}
+		}
+
+		return nil
+	}
+
+	freshRelease := &solarv1alpha1.Release{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(release), freshRelease); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to get latest Release for finalizer removal")
+	}
+	original := freshRelease.DeepCopy()
+	freshRelease.Finalizers = slices.DeleteFunc(freshRelease.Finalizers, func(s string) bool { return s == releaseRefFinalizer })
+	if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Release")
+	}
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Removed protection finalizer from Release", "release", release.Name)
+
+	return nil
 }

--- a/pkg/controller/profile_controller.go
+++ b/pkg/controller/profile_controller.go
@@ -210,8 +210,6 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Profile")
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// Protect the referenced Release from deletion.

--- a/pkg/controller/profile_controller.go
+++ b/pkg/controller/profile_controller.go
@@ -205,10 +205,12 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest Profile for finalizer addition")
 		}
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, profileFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Profile")
+		if !slices.Contains(latest.Finalizers, profileFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, profileFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Profile")
+			}
 		}
 	}
 

--- a/pkg/controller/profile_controller_test.go
+++ b/pkg/controller/profile_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -240,9 +241,10 @@ var _ = Describe("ProfileReconciler", Ordered, func() {
 			// then removes profileFinalizer, unblocking Release deletion.
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, profile))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{})
+				return apierrors.IsNotFound(err)
+			}, eventuallyTimeout).Should(BeTrue())
 		})
 
 		It("removes releaseRefFinalizer from Release when the last Profile is deleted", func() {
@@ -357,9 +359,10 @@ var _ = Describe("ProfileReconciler", Ordered, func() {
 			Expect(k8sClient.Patch(ctx, bindingWithoutBlocker, client.MergeFrom(bindingDeleting))).To(Succeed())
 
 			// Profile must eventually complete deletion (fully removed from API).
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{})
+				return apierrors.IsNotFound(err)
+			}, eventuallyTimeout).Should(BeTrue())
 
 			// Release must eventually be unprotected.
 			Eventually(func(g Gomega) {

--- a/pkg/controller/profile_controller_test.go
+++ b/pkg/controller/profile_controller_test.go
@@ -4,8 +4,11 @@
 package controller
 
 import (
+	"slices"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -161,6 +164,209 @@ var _ = Describe("ProfileReconciler", Ordered, func() {
 			Expect(bindings[0].OwnerReferences[0].Name).To(Equal("profile-gc"))
 			Expect(bindings[0].OwnerReferences[0].Kind).To(Equal("Profile"))
 			Expect(*bindings[0].OwnerReferences[0].Controller).To(BeTrue())
+		})
+	})
+
+	Describe("deletion protection for Release", func() {
+		var (
+			validRelease = func(name string) *solarv1alpha1.Release {
+				return &solarv1alpha1.Release{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: ns.Name,
+					},
+					Spec: solarv1alpha1.ReleaseSpec{
+						ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
+						UniqueName:          name,
+					},
+				}
+			}
+		)
+
+		It("adds profileFinalizer to Profile and releaseRefFinalizer to Release", func() {
+			release := validRelease("dp-prof-release-fin")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			profile := newProfile("dp-profile-fin", map[string]string{"env": "dp-test"})
+			profile.Spec.ReleaseRef.Name = release.Name
+			Expect(k8sClient.Create(ctx, profile)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, profile, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, profile))
+			})
+
+			Eventually(func(g Gomega) {
+				updatedProfile := &solarv1alpha1.Profile{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), updatedProfile)).To(Succeed())
+				g.Expect(updatedProfile.Finalizers).To(ContainElement(profileFinalizer))
+
+				updatedRelease := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updatedRelease)).To(Succeed())
+				g.Expect(updatedRelease.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks Release deletion while a Profile references it", func() {
+			release := validRelease("dp-prof-release-blocked")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			profile := newProfile("dp-profile-blocks-release", map[string]string{"env": "dp-blocked"})
+			profile.Spec.ReleaseRef.Name = release.Name
+			Expect(k8sClient.Create(ctx, profile)).To(Succeed())
+
+			// Wait for protection finalizer on Release.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete Release — it should be blocked.
+			Expect(k8sClient.Delete(ctx, release)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, consistentlyDuration).Should(Succeed())
+
+			// Delete Profile — controller removes releaseRefFinalizer from Release,
+			// then removes profileFinalizer, unblocking Release deletion.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, profile))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{}))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("removes releaseRefFinalizer from Release when the last Profile is deleted", func() {
+			release := validRelease("dp-prof-release-unprotect")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			profile := newProfile("dp-profile-last", map[string]string{"env": "dp-last"})
+			profile.Spec.ReleaseRef.Name = release.Name
+			Expect(k8sClient.Create(ctx, profile)).To(Succeed())
+
+			// Wait for protection finalizer.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete the Profile — the controller's deletion handler removes releaseRefFinalizer
+			// from Release (no other references), then removes profileFinalizer.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, profile))).To(Succeed())
+
+			// releaseRefFinalizer should be removed from Release.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks Profile deletion until owned ReleaseBinding is fully removed from API", func() {
+			// The Profile controller must keep profile-finalizer (stay blocked) until every owned
+			// ReleaseBinding is completely gone from the API. While any binding still exists, the
+			// Release must also remain protected. We use a test-only blocker finalizer on the binding
+			// to hold it in the deleting state and assert both invariants for the full Consistently
+			// window before releasing control.
+			release := validRelease("dp-prof-gc-window-release")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			target := newTarget("dp-prof-gc-window-target", map[string]string{"env": "dp-gc-window"})
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+			DeferCleanup(func() { _ = client.IgnoreNotFound(k8sClient.Delete(ctx, target)) })
+
+			profile := newProfile("dp-prof-gc-window", map[string]string{"env": "dp-gc-window"})
+			profile.Spec.ReleaseRef.Name = release.Name
+			Expect(k8sClient.Create(ctx, profile)).To(Succeed())
+
+			// Wait for the owned ReleaseBinding and release-ref to be established.
+			var bindingKey types.NamespacedName
+			Eventually(func(g Gomega) {
+				bindings := listOwnedBindings(profile.Name)
+				g.Expect(bindings).To(HaveLen(1))
+				bindingKey = client.ObjectKeyFromObject(&bindings[0])
+
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Add a test-only blocker finalizer to hold the binding in deleting state.
+			// This lets us assert profile and release invariants during the blocked window.
+			const testBlocker = "test.solar/blocker"
+			binding := &solarv1alpha1.ReleaseBinding{}
+			Expect(k8sClient.Get(ctx, bindingKey, binding)).To(Succeed())
+			blockerAdded := binding.DeepCopy()
+			blockerAdded.Finalizers = append(blockerAdded.Finalizers, testBlocker)
+			Expect(k8sClient.Patch(ctx, blockerAdded, client.MergeFrom(binding))).To(Succeed())
+			DeferCleanup(func() {
+				wipeFinalizers := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, blockerAdded, wipeFinalizers))
+			})
+
+			// Delete the Profile.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, profile))).To(Succeed())
+
+			// Wait for Profile to enter deletion (DeletionTimestamp set).
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Profile{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, eventuallyTimeout).Should(Succeed())
+
+			// For the full Consistently window: Profile must stay blocked (profile-finalizer present)
+			// and Release must remain protected (release-ref present) while binding is alive.
+			Consistently(func(g Gomega) {
+				updatedProfile := &solarv1alpha1.Profile{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), updatedProfile)).To(Succeed())
+				g.Expect(updatedProfile.Finalizers).To(ContainElement(profileFinalizer),
+					"Profile must keep profile-finalizer while owned ReleaseBinding still exists")
+
+				updatedRelease := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updatedRelease)).To(Succeed())
+				g.Expect(updatedRelease.Finalizers).To(ContainElement(releaseRefFinalizer),
+					"Release must keep release-ref while owned ReleaseBinding still exists")
+			}, consistentlyDuration).Should(Succeed())
+
+			// Remove the blocker — binding is now fully deleted.
+			bindingDeleting := &solarv1alpha1.ReleaseBinding{}
+			Expect(k8sClient.Get(ctx, bindingKey, bindingDeleting)).To(Succeed())
+			bindingWithoutBlocker := bindingDeleting.DeepCopy()
+			bindingWithoutBlocker.Finalizers = slices.DeleteFunc(bindingWithoutBlocker.Finalizers,
+				func(s string) bool { return s == testBlocker })
+			Expect(k8sClient.Patch(ctx, bindingWithoutBlocker, client.MergeFrom(bindingDeleting))).To(Succeed())
+
+			// Profile must eventually complete deletion (fully removed from API).
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{}))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Release must eventually be unprotected.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
 		})
 	})
 

--- a/pkg/controller/registrybinding_controller.go
+++ b/pkg/controller/registrybinding_controller.go
@@ -1,0 +1,126 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+// RegistryBindingReconciler manages the deletion-protection finalizer on the Registry referenced
+// by each RegistryBinding, preventing Registry deletion while RegistryBindings exist.
+type RegistryBindingReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// WatchNamespace restricts reconciliation to this namespace.
+	// Should be empty in production (watches all namespaces).
+	// Intended for use in integration tests only.
+	WatchNamespace string
+}
+
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registrybindings,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registrybindings/finalizers,verbs=update
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registries,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registries/finalizers,verbs=update
+
+func (r *RegistryBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	log.V(1).Info("RegistryBinding is being reconciled", "req", req)
+
+	if r.WatchNamespace != "" && req.Namespace != r.WatchNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	rb := &solarv1alpha1.RegistryBinding{}
+	if err := r.Get(ctx, req.NamespacedName, rb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, errLogAndWrap(log, err, "failed to get RegistryBinding")
+	}
+
+	// Handle deletion: remove registryRefFinalizer from Registry if no other active referencer exists.
+	if !rb.DeletionTimestamp.IsZero() {
+		if rb.Spec.RegistryRef.Name != "" {
+			registry := &solarv1alpha1.Registry{}
+			if err := r.Get(ctx, types.NamespacedName{Name: rb.Spec.RegistryRef.Name, Namespace: rb.Namespace}, registry); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Registry for finalizer cleanup")
+				}
+			} else if err := r.removeRegistryRefFinalizer(ctx, rb, registry); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		if slices.Contains(rb.Finalizers, registryBindingFinalizer) {
+			latest := &solarv1alpha1.RegistryBinding{}
+			if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest RegistryBinding for finalizer removal")
+			}
+			original := latest.DeepCopy()
+			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool { return s == registryBindingFinalizer })
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to remove finalizer from RegistryBinding")
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure self-finalizer exists.
+	if !slices.Contains(rb.Finalizers, registryBindingFinalizer) {
+		latest := &solarv1alpha1.RegistryBinding{}
+		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest RegistryBinding for finalizer addition")
+		}
+		original := latest.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, registryBindingFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to RegistryBinding")
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Protect the referenced Registry from deletion.
+	if rb.Spec.RegistryRef.Name != "" {
+		registry := &solarv1alpha1.Registry{}
+		if err := r.Get(ctx, types.NamespacedName{Name: rb.Spec.RegistryRef.Name, Namespace: rb.Namespace}, registry); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Registry for protection finalizer")
+			}
+		} else if !slices.Contains(registry.Finalizers, registryRefFinalizer) {
+			latest := registry.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, registryRefFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(registry)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Registry")
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// removeRegistryRefFinalizer removes registryRefFinalizer from registry when no other active
+// Target or RegistryBinding (excluding the deleting RegistryBinding) still references it.
+func (r *RegistryBindingReconciler) removeRegistryRefFinalizer(ctx context.Context, deletingRB *solarv1alpha1.RegistryBinding, registry *solarv1alpha1.Registry) error {
+	return removeRegistryRefFinalizer(ctx, r.Client, nil, deletingRB, registry)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RegistryBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&solarv1alpha1.RegistryBinding{}).
+		Complete(r)
+}

--- a/pkg/controller/registrybinding_controller.go
+++ b/pkg/controller/registrybinding_controller.go
@@ -84,10 +84,12 @@ func (r *RegistryBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest RegistryBinding for finalizer addition")
 		}
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, registryBindingFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to RegistryBinding")
+		if !slices.Contains(latest.Finalizers, registryBindingFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, registryBindingFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to RegistryBinding")
+			}
 		}
 	}
 

--- a/pkg/controller/registrybinding_controller.go
+++ b/pkg/controller/registrybinding_controller.go
@@ -89,8 +89,6 @@ func (r *RegistryBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to RegistryBinding")
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// Protect the referenced Registry from deletion.

--- a/pkg/controller/registrybinding_controller.go
+++ b/pkg/controller/registrybinding_controller.go
@@ -103,7 +103,7 @@ func (r *RegistryBindingReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		} else if !slices.Contains(registry.Finalizers, registryRefFinalizer) {
 			latest := registry.DeepCopy()
 			latest.Finalizers = append(latest.Finalizers, registryRefFinalizer)
-			if err := r.Patch(ctx, latest, client.MergeFrom(registry)); err != nil {
+			if err := r.Patch(ctx, latest, client.MergeFromWithOptions(registry, client.MergeFromWithOptimisticLock{})); err != nil {
 				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Registry")
 			}
 		}

--- a/pkg/controller/registrybinding_controller_test.go
+++ b/pkg/controller/registrybinding_controller_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RegistryBindingReconciler", Ordered, func() {
+	var (
+		validRegistry = func(name string) *solarv1alpha1.Registry {
+			return &solarv1alpha1.Registry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.RegistrySpec{
+					Hostname: "registry.example.com",
+				},
+			}
+		}
+
+		validRegistryBinding = func(name string, registryName string) *solarv1alpha1.RegistryBinding {
+			return &solarv1alpha1.RegistryBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.RegistryBindingSpec{
+					TargetRef:   corev1.LocalObjectReference{Name: "my-target"},
+					RegistryRef: corev1.LocalObjectReference{Name: registryName},
+				},
+			}
+		}
+	)
+
+	Describe("protection finalizer on Registry", func() {
+		It("adds registryBindingFinalizer to RegistryBinding and registryRefFinalizer to Registry", func() {
+			registry := validRegistry("dp-regb-registry-fin")
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, registry, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, registry))
+			})
+
+			rb := validRegistryBinding("dp-regb-fin", registry.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb))
+			})
+
+			Eventually(func(g Gomega) {
+				updatedRB := &solarv1alpha1.RegistryBinding{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb), updatedRB)).To(Succeed())
+				g.Expect(updatedRB.Finalizers).To(ContainElement(registryBindingFinalizer))
+
+				updatedRegistry := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updatedRegistry)).To(Succeed())
+				g.Expect(updatedRegistry.Finalizers).To(ContainElement(registryRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks Registry deletion while a RegistryBinding references it", func() {
+			registry := validRegistry("dp-regb-registry-blocked")
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+
+			rb := validRegistryBinding("dp-regb-blocks-registry", registry.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+
+			// Wait for protection finalizer on Registry.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(registryRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete Registry — it should be blocked.
+			Expect(k8sClient.Delete(ctx, registry)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, consistentlyDuration).Should(Succeed())
+
+			// Delete RegistryBinding — controller removes registryRefFinalizer from Registry,
+			// then removes registryBindingFinalizer, unblocking Registry deletion.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rb))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), &solarv1alpha1.Registry{}))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("removes registryRefFinalizer from Registry when last RegistryBinding is deleted", func() {
+			registry := validRegistry("dp-regb-registry-unprotect")
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, registry, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, registry))
+			})
+
+			rb := validRegistryBinding("dp-regb-last", registry.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+
+			// Wait for protection finalizer.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(registryRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete the RegistryBinding — the controller's deletion handler will call
+			// removeRegistryRefFinalizer (no other references) then remove registryBindingFinalizer.
+			Expect(k8sClient.Delete(ctx, rb)).To(Succeed())
+
+			// registryRefFinalizer should be removed from Registry.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(registryRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("retains registryRefFinalizer when a second RegistryBinding still references the Registry", func() {
+			registry := validRegistry("dp-reg-multi")
+			Expect(k8sClient.Create(ctx, registry)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, registry, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, registry))
+			})
+
+			rb1 := validRegistryBinding("dp-regb-multi-1", registry.Name)
+			Expect(k8sClient.Create(ctx, rb1)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb1, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb1))
+			})
+
+			rb2 := validRegistryBinding("dp-regb-multi-2", registry.Name)
+			Expect(k8sClient.Create(ctx, rb2)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb2, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb2))
+			})
+
+			// Wait for the protection finalizer to be established.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(registryRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete rb1 — rb2 still holds the reference, so registry-ref must stay.
+			Expect(k8sClient.Delete(ctx, rb1)).To(Succeed())
+
+			// Wait for rb1 to be fully gone from the API.
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.RegistryBinding{}))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// registry-ref must remain because rb2 still references the Registry.
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Registry{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(registryRefFinalizer))
+			}, consistentlyDuration).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/registrybinding_controller_test.go
+++ b/pkg/controller/registrybinding_controller_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,9 +100,9 @@ var _ = Describe("RegistryBindingReconciler", Ordered, func() {
 			// then removes registryBindingFinalizer, unblocking Registry deletion.
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rb))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), &solarv1alpha1.Registry{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(registry), &solarv1alpha1.Registry{}))
+			}, eventuallyTimeout).Should(BeTrue())
 		})
 
 		It("removes registryRefFinalizer from Registry when last RegistryBinding is deleted", func() {
@@ -171,9 +172,9 @@ var _ = Describe("RegistryBindingReconciler", Ordered, func() {
 			Expect(k8sClient.Delete(ctx, rb1)).To(Succeed())
 
 			// Wait for rb1 to be fully gone from the API.
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.RegistryBinding{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.RegistryBinding{}))
+			}, eventuallyTimeout).Should(BeTrue())
 
 			// registry-ref must remain because rb2 still references the Registry.
 			Consistently(func(g Gomega) {

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -108,10 +108,12 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to get latest Release for finalizer addition")
 		}
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, releaseFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrlResult, errLogAndWrap(log, err, "failed to add finalizer to Release")
+		if !slices.Contains(latest.Finalizers, releaseFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, releaseFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrlResult, errLogAndWrap(log, err, "failed to add finalizer to Release")
+			}
 		}
 	}
 

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -113,8 +113,6 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
 			return ctrlResult, errLogAndWrap(log, err, "failed to add finalizer to Release")
 		}
-
-		return ctrlResult, nil
 	}
 
 	cvNamespace := res.Namespace

--- a/pkg/controller/release_controller.go
+++ b/pkg/controller/release_controller.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -40,11 +41,14 @@ type ReleaseReconciler struct {
 
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions,verbs=get;list;watch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=componentversions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=referencegrants,verbs=get;list;watch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
-// Reconcile validates the Release by resolving its ComponentVersion reference.
+// Reconcile validates the Release by resolving its ComponentVersion reference and
+// manages deletion-protection finalizers on that ComponentVersion.
 func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	ctrlResult := ctrl.Result{}
@@ -63,6 +67,54 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 
 		return ctrlResult, errLogAndWrap(log, err, "failed to get object")
+	}
+
+	// Handle deletion: remove componentVersionRefFinalizer from CV if no other Release references it.
+	if !res.DeletionTimestamp.IsZero() {
+		cvNamespace := res.Namespace
+		if res.Spec.ComponentVersionNamespace != "" {
+			cvNamespace = res.Spec.ComponentVersionNamespace
+		}
+
+		if res.Spec.ComponentVersionRef.Name != "" {
+			cv := &solarv1alpha1.ComponentVersion{}
+			if err := r.Get(ctx, types.NamespacedName{Name: res.Spec.ComponentVersionRef.Name, Namespace: cvNamespace}, cv); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrlResult, errLogAndWrap(log, err, "failed to get ComponentVersion for finalizer cleanup")
+				}
+			} else if err := r.removeComponentVersionRefFinalizer(ctx, res, cv); err != nil {
+				return ctrlResult, err
+			}
+		}
+
+		if slices.Contains(res.Finalizers, releaseFinalizer) {
+			latest := &solarv1alpha1.Release{}
+			if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+				return ctrlResult, errLogAndWrap(log, err, "failed to get latest Release for finalizer removal")
+			}
+			original := latest.DeepCopy()
+			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool { return s == releaseFinalizer })
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrlResult, errLogAndWrap(log, err, "failed to remove finalizer from Release")
+			}
+		}
+
+		return ctrlResult, nil
+	}
+
+	// Ensure self-finalizer exists before any other work.
+	if !slices.Contains(res.Finalizers, releaseFinalizer) {
+		latest := &solarv1alpha1.Release{}
+		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+			return ctrlResult, errLogAndWrap(log, err, "failed to get latest Release for finalizer addition")
+		}
+		original := latest.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, releaseFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+			return ctrlResult, errLogAndWrap(log, err, "failed to add finalizer to Release")
+		}
+
+		return ctrlResult, nil
 	}
 
 	cvNamespace := res.Namespace
@@ -121,6 +173,15 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrlResult, errLogAndWrap(log, err, "failed to get ComponentVersion")
 	}
 
+	// Protect ComponentVersion from deletion while this Release references it.
+	if !slices.Contains(cv.Finalizers, componentVersionRefFinalizer) {
+		latest := cv.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, componentVersionRefFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(cv)); err != nil {
+			return ctrlResult, errLogAndWrap(log, err, "failed to add protection finalizer to ComponentVersion")
+		}
+	}
+
 	// ComponentVersion found — set resolved condition and effective unique name.
 	uname := effectiveUniqueName(res, cv)
 
@@ -140,6 +201,49 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	return ctrlResult, nil
+}
+
+// removeComponentVersionRefFinalizer removes componentVersionRefFinalizer from cv when no other
+// active Release still references it (excluding the Release that is currently being deleted).
+func (r *ReleaseReconciler) removeComponentVersionRefFinalizer(ctx context.Context, deletingRelease *solarv1alpha1.Release, cv *solarv1alpha1.ComponentVersion) error {
+	if !slices.Contains(cv.Finalizers, componentVersionRefFinalizer) {
+		return nil
+	}
+
+	refKey := cv.Namespace + "/" + cv.Name
+	releaseList := &solarv1alpha1.ReleaseList{}
+	if err := r.List(ctx, releaseList, client.MatchingFields{indexReleaseByCVRef: refKey}); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list Releases for ComponentVersion finalizer check")
+	}
+
+	for _, rel := range releaseList.Items {
+		if rel.Name == deletingRelease.Name && rel.Namespace == deletingRelease.Namespace {
+			continue
+		}
+		if !rel.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		return nil // another active Release still references this ComponentVersion
+	}
+
+	freshCV := &solarv1alpha1.ComponentVersion{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(cv), freshCV); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to get latest ComponentVersion for finalizer removal")
+	}
+	original := freshCV.DeepCopy()
+	freshCV.Finalizers = slices.DeleteFunc(freshCV.Finalizers, func(s string) bool { return s == componentVersionRefFinalizer })
+	if err := r.Patch(ctx, freshCV, client.MergeFrom(original)); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from ComponentVersion")
+	}
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Removed protection finalizer from ComponentVersion", "componentversion", cv.Name)
+
+	return nil
 }
 
 // componentVersionGranted returns true if a ReferenceGrant in cvNamespace permits
@@ -177,25 +281,17 @@ func (r *ReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *ReleaseReconciler) mapComponentVersionToReleases(ctx context.Context, obj client.Object) []reconcile.Request {
 	log := ctrl.LoggerFrom(ctx)
 
+	refKey := obj.GetNamespace() + "/" + obj.GetName()
 	releaseList := &solarv1alpha1.ReleaseList{}
-	if err := r.List(ctx, releaseList); err != nil {
+	if err := r.List(ctx, releaseList, client.MatchingFields{indexReleaseByCVRef: refKey}); err != nil {
 		log.Error(err, "failed to list Releases for ComponentVersion mapping")
 
 		return nil
 	}
 
-	var requests []reconcile.Request
-
-	for _, rel := range releaseList.Items {
-		cvNs := rel.Namespace
-		if rel.Spec.ComponentVersionNamespace != "" {
-			cvNs = rel.Spec.ComponentVersionNamespace
-		}
-		if rel.Spec.ComponentVersionRef.Name == obj.GetName() && cvNs == obj.GetNamespace() {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: client.ObjectKeyFromObject(&rel),
-			})
-		}
+	requests := make([]reconcile.Request, len(releaseList.Items))
+	for i := range releaseList.Items {
+		requests[i] = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&releaseList.Items[i])}
 	}
 
 	return requests

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -8,6 +8,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
@@ -196,7 +197,7 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 			release.Spec.ComponentVersionRef.Name = "shared-cv"
 			release.Spec.ComponentVersionNamespace = catalogNs.Name
 			Expect(k8sClient.Create(ctx, release)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, release)
+			DeferCleanup(func() { _ = client.IgnoreNotFound(k8sClient.Delete(ctx, release)) })
 
 			updatedRelease := &solarv1alpha1.Release{}
 			Eventually(func(g Gomega) {
@@ -210,7 +211,7 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 			release.Spec.ComponentVersionRef.Name = "shared-cv"
 			release.Spec.ComponentVersionNamespace = catalogNs.Name
 			Expect(k8sClient.Create(ctx, release)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, release)
+			DeferCleanup(func() { _ = client.IgnoreNotFound(k8sClient.Delete(ctx, release)) })
 
 			updatedRelease := &solarv1alpha1.Release{}
 			Eventually(func(g Gomega) {
@@ -243,7 +244,7 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 			release.Spec.ComponentVersionRef.Name = "shared-cv"
 			release.Spec.ComponentVersionNamespace = catalogNs.Name
 			Expect(k8sClient.Create(ctx, release)).To(Succeed())
-			DeferCleanup(k8sClient.Delete, ctx, release)
+			DeferCleanup(func() { _ = client.IgnoreNotFound(k8sClient.Delete(ctx, release)) })
 
 			// Wait for Resolved=True
 			updatedRelease := &solarv1alpha1.Release{}
@@ -262,6 +263,100 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(cond.Reason).To(Equal("NotGranted"))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+	})
+
+	Describe("deletion protection for ComponentVersion", func() {
+		It("adds releaseFinalizer to Release and componentVersionRefFinalizer to ComponentVersion", func() {
+			cv := validComponentVersion("dp-cv-fin", ns)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, cv, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, cv))
+			})
+
+			release := validRelease("dp-release-fin", ns)
+			release.Spec.ComponentVersionRef.Name = cv.Name
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			Eventually(func(g Gomega) {
+				updatedRelease := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updatedRelease)).To(Succeed())
+				g.Expect(updatedRelease.Finalizers).To(ContainElement(releaseFinalizer))
+
+				updatedCV := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updatedCV)).To(Succeed())
+				g.Expect(updatedCV.Finalizers).To(ContainElement(componentVersionRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks ComponentVersion deletion while a Release references it", func() {
+			cv := validComponentVersion("dp-cv-blocked", ns)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+
+			release := validRelease("dp-release-blocks-cv", ns)
+			release.Spec.ComponentVersionRef.Name = cv.Name
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			// Wait for protection finalizer on CV.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentVersionRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Try to delete the ComponentVersion — it should be blocked.
+			Expect(k8sClient.Delete(ctx, cv)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, consistentlyDuration).Should(Succeed())
+
+			// Delete the Release — controller removes componentVersionRefFinalizer from CV,
+			// then removes releaseFinalizer, unblocking CV deletion.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, release))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), &solarv1alpha1.ComponentVersion{}))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("removes componentVersionRefFinalizer when the last Release is deleted", func() {
+			cv := validComponentVersion("dp-cv-unprotect", ns)
+			Expect(k8sClient.Create(ctx, cv)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, cv, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, cv))
+			})
+
+			release := validRelease("dp-release-last", ns)
+			release.Spec.ComponentVersionRef.Name = cv.Name
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(componentVersionRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete the Release — the controller's deletion handler removes componentVersionRefFinalizer
+			// from CV (no other references), then removes releaseFinalizer.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, release))).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.ComponentVersion{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(componentVersionRefFinalizer))
 			}, eventuallyTimeout).Should(Succeed())
 		})
 	})

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -325,9 +326,9 @@ var _ = Describe("ReleaseReconciler", Ordered, func() {
 			// then removes releaseFinalizer, unblocking CV deletion.
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, release))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), &solarv1alpha1.ComponentVersion{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(cv), &solarv1alpha1.ComponentVersion{}))
+			}, eventuallyTimeout).Should(BeTrue())
 		})
 
 		It("removes componentVersionRefFinalizer when the last Release is deleted", func() {

--- a/pkg/controller/releasebinding_controller.go
+++ b/pkg/controller/releasebinding_controller.go
@@ -106,8 +106,6 @@ func (r *ReleaseBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ReleaseBinding")
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	// Protect the referenced Release from deletion.

--- a/pkg/controller/releasebinding_controller.go
+++ b/pkg/controller/releasebinding_controller.go
@@ -101,10 +101,12 @@ func (r *ReleaseBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ReleaseBinding for finalizer addition")
 		}
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, releaseBindingFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ReleaseBinding")
+		if !slices.Contains(latest.Finalizers, releaseBindingFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, releaseBindingFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ReleaseBinding")
+			}
 		}
 	}
 
@@ -129,10 +131,20 @@ func (r *ReleaseBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					return ctrl.Result{}, errLogAndWrap(log, err, "failed to check owner Profile for deletion status")
 				}
 			}
-			latest := release.DeepCopy()
-			latest.Finalizers = append(latest.Finalizers, releaseRefFinalizer)
-			if err := r.Patch(ctx, latest, client.MergeFrom(release)); err != nil {
-				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
+			freshRelease := &solarv1alpha1.Release{}
+			if err := r.Get(ctx, types.NamespacedName{Name: rb.Spec.ReleaseRef.Name, Namespace: rb.Namespace}, freshRelease); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest Release for finalizer addition")
+				}
+
+				return ctrl.Result{}, nil
+			}
+			if !slices.Contains(freshRelease.Finalizers, releaseRefFinalizer) {
+				original := freshRelease.DeepCopy()
+				freshRelease.Finalizers = append(freshRelease.Finalizers, releaseRefFinalizer)
+				if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
+				}
 			}
 		}
 	}

--- a/pkg/controller/releasebinding_controller.go
+++ b/pkg/controller/releasebinding_controller.go
@@ -142,7 +142,7 @@ func (r *ReleaseBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if !slices.Contains(freshRelease.Finalizers, releaseRefFinalizer) {
 				original := freshRelease.DeepCopy()
 				freshRelease.Finalizers = append(freshRelease.Finalizers, releaseRefFinalizer)
-				if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+				if err := r.Patch(ctx, freshRelease, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
 					return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
 				}
 			}
@@ -232,7 +232,7 @@ func (r *ReleaseBindingReconciler) removeReleaseRefFinalizer(ctx context.Context
 	}
 	original := freshRelease.DeepCopy()
 	freshRelease.Finalizers = slices.DeleteFunc(freshRelease.Finalizers, func(s string) bool { return s == releaseRefFinalizer })
-	if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+	if err := r.Patch(ctx, freshRelease, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
 		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Release")
 	}
 

--- a/pkg/controller/releasebinding_controller.go
+++ b/pkg/controller/releasebinding_controller.go
@@ -1,0 +1,239 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+// ReleaseBindingReconciler manages the deletion-protection finalizer on the Release referenced
+// by each ReleaseBinding. This covers both Profile-created and manually created ReleaseBindings.
+type ReleaseBindingReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	// WatchNamespace restricts reconciliation to this namespace.
+	// Should be empty in production (watches all namespaces).
+	// Intended for use in integration tests only.
+	WatchNamespace string
+}
+
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releasebindings,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releasebindings/finalizers,verbs=update
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=profiles,verbs=get;list;watch
+
+func (r *ReleaseBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	log.V(1).Info("ReleaseBinding is being reconciled", "req", req)
+
+	if r.WatchNamespace != "" && req.Namespace != r.WatchNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	rb := &solarv1alpha1.ReleaseBinding{}
+	if err := r.Get(ctx, req.NamespacedName, rb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, errLogAndWrap(log, err, "failed to get ReleaseBinding")
+	}
+
+	// Handle deletion: remove releaseRefFinalizer from Release if no other active referencer exists.
+	if !rb.DeletionTimestamp.IsZero() {
+		if rb.Spec.ReleaseRef.Name != "" {
+			// If owned by a Profile that is still managing cleanup (profileFinalizer present),
+			// defer release-ref removal to the Profile controller.
+			profileOwnerManaging := false
+			if ownerRef := metav1.GetControllerOf(rb); ownerRef != nil && ownerRef.Kind == "Profile" && ownerRef.APIVersion == solarv1alpha1.SchemeGroupVersion.String() {
+				ownerProfile := &solarv1alpha1.Profile{}
+				if err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: rb.Namespace}, ownerProfile); err != nil {
+					if !apierrors.IsNotFound(err) {
+						return ctrl.Result{}, errLogAndWrap(log, err, "failed to check owner Profile during ReleaseBinding deletion")
+					}
+				} else if slices.Contains(ownerProfile.Finalizers, profileFinalizer) {
+					profileOwnerManaging = true
+				}
+			}
+			if !profileOwnerManaging {
+				release := &solarv1alpha1.Release{}
+				if err := r.Get(ctx, types.NamespacedName{Name: rb.Spec.ReleaseRef.Name, Namespace: rb.Namespace}, release); err != nil {
+					if !apierrors.IsNotFound(err) {
+						return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Release for finalizer cleanup")
+					}
+				} else if err := r.removeReleaseRefFinalizer(ctx, rb, release); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+		}
+
+		if slices.Contains(rb.Finalizers, releaseBindingFinalizer) {
+			latest := &solarv1alpha1.ReleaseBinding{}
+			if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ReleaseBinding for finalizer removal")
+			}
+			original := latest.DeepCopy()
+			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool { return s == releaseBindingFinalizer })
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to remove finalizer from ReleaseBinding")
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure self-finalizer exists.
+	if !slices.Contains(rb.Finalizers, releaseBindingFinalizer) {
+		latest := &solarv1alpha1.ReleaseBinding{}
+		if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest ReleaseBinding for finalizer addition")
+		}
+		original := latest.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, releaseBindingFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to ReleaseBinding")
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	// Protect the referenced Release from deletion.
+	if rb.Spec.ReleaseRef.Name != "" {
+		release := &solarv1alpha1.Release{}
+		if err := r.Get(ctx, types.NamespacedName{Name: rb.Spec.ReleaseRef.Name, Namespace: rb.Namespace}, release); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Release for protection finalizer")
+			}
+		} else if !slices.Contains(release.Finalizers, releaseRefFinalizer) {
+			// If this ReleaseBinding is owned by a Profile that is gone or being deleted, skip
+			// adding the protection finalizer — the binding will be GC'd alongside the Profile,
+			// and the Profile controller already handled removal of releaseRefFinalizer.
+			if ownerRef := metav1.GetControllerOf(rb); ownerRef != nil && ownerRef.Kind == "Profile" && ownerRef.APIVersion == solarv1alpha1.SchemeGroupVersion.String() {
+				ownerProfile := &solarv1alpha1.Profile{}
+				err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: rb.Namespace}, ownerProfile)
+				if apierrors.IsNotFound(err) || (err == nil && !ownerProfile.DeletionTimestamp.IsZero()) {
+					return ctrl.Result{}, nil
+				}
+				if err != nil {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to check owner Profile for deletion status")
+				}
+			}
+			latest := release.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, releaseRefFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(release)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Release")
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// removeReleaseRefFinalizer removes releaseRefFinalizer from release when no other active
+// Profile or ReleaseBinding (excluding the deleting ReleaseBinding) still references it.
+func (r *ReleaseBindingReconciler) removeReleaseRefFinalizer(ctx context.Context, deletingRB *solarv1alpha1.ReleaseBinding, release *solarv1alpha1.Release) error {
+	if !slices.Contains(release.Finalizers, releaseRefFinalizer) {
+		return nil
+	}
+
+	// Count active Profiles in the same namespace referencing this Release.
+	profileList := &solarv1alpha1.ProfileList{}
+	if err := r.List(ctx, profileList,
+		client.InNamespace(release.Namespace),
+		client.MatchingFields{indexProfileByReleaseName: release.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list Profiles for Release finalizer check")
+	}
+
+	for _, p := range profileList.Items {
+		if !p.DeletionTimestamp.IsZero() {
+			// Profile is deleting. If profile-finalizer is still present, the Profile controller
+			// is managing cleanup and will remove release-ref once all owned bindings are gone.
+			if slices.Contains(p.Finalizers, profileFinalizer) {
+				return nil
+			}
+
+			continue
+		}
+
+		return nil
+	}
+
+	// Count active ReleaseBindings (excluding self and those owned by deleting Profiles) referencing this Release.
+	bindingList := &solarv1alpha1.ReleaseBindingList{}
+	if err := r.List(ctx, bindingList,
+		client.InNamespace(release.Namespace),
+		client.MatchingFields{indexReleaseBindingReleaseName: release.Name},
+	); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to list ReleaseBindings for Release finalizer check")
+	}
+
+	// Cache owner Profile lookups to avoid repeated Gets when bindings share the same owner.
+	ownerProfileCache := map[string]*solarv1alpha1.Profile{} // nil = gone or deleting
+	for _, rb := range bindingList.Items {
+		if rb.Name == deletingRB.Name || !rb.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		ownerRef := metav1.GetControllerOf(&rb)
+		if ownerRef == nil || ownerRef.Kind != "Profile" || ownerRef.APIVersion != solarv1alpha1.SchemeGroupVersion.String() {
+			return nil // active binding without a Profile owner → Release still referenced
+		}
+
+		cacheKey := rb.Namespace + "/" + ownerRef.Name
+		if _, seen := ownerProfileCache[cacheKey]; !seen {
+			op := &solarv1alpha1.Profile{}
+			err := r.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: rb.Namespace}, op)
+			switch {
+			case apierrors.IsNotFound(err) || (err == nil && !op.DeletionTimestamp.IsZero()):
+				ownerProfileCache[cacheKey] = nil // gone or deleting
+			case err != nil:
+				return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to check owner Profile for Release finalizer check")
+			default:
+				ownerProfileCache[cacheKey] = op
+			}
+		}
+
+		if ownerProfileCache[cacheKey] != nil {
+			return nil // binding is actively owned → Release still referenced
+		}
+	}
+
+	freshRelease := &solarv1alpha1.Release{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(release), freshRelease); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to get latest Release for finalizer removal")
+	}
+	original := freshRelease.DeepCopy()
+	freshRelease.Finalizers = slices.DeleteFunc(freshRelease.Finalizers, func(s string) bool { return s == releaseRefFinalizer })
+	if err := r.Patch(ctx, freshRelease, client.MergeFrom(original)); err != nil {
+		return errLogAndWrap(ctrl.LoggerFrom(ctx), err, "failed to remove protection finalizer from Release")
+	}
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Removed protection finalizer from Release", "release", release.Name)
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ReleaseBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&solarv1alpha1.ReleaseBinding{}).
+		Complete(r)
+}

--- a/pkg/controller/releasebinding_controller_test.go
+++ b/pkg/controller/releasebinding_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,9 +103,9 @@ var _ = Describe("ReleaseBindingReconciler", Ordered, func() {
 			// then removes releaseBindingFinalizer, unblocking Release deletion.
 			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rb))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{}))
+			}, eventuallyTimeout).Should(BeTrue())
 		})
 
 		It("removes releaseRefFinalizer from Release when last ReleaseBinding is deleted", func() {
@@ -174,9 +175,9 @@ var _ = Describe("ReleaseBindingReconciler", Ordered, func() {
 			Expect(k8sClient.Delete(ctx, rb1)).To(Succeed())
 
 			// Wait for rb1 to be fully gone from the API.
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.ReleaseBinding{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.ReleaseBinding{}))
+			}, eventuallyTimeout).Should(BeTrue())
 
 			// release-ref must remain because rb2 still references the Release.
 			Consistently(func(g Gomega) {
@@ -292,9 +293,9 @@ var _ = Describe("ReleaseBindingReconciler", Ordered, func() {
 				func(s string) bool { return s == testBlocker })
 			Expect(k8sClient.Patch(ctx, withoutBlocker, client.MergeFrom(bindingDeleting))).To(Succeed())
 
-			Eventually(func() error {
-				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{}))
-			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{}))
+			}, eventuallyTimeout).Should(BeTrue())
 			Eventually(func(g Gomega) {
 				updated := &solarv1alpha1.Release{}
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())

--- a/pkg/controller/releasebinding_controller_test.go
+++ b/pkg/controller/releasebinding_controller_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ReleaseBindingReconciler", Ordered, func() {
+	var (
+		validRelease = func(name string) *solarv1alpha1.Release {
+			return &solarv1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
+					UniqueName:          name,
+				},
+			}
+		}
+
+		validReleaseBinding = func(name string, releaseName string) *solarv1alpha1.ReleaseBinding {
+			return &solarv1alpha1.ReleaseBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.ReleaseBindingSpec{
+					TargetRef:  corev1.LocalObjectReference{Name: "my-target"},
+					ReleaseRef: corev1.LocalObjectReference{Name: releaseName},
+				},
+			}
+		}
+	)
+
+	Describe("protection finalizer on Release", func() {
+		It("adds releaseBindingFinalizer to ReleaseBinding and releaseRefFinalizer to Release", func() {
+			release := validRelease("dp-rb-release-fin")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			rb := validReleaseBinding("dp-rb-fin", release.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb))
+			})
+
+			Eventually(func(g Gomega) {
+				updatedRB := &solarv1alpha1.ReleaseBinding{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb), updatedRB)).To(Succeed())
+				g.Expect(updatedRB.Finalizers).To(ContainElement(releaseBindingFinalizer))
+
+				updatedRelease := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updatedRelease)).To(Succeed())
+				g.Expect(updatedRelease.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("blocks Release deletion while a ReleaseBinding references it", func() {
+			release := validRelease("dp-rb-release-blocked")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+
+			rb := validReleaseBinding("dp-rb-blocks-release", release.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+
+			// Wait for protection finalizer on Release.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete Release — it should be blocked.
+			Expect(k8sClient.Delete(ctx, release)).To(Succeed())
+
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, consistentlyDuration).Should(Succeed())
+
+			// Delete ReleaseBinding — controller removes releaseRefFinalizer from Release,
+			// then removes releaseBindingFinalizer, unblocking Release deletion.
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, rb))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), &solarv1alpha1.Release{}))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("removes releaseRefFinalizer from Release when last ReleaseBinding is deleted", func() {
+			release := validRelease("dp-rb-release-unprotect")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			rb := validReleaseBinding("dp-rb-last", release.Name)
+			Expect(k8sClient.Create(ctx, rb)).To(Succeed())
+
+			// Wait for protection finalizer.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete the ReleaseBinding — the controller's deletion handler removes releaseRefFinalizer
+			// from Release (no other references), then removes releaseBindingFinalizer.
+			Expect(k8sClient.Delete(ctx, rb)).To(Succeed())
+
+			// releaseRefFinalizer should be removed from Release.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+
+		It("retains releaseRefFinalizer when a second ReleaseBinding still references the Release", func() {
+			release := validRelease("dp-rb-multi-release")
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			rb1 := validReleaseBinding("dp-rb-multi-1", release.Name)
+			Expect(k8sClient.Create(ctx, rb1)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb1, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb1))
+			})
+
+			rb2 := validReleaseBinding("dp-rb-multi-2", release.Name)
+			Expect(k8sClient.Create(ctx, rb2)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, rb2, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, rb2))
+			})
+
+			// Wait for the protection finalizer to be established.
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Delete rb1 — rb2 still holds the reference, so release-ref must stay.
+			Expect(k8sClient.Delete(ctx, rb1)).To(Succeed())
+
+			// Wait for rb1 to be fully gone from the API.
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(rb1), &solarv1alpha1.ReleaseBinding{}))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// release-ref must remain because rb2 still references the Release.
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, consistentlyDuration).Should(Succeed())
+		})
+	})
+
+	Describe("Profile-owned binding guard", func() {
+		It("skips removeReleaseRefFinalizer while owner Profile still holds profileFinalizer", func() {
+			release := &solarv1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "dp-rb-guard-release", Namespace: ns.Name},
+				Spec: solarv1alpha1.ReleaseSpec{
+					ComponentVersionRef: corev1.LocalObjectReference{Name: "my-cv"},
+					UniqueName:          "dp-rb-guard-release",
+				},
+			}
+			Expect(k8sClient.Create(ctx, release)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, release, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, release))
+			})
+
+			target := &solarv1alpha1.Target{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dp-rb-guard-target",
+					Namespace: ns.Name,
+					Labels:    map[string]string{"env": "dp-rb-guard"},
+				},
+				Spec: solarv1alpha1.TargetSpec{},
+			}
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+			DeferCleanup(func() { _ = client.IgnoreNotFound(k8sClient.Delete(ctx, target)) })
+
+			profile := &solarv1alpha1.Profile{
+				ObjectMeta: metav1.ObjectMeta{Name: "dp-rb-guard-profile", Namespace: ns.Name},
+				Spec: solarv1alpha1.ProfileSpec{
+					TargetSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dp-rb-guard"},
+					},
+					ReleaseRef: corev1.LocalObjectReference{Name: release.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, profile)).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, profile, patch))
+				_ = client.IgnoreNotFound(k8sClient.Delete(ctx, profile))
+			})
+
+			// Wait for the Profile controller to create the owned ReleaseBinding and for
+			// release-ref to appear on the Release.
+			var bindingKey types.NamespacedName
+			Eventually(func(g Gomega) {
+				list := &solarv1alpha1.ReleaseBindingList{}
+				g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(Succeed())
+				var owned []solarv1alpha1.ReleaseBinding
+				for _, rb := range list.Items {
+					for _, ref := range rb.OwnerReferences {
+						if ref.Name == profile.Name && ref.Kind == "Profile" {
+							owned = append(owned, rb)
+						}
+					}
+				}
+				g.Expect(owned).To(HaveLen(1))
+				bindingKey = client.ObjectKeyFromObject(&owned[0])
+
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// Add a test-only blocker finalizer to hold the binding in Terminating state so we can
+			// assert invariants during the window when Profile still holds profileFinalizer.
+			const testBlocker = "test.solar/blocker"
+			binding := &solarv1alpha1.ReleaseBinding{}
+			Expect(k8sClient.Get(ctx, bindingKey, binding)).To(Succeed())
+			withBlocker := binding.DeepCopy()
+			withBlocker.Finalizers = append(withBlocker.Finalizers, testBlocker)
+			Expect(k8sClient.Patch(ctx, withBlocker, client.MergeFrom(binding))).To(Succeed())
+			DeferCleanup(func() {
+				patch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+				_ = client.IgnoreNotFound(k8sClient.Patch(ctx, withBlocker, patch))
+			})
+
+			// Delete the Profile — the Profile controller will delete the owned binding, which
+			// enters Terminating state (held by testBlocker).
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, profile))).To(Succeed())
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Profile{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), updated)).To(Succeed())
+				g.Expect(updated.DeletionTimestamp).NotTo(BeNil())
+			}, eventuallyTimeout).Should(Succeed())
+
+			// While the binding is in Terminating (testBlocker present), the ReleaseBinding
+			// controller must NOT remove release-ref — the guard defers to the Profile controller.
+			Consistently(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).To(ContainElement(releaseRefFinalizer),
+					"release-ref must not be removed while Profile controller still owns cleanup")
+			}, consistentlyDuration).Should(Succeed())
+
+			// Release the blocker — binding completes deletion, Profile controller removes
+			// release-ref from Release, then removes profileFinalizer from Profile.
+			bindingDeleting := &solarv1alpha1.ReleaseBinding{}
+			Expect(k8sClient.Get(ctx, bindingKey, bindingDeleting)).To(Succeed())
+			withoutBlocker := bindingDeleting.DeepCopy()
+			withoutBlocker.Finalizers = slices.DeleteFunc(withoutBlocker.Finalizers,
+				func(s string) bool { return s == testBlocker })
+			Expect(k8sClient.Patch(ctx, withoutBlocker, client.MergeFrom(bindingDeleting))).To(Succeed())
+
+			Eventually(func() error {
+				return client.IgnoreNotFound(k8sClient.Get(ctx, client.ObjectKeyFromObject(profile), &solarv1alpha1.Profile{}))
+			}, eventuallyTimeout).Should(Succeed())
+			Eventually(func(g Gomega) {
+				updated := &solarv1alpha1.Release{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(release), updated)).To(Succeed())
+				g.Expect(updated.Finalizers).NotTo(ContainElement(releaseRefFinalizer))
+			}, eventuallyTimeout).Should(Succeed())
+		})
+	})
+})

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -44,11 +44,14 @@ var (
 
 	ns *corev1.Namespace
 
-	targetReconciler         *TargetReconciler
-	releaseReconciler        *ReleaseReconciler
-	renderTaskReconciler     *RenderTaskReconciler
-	profileReconciler        *ProfileReconciler
-	renderArtifactReconciler *RenderArtifactReconciler
+	targetReconciler           *TargetReconciler
+	releaseReconciler          *ReleaseReconciler
+	renderTaskReconciler       *RenderTaskReconciler
+	profileReconciler          *ProfileReconciler
+	renderArtifactReconciler   *RenderArtifactReconciler
+	componentVersionReconciler *ComponentVersionReconciler
+	releaseBindingReconciler   *ReleaseBindingReconciler
+	registryBindingReconciler  *RegistryBindingReconciler
 
 	// fakeTagDeleter is injected into RenderArtifactReconciler so tests can
 	// control OCI delete outcomes without making real network calls.
@@ -162,6 +165,24 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(renderArtifactReconciler.SetupWithManager(mgr)).To(Succeed())
 
+	componentVersionReconciler = &ComponentVersionReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	Expect(componentVersionReconciler.SetupWithManager(mgr)).To(Succeed())
+
+	releaseBindingReconciler = &ReleaseBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	Expect(releaseBindingReconciler.SetupWithManager(mgr)).To(Succeed())
+
+	registryBindingReconciler = &RegistryBindingReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	Expect(registryBindingReconciler.SetupWithManager(mgr)).To(Succeed())
+
 	go func() {
 		defer GinkgoRecover()
 		Expect(mgr.Start(ctx)).To(Succeed(), "failed to start manager")
@@ -192,6 +213,9 @@ var _ = BeforeEach(func() {
 	renderTaskReconciler.WatchNamespace = nsName
 	profileReconciler.WatchNamespace = nsName
 	renderArtifactReconciler.WatchNamespace = nsName
+	componentVersionReconciler.WatchNamespace = nsName
+	releaseBindingReconciler.WatchNamespace = nsName
+	registryBindingReconciler.WatchNamespace = nsName
 	// Reset the fake deleter state for each test
 	fakeTagDeleter.reset()
 })
@@ -203,6 +227,9 @@ var _ = AfterEach(func() {
 	renderTaskReconciler.WatchNamespace = "cleanup-disabled"
 	profileReconciler.WatchNamespace = "cleanup-disabled"
 	renderArtifactReconciler.WatchNamespace = "cleanup-disabled"
+	componentVersionReconciler.WatchNamespace = "cleanup-disabled"
+	releaseBindingReconciler.WatchNamespace = "cleanup-disabled"
+	registryBindingReconciler.WatchNamespace = "cleanup-disabled"
 
 	// Clean up RenderTasks in the test namespace.
 	// Delete first (sets DeletionTimestamp), then force-remove finalizers via patch.
@@ -283,6 +310,78 @@ var _ = AfterEach(func() {
 		return len(list.Items)
 	}, 30*time.Second).Should(Equal(0))
 
+	// Force-delete resources that now carry finalizers so the namespace can be deleted.
+	finalizerPatch := client.RawPatch(types.JSONPatchType, []byte(`[{"op":"replace","path":"/metadata/finalizers","value":[]}]`))
+	forceDelete := func(objs []client.Object) {
+		for _, obj := range objs {
+			_ = client.IgnoreNotFound(k8sClient.Delete(ctx, obj))
+			_ = client.IgnoreNotFound(k8sClient.Patch(ctx, obj, finalizerPatch))
+		}
+	}
+
+	releaseList := &solarv1alpha1.ReleaseList{}
+	if err := k8sClient.List(ctx, releaseList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(releaseList.Items))
+		for i := range releaseList.Items {
+			objs[i] = &releaseList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	profileList := &solarv1alpha1.ProfileList{}
+	if err := k8sClient.List(ctx, profileList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(profileList.Items))
+		for i := range profileList.Items {
+			objs[i] = &profileList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	cvList := &solarv1alpha1.ComponentVersionList{}
+	if err := k8sClient.List(ctx, cvList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(cvList.Items))
+		for i := range cvList.Items {
+			objs[i] = &cvList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	rbList := &solarv1alpha1.ReleaseBindingList{}
+	if err := k8sClient.List(ctx, rbList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(rbList.Items))
+		for i := range rbList.Items {
+			objs[i] = &rbList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	regbList := &solarv1alpha1.RegistryBindingList{}
+	if err := k8sClient.List(ctx, regbList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(regbList.Items))
+		for i := range regbList.Items {
+			objs[i] = &regbList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	compList := &solarv1alpha1.ComponentList{}
+	if err := k8sClient.List(ctx, compList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(compList.Items))
+		for i := range compList.Items {
+			objs[i] = &compList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
+	registryList := &solarv1alpha1.RegistryList{}
+	if err := k8sClient.List(ctx, registryList, client.InNamespace(ns.Name)); err == nil {
+		objs := make([]client.Object, len(registryList.Items))
+		for i := range registryList.Items {
+			objs[i] = &registryList.Items[i]
+		}
+		forceDelete(objs)
+	}
+
 	Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
 
 	targetReconciler.WatchNamespace = ""
@@ -290,4 +389,7 @@ var _ = AfterEach(func() {
 	renderTaskReconciler.WatchNamespace = ""
 	profileReconciler.WatchNamespace = ""
 	renderArtifactReconciler.WatchNamespace = ""
+	componentVersionReconciler.WatchNamespace = ""
+	releaseBindingReconciler.WatchNamespace = ""
+	registryBindingReconciler.WatchNamespace = ""
 })

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -171,10 +171,12 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to get latest Target for finalizer addition")
 		}
 
-		original := latest.DeepCopy()
-		latest.Finalizers = append(latest.Finalizers, targetFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
-			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Target")
+		if !slices.Contains(latest.Finalizers, targetFinalizer) {
+			original := latest.DeepCopy()
+			latest.Finalizers = append(latest.Finalizers, targetFinalizer)
+			if err := r.Patch(ctx, latest, client.MergeFrom(original)); err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to add finalizer to Target")
+			}
 		}
 
 		return ctrl.Result{}, nil

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -80,7 +80,8 @@ type TargetReconciler struct {
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=targets/finalizers,verbs=update
-//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registries,verbs=get;list;watch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registries,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registries/finalizers,verbs=update
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releasebindings,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=registrybindings,verbs=get;list;watch
 //+kubebuilder:rbac:groups=solar.opendefense.cloud,resources=releases,verbs=get;list;watch
@@ -125,6 +126,23 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Delete owned RenderBindings so the GC controller can clean up orphaned RenderArtifacts.
 		if err := r.deleteOwnedRenderBindings(ctx, target); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to delete owned RenderBindings")
+		}
+
+		// Remove protection finalizer from Registry if no other Target or RegistryBinding references it.
+		registryNamespace := target.Namespace
+		if target.Spec.RenderRegistryNamespace != "" {
+			registryNamespace = target.Spec.RenderRegistryNamespace
+		}
+
+		if target.Spec.RenderRegistryRef.Name != "" {
+			registry := &solarv1alpha1.Registry{}
+			if err := r.Get(ctx, client.ObjectKey{Name: target.Spec.RenderRegistryRef.Name, Namespace: registryNamespace}, registry); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Registry for finalizer cleanup")
+				}
+			} else if err := r.removeRegistryRefFinalizer(ctx, target, registry); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 
 		// Remove finalizer
@@ -202,6 +220,16 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		return ctrl.Result{}, errLogAndWrap(log, err, "failed to get Registry")
+	}
+
+	// Protect Registry from deletion while this Target references it, regardless of
+	// whether SolarSecretRef is configured — the Target still references this Registry.
+	if !slices.Contains(registry.Finalizers, registryRefFinalizer) {
+		latest := registry.DeepCopy()
+		latest.Finalizers = append(latest.Finalizers, registryRefFinalizer)
+		if err := r.Patch(ctx, latest, client.MergeFrom(registry)); err != nil {
+			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Registry")
+		}
 	}
 
 	if registry.Spec.SolarSecretRef == nil {
@@ -1474,4 +1502,10 @@ func (r *TargetReconciler) mapReleaseBindingToTarget(_ context.Context, obj clie
 			},
 		},
 	}
+}
+
+// removeRegistryRefFinalizer removes registryRefFinalizer from registry when no other active
+// Target or RegistryBinding (excluding the deleting Target) still references it.
+func (r *TargetReconciler) removeRegistryRefFinalizer(ctx context.Context, deletingTarget *solarv1alpha1.Target, registry *solarv1alpha1.Registry) error {
+	return removeRegistryRefFinalizer(ctx, r.Client, deletingTarget, nil, registry)
 }

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -229,7 +229,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if !slices.Contains(registry.Finalizers, registryRefFinalizer) {
 		latest := registry.DeepCopy()
 		latest.Finalizers = append(latest.Finalizers, registryRefFinalizer)
-		if err := r.Patch(ctx, latest, client.MergeFrom(registry)); err != nil {
+		if err := r.Patch(ctx, latest, client.MergeFromWithOptions(registry, client.MergeFromWithOptimisticLock{})); err != nil {
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to add protection finalizer to Registry")
 		}
 	}


### PR DESCRIPTION
## What
Implements deletion protection for `ComponentVersion`, `Release`, `Registry`, and `ReleaseBinding` resources using controller-managed finalizers, preventing cascade-deletion accidents when upstream resources are deleted while still referenced.

Closes #308 

## Why
Before this change, deleting a `Component` while `ComponentVersions` still pointed to it, or a `Release` while active deployments existed, would cause dangling references and silent failures downstream. This adds a guard at the API level: referenced resources cannot be deleted until all their referencers are gone.

## Testing
All 17 envtest/Ginkgo suites pass. Each new controller is covered by dedicated tests:
- Add-finalizer-on-create (both self-finalizer and protection finalizer)
- Block-deletion-while-referenced (Consistently assert DeletionTimestamp present, resource not gone)
- Remove-protection-finalizer-when-last-reference-deleted
- Retain-protection-finalizer-when-a-second-referencer-still-exists (multi-referencer scenario)
- Profile-owned-binding guard: `removeReleaseRefFinalizer` deferred to Profile controller while `profileFinalizer` is present, verified with a test-only blocker finalizer

`make test-e2e` timeout bumped from the implicit 10 m Go default to 15 m; new controllers add reconcile cycles to namespace teardown (previously resources were GC'd immediately).

## Notes for reviewers

**New controllers** — `ComponentVersionReconciler`, `ReleaseBindingReconciler`, and `RegistryBindingReconciler` are registered in `solar-controller-manager`. During a rolling upgrade, the brief window between old pod termination and new pod startup leaves existing resources unprotected; this is unavoidable with a rolling deploy and the window is short.

**RBAC changes** — `patch`/`update` verbs added to `components`, `componentversions`, `profiles`, `registries`, and `registrybindings`; new `/finalizers` sub-resource rules added for all of those plus `releases` and `releasebindings`. See `charts/solar/files/role.yaml`.

**New finalizers on existing resources** — after upgrade, all existing `ComponentVersions`, `ReleaseBindings`, `RegistryBindings`, and `Releases` will have finalizers added on their next reconcile. Resources already in Terminating state before upgrade will be unblocked normally once the new controllers are running.

**No API schema changes** — only an informational doc comment added to `Profile` describing cascade-deletion behaviour.

**Finalizer placement** — all protection-finalizer patches use a fresh `Get` immediately before the `Patch` to avoid a JSON-merge-patch race where a concurrent add could be overwritten by a stale base object (RFC 7396: only fields present in the patch body are applied; `resourceVersion` is excluded from the diff when both base and modified share the same value).

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ComponentVersion, ReleaseBinding, and RegistryBinding controllers with coordinated finalizer-based deletion protection and safer cascade cleanup across related resources.
* **Documentation**
  * Added developer guides for the new controllers.
  * Expanded Profile deletion documentation (developer guide and API reference) with clearer destructive/cascading and undeployment-avoidance guidance.
* **Chores / Tests**
  * Updated RBAC permissions to support finalizer and reference handling.
  * Increased e2e test timeout for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->