### PR TITLE
ci(release): sign release binaries and checksums with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,11 @@ jobs:
         run: |
           find bin -type f ! -name checksums.txt | sort | xargs sha256sum > bin/checksums.txt
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: 'bin/solar-*-*' # binaries only; runs before signing so .sig/.pem are not yet present
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
@@ -96,11 +101,6 @@ jobs:
               --output-certificate "${f}.pem" \
               "$f"
           done
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
-        with:
-          subject-path: 'bin/solar-*-*' # binaries only, excludes checksums/.sig/.pem
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write # for keyless cosign sign-blob
+  attestations: write # for build-provenance attestation
 
 env:
   REGISTRY: ghcr.io
@@ -77,6 +79,28 @@ jobs:
       - name: Create checksums
         run: |
           find bin -type f ! -name checksums.txt | sort | xargs sha256sum > bin/checksums.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign release artefacts (keyless)
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cd bin
+          for f in *; do
+            [ -f "$f" ] || continue
+            case "$f" in *.sig|*.pem) continue ;; esac
+            cosign sign-blob --yes \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "$f"
+          done
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: 'bin/solar-*-*' # binaries only, excludes checksums/.sig/.pem
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3

--- a/docs/operator-manual/releases.md
+++ b/docs/operator-manual/releases.md
@@ -23,7 +23,7 @@ cosign verify-blob \
 
 The same command works for `checksums.txt` and any other artefact — swap the file names accordingly. A successful run prints `Verified OK`.
 
-The artefacts additionally carry a [build-provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which can be verified with the GitHub CLI:
+Release binaries additionally carry a [build-provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which can be verified with the GitHub CLI:
 
 ```bash
 gh attestation verify solar-apiserver-linux-amd64 --repo opendefensecloud/solution-arsenal

--- a/docs/operator-manual/releases.md
+++ b/docs/operator-manual/releases.md
@@ -5,3 +5,26 @@ You can find the most recent version in the [GitHub Releases](https://github.com
 ## Versioning
 
 Versions are expressed as `x.y.z`, where `x` is the major version, `y` is the minor version, and `z` is the patch version, following Semantic Versioning terminology.
+
+## Verifying release artefacts
+
+Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching `<file>.sig` (signature) and `<file>.pem` (certificate) is published next to it on the GitHub Release page.
+
+To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.pem` and `.sig`:
+
+```bash
+cosign verify-blob \
+  --certificate solar-apiserver-linux-amd64.pem \
+  --signature  solar-apiserver-linux-amd64.sig \
+  --certificate-identity-regexp 'https://github.com/opendefensecloud/solution-arsenal/\.github/workflows/release\.yaml@.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  solar-apiserver-linux-amd64
+```
+
+The same command works for `checksums.txt` and any other artefact — swap the file names accordingly. A successful run prints `Verified OK`.
+
+The artefacts additionally carry a [build-provenance attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds), which can be verified with the GitHub CLI:
+
+```bash
+gh attestation verify solar-apiserver-linux-amd64 --repo opendefensecloud/solution-arsenal
+```


### PR DESCRIPTION
## What
Keylessly sign every GitHub Release artefact (binaries + `checksums.txt`) with cosign, and document how to verify them. Part of opendefensecloud/odd-internal#42.

## Why
OpenSSF Scorecard rated `Signed-Releases` as `?` for this repo — no signed assets were found on the latest releases (`v0.1.0`, `v0.1.1`). Container images (`docker.yaml`) and Helm charts (`helm-publish.yaml`) were already keylessly cosign-signed, but `release.yaml` uploaded `bin/*` and `checksums.txt` unsigned. This lifts the proven keyless-signing pattern from `docker.yaml` over to the binary release path so the next tag publishes signed artefacts and Scorecard `Signed-Releases` rises to 10/10.

## Testing
- Validated `release.yaml` parses as YAML and dry-ran the sign loop locally with a `cosign` stub: 3 dummy artefacts produce exactly one `.sig` + `.pem` each, and a second run is idempotent (skips already-signed files, no `.sig.sig`/`.pem.pem`).
- `make codegen` produced no changes.
- End-to-end (post-merge): push a `v0.3.0-rc1` pre-release tag, confirm matching `.sig`/`.pem` for all assets on the Release page, run the documented `cosign verify-blob`, then confirm Scorecard `Signed-Releases` lifts after the next real tag.

## Notes for reviewers
- Adds `id-token: write` (keyless OIDC) and `attestations: write` permissions to the release job — required for `cosign sign-blob` and `actions/attest-build-provenance` respectively.
- The new `.sig`/`.pem` files are uploaded automatically by the existing `files: bin/*` glob; signing runs after checksum creation so `checksums.txt` is itself signed.
- `cosign` is pinned to the same digest already used in `docker.yaml`.
- Verification (`cosign verify-blob` and `gh attestation verify`) is documented in `docs/operator-manual/releases.md`.

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Verifying release artefacts” guide, including steps to verify download signatures and build provenance attestations.

* **Release Improvements**
  * Release binaries now come with keyless cryptographic signatures and build provenance attestations to help verify authenticity and integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->