### PR TITLE
ci: harden GitHub workflows

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
         with:
           configFile: .commitlintrc.yml

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,8 @@
 name: Build/Publish Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types:
@@ -51,6 +54,8 @@ jobs:
       is-local: ${{ env.ACT == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Setup Local Registry for act
         if: ${{ env.ACT == 'true' }}
         run: |

--- a/.github/workflows/docs-develop.yaml
+++ b/.github/workflows/docs-develop.yaml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          # Credentials are intentionally persisted: `mike deploy --push` below
+          # uses the checkout token to push the built docs to the gh-pages branch.
+          persist-credentials: true
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.14.5

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          # Credentials are intentionally persisted: `mike deploy --push` below
+          # uses the checkout token to push the built docs to the gh-pages branch.
+          persist-credentials: true
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: 3.14.5

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -19,6 +19,8 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
@@ -39,6 +41,8 @@ jobs:
       go-version: ${{ steps.go-version.outputs.version }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - id: go-version
         uses: opendefensecloud/dev-kit/.github/actions/get-go-version@5107b50be074d483888a332c008d6bd27beb93e0 # v1.0.10
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -60,6 +64,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ needs.lint.outputs.go-version }}

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5

--- a/.github/workflows/helm-publish.yaml
+++ b/.github/workflows/helm-publish.yaml
@@ -1,5 +1,8 @@
 name: Publish Helm Chart
 
+permissions:
+  contents: read
+
 on:
   release:
     types:
@@ -36,6 +39,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5

--- a/.github/workflows/issues-add-labels.yaml
+++ b/.github/workflows/issues-add-labels.yaml
@@ -1,4 +1,8 @@
 name: Label issues
+
+permissions:
+  contents: read
+
 on:
   issues:
     types:

--- a/.github/workflows/issues-add-to-project.yml
+++ b/.github/workflows/issues-add-to-project.yml
@@ -1,5 +1,8 @@
 name: Add issues to project
 
+permissions:
+  contents: read
+
 on:
   issues:
     types:
@@ -12,6 +15,8 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-24.04
+    # Authenticates with ADD_TO_PROJECT_PAT, so the workflow GITHUB_TOKEN needs no scopes.
+    permissions: {}
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract go version from flake.nix
         id: get-go-version

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - id: go-version
         uses: opendefensecloud/dev-kit/.github/actions/get-go-version@5107b50be074d483888a332c008d6bd27beb93e0 # v1.0.10
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/.github/workflows/update-action-pins.yml
+++ b/.github/workflows/update-action-pins.yml
@@ -1,5 +1,8 @@
 name: Update Action Pins
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Relates to https://github.com/opendefensecloud/odd-internal/issues/40 and https://github.com/opendefensecloud/odd-internal/issues/43.

## Why
Restrict the permissions of our GitHub workflows to follow security best practices.

## Testing
none

## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security of continuous integration and deployment pipelines through improved credential isolation and stricter permission scoping across automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->