### PR TITLE
fix: handle http registries in RenderArtifacts and RenderTasks

### DIFF
--- a/api/solar/renderartifact_types.go
+++ b/api/solar/renderartifact_types.go
@@ -33,6 +33,9 @@ type RenderArtifactSpec struct {
 	// RegistryFlavor identifies the registry implementation (e.g. "zot", "harbor").
 	// +optional
 	RegistryFlavor string `json:"registryFlavor,omitempty"`
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	// +optional
+	PlainHTTP bool `json:"plainHTTP,omitempty"`
 }
 
 // RenderArtifactStatus holds the observed state of a RenderArtifact.

--- a/api/solar/rendertask_types.go
+++ b/api/solar/rendertask_types.go
@@ -30,6 +30,10 @@ type RenderTaskSpec struct {
 	// +optional
 	PushSecretRef *corev1.LocalObjectReference `json:"pushSecretRef,omitempty"`
 
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	// +optional
+	PlainHTTP bool `json:"plainHTTP,omitempty"`
+
 	// failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.
 	// After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete
 	// the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.

--- a/api/solar/v1alpha1/renderartifact_types.go
+++ b/api/solar/v1alpha1/renderartifact_types.go
@@ -32,6 +32,9 @@ type RenderArtifactSpec struct {
 	// RegistryFlavor identifies the registry implementation (e.g. "zot", "harbor").
 	// +optional
 	RegistryFlavor string `json:"registryFlavor,omitempty"`
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	// +optional
+	PlainHTTP bool `json:"plainHTTP,omitempty"`
 }
 
 // RenderArtifactStatus holds the observed state of a RenderArtifact.

--- a/api/solar/v1alpha1/rendertask_types.go
+++ b/api/solar/v1alpha1/rendertask_types.go
@@ -29,6 +29,10 @@ type RenderTaskSpec struct {
 	// +optional
 	PushSecretRef *corev1.LocalObjectReference `json:"pushSecretRef,omitempty"`
 
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	// +optional
+	PlainHTTP bool `json:"plainHTTP,omitempty"`
+
 	// failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.
 	// After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete
 	// the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.

--- a/api/solar/v1alpha1/zz_generated.conversion.go
+++ b/api/solar/v1alpha1/zz_generated.conversion.go
@@ -1762,6 +1762,7 @@ func autoConvert_v1alpha1_RenderArtifactSpec_To_solar_RenderArtifactSpec(in *Ren
 	out.PushSecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.PushSecretRef))
 	out.PushSecretNamespace = in.PushSecretNamespace
 	out.RegistryFlavor = in.RegistryFlavor
+	out.PlainHTTP = in.PlainHTTP
 	return nil
 }
 
@@ -1778,6 +1779,7 @@ func autoConvert_solar_RenderArtifactSpec_To_v1alpha1_RenderArtifactSpec(in *sol
 	out.PushSecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.PushSecretRef))
 	out.PushSecretNamespace = in.PushSecretNamespace
 	out.RegistryFlavor = in.RegistryFlavor
+	out.PlainHTTP = in.PlainHTTP
 	return nil
 }
 
@@ -1964,6 +1966,7 @@ func autoConvert_v1alpha1_RenderTaskSpec_To_solar_RenderTaskSpec(in *RenderTaskS
 	out.Tag = in.Tag
 	out.BaseURL = in.BaseURL
 	out.PushSecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.PushSecretRef))
+	out.PlainHTTP = in.PlainHTTP
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	out.OwnerName = in.OwnerName
 	out.OwnerNamespace = in.OwnerNamespace
@@ -1984,6 +1987,7 @@ func autoConvert_solar_RenderTaskSpec_To_v1alpha1_RenderTaskSpec(in *solar.Rende
 	out.Tag = in.Tag
 	out.BaseURL = in.BaseURL
 	out.PushSecretRef = (*corev1.LocalObjectReference)(unsafe.Pointer(in.PushSecretRef))
+	out.PlainHTTP = in.PlainHTTP
 	out.FailedJobTTL = (*int32)(unsafe.Pointer(in.FailedJobTTL))
 	out.OwnerName = in.OwnerName
 	out.OwnerNamespace = in.OwnerNamespace

--- a/client-go/applyconfigurations/solar/v1alpha1/renderartifactspec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/renderartifactspec.go
@@ -30,6 +30,8 @@ type RenderArtifactSpecApplyConfiguration struct {
 	PushSecretNamespace *string `json:"pushSecretNamespace,omitempty"`
 	// RegistryFlavor identifies the registry implementation (e.g. "zot", "harbor").
 	RegistryFlavor *string `json:"registryFlavor,omitempty"`
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	PlainHTTP *bool `json:"plainHTTP,omitempty"`
 }
 
 // RenderArtifactSpecApplyConfiguration constructs a declarative configuration of the RenderArtifactSpec type for use with
@@ -91,5 +93,13 @@ func (b *RenderArtifactSpecApplyConfiguration) WithPushSecretNamespace(value str
 // If called multiple times, the RegistryFlavor field is set to the value of the last call.
 func (b *RenderArtifactSpecApplyConfiguration) WithRegistryFlavor(value string) *RenderArtifactSpecApplyConfiguration {
 	b.RegistryFlavor = &value
+	return b
+}
+
+// WithPlainHTTP sets the PlainHTTP field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PlainHTTP field is set to the value of the last call.
+func (b *RenderArtifactSpecApplyConfiguration) WithPlainHTTP(value bool) *RenderArtifactSpecApplyConfiguration {
+	b.PlainHTTP = &value
 	return b
 }

--- a/client-go/applyconfigurations/solar/v1alpha1/rendertaskspec.go
+++ b/client-go/applyconfigurations/solar/v1alpha1/rendertaskspec.go
@@ -28,6 +28,8 @@ type RenderTaskSpecApplyConfiguration struct {
 	// PushSecretRef references a Secret in the same namespace with registry credentials
 	// for pushing the rendered chart.
 	PushSecretRef *v1.LocalObjectReference `json:"pushSecretRef,omitempty"`
+	// PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.
+	PlainHTTP *bool `json:"plainHTTP,omitempty"`
 	// failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.
 	// After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete
 	// the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.
@@ -100,6 +102,14 @@ func (b *RenderTaskSpecApplyConfiguration) WithBaseURL(value string) *RenderTask
 // If called multiple times, the PushSecretRef field is set to the value of the last call.
 func (b *RenderTaskSpecApplyConfiguration) WithPushSecretRef(value v1.LocalObjectReference) *RenderTaskSpecApplyConfiguration {
 	b.PushSecretRef = &value
+	return b
+}
+
+// WithPlainHTTP sets the PlainHTTP field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PlainHTTP field is set to the value of the last call.
+func (b *RenderTaskSpecApplyConfiguration) WithPlainHTTP(value bool) *RenderTaskSpecApplyConfiguration {
+	b.PlainHTTP = &value
 	return b
 }
 

--- a/client-go/openapi/zz_generated.openapi.go
+++ b/client-go/openapi/zz_generated.openapi.go
@@ -2314,6 +2314,13 @@ func schema_solar_api_solar_v1alpha1_RenderArtifactSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"plainHTTP": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"baseURL", "repository", "tag", "renderTaskRef"},
 			},
@@ -2682,6 +2689,13 @@ func schema_solar_api_solar_v1alpha1_RenderTaskSpec(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "PushSecretRef references a Secret in the same namespace with registry credentials for pushing the rendered chart.",
 							Ref:         ref(v1.LocalObjectReference{}.OpenAPIModelName()),
+						},
+					},
+					"plainHTTP": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PlainHTTP uses HTTP instead of HTTPS for OCI registry connections.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"failedJobTTL": {

--- a/docs/user-guide/api-reference.md
+++ b/docs/user-guide/api-reference.md
@@ -854,6 +854,7 @@ _Appears in:_
 | `pushSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | PushSecretRef references a Secret with push credentials. Used for tag deletion during GC. |  | Optional: \{\} <br /> |
 | `pushSecretNamespace` _string_ | PushSecretNamespace is the namespace of the Secret referenced by PushSecretRef.<br />When empty, defaults to the RenderArtifact's own namespace.<br />Set when the Registry lives in a different namespace from the Target (cross-namespace). |  | Optional: \{\} <br /> |
 | `registryFlavor` _string_ | RegistryFlavor identifies the registry implementation (e.g. "zot", "harbor"). |  | Optional: \{\} <br /> |
+| `plainHTTP` _boolean_ | PlainHTTP uses HTTP instead of HTTPS for OCI registry connections. |  | Optional: \{\} <br /> |
 
 
 #### RenderArtifactStatus
@@ -989,6 +990,7 @@ _Appears in:_
 | `tag` _string_ | Tag is the Tag of the helm chart to be pushed.<br />Make sure that the tag matches the version in Chart.yaml, otherwise helm<br />will error before pushing. |  |  |
 | `baseURL` _string_ | BaseURL is the registry URL to push the rendered chart to (e.g. "registry.example.com:5000"). |  |  |
 | `pushSecretRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | PushSecretRef references a Secret in the same namespace with registry credentials<br />for pushing the rendered chart. |  | Optional: \{\} <br /> |
+| `plainHTTP` _boolean_ | PlainHTTP uses HTTP instead of HTTPS for OCI registry connections. |  | Optional: \{\} <br /> |
 | `failedJobTTL` _integer_ | failedJobTTL is the TTL in seconds after which a failed render job and its secrets are cleaned up.<br />After this duration, the Kubernetes TTL controller will delete the Job and the controller will delete<br />the Secrets (ConfigSecret, AuthSecret). On success, Job and Secrets are deleted immediately.<br />If not set, defaults to 3600 (1 hour). |  | Optional: \{\} <br /> |
 | `ownerName` _string_ | OwnerName is the name of the resource that created this RenderTask. |  | MinLength: 1 <br /> |
 | `ownerNamespace` _string_ | OwnerNamespace is the namespace of the resource that created this RenderTask. |  | MinLength: 1 <br /> |

--- a/pkg/controller/renderartifact_controller.go
+++ b/pkg/controller/renderartifact_controller.go
@@ -51,7 +51,7 @@ type RenderArtifactReconciler struct {
 	APIReader client.Reader
 	// DeleteTag overrides the OCI tag deletion function used during GC.
 	// Defaults to ociregistry.DeleteTag; replaced in tests.
-	DeleteTag func(ctx context.Context, rawRef string, auth authn.Authenticator) error
+	DeleteTag func(ctx context.Context, rawRef string, auth authn.Authenticator, insecure bool) error
 	// WatchNamespace restricts reconciliation to this namespace.
 	// Should be empty in production (watches all namespaces).
 	// Intended for use in integration tests only.
@@ -200,7 +200,7 @@ func (r *RenderArtifactReconciler) cleanupOCIArtifact(ctx context.Context, artif
 
 	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if err := deleteFn(deleteCtx, rawRef, auth); err != nil {
+	if err := deleteFn(deleteCtx, rawRef, auth, artifact.Spec.PlainHTTP); err != nil {
 		// If the tag is already gone, proceed normally.
 		var transportErr *transport.Error
 		if errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusNotFound {

--- a/pkg/controller/renderartifact_controller_test.go
+++ b/pkg/controller/renderartifact_controller_test.go
@@ -23,18 +23,24 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// callRecord records a single DeleteTag invocation.
+type callRecord struct {
+	rawRef   string
+	insecure bool
+}
+
 // stubTagDeleter is a thread-safe fake whose behaviour is controlled by tests.
 // The zero value succeeds silently.
 type stubTagDeleter struct {
 	mu         sync.Mutex
-	failErr    error    // if non-nil, DeleteTag returns this error
-	calledWith []string // refs passed to DeleteTag
+	failErr    error        // if non-nil, DeleteTag returns this error
+	calledWith []callRecord // invocations passed to DeleteTag
 }
 
-func (s *stubTagDeleter) DeleteTag(_ context.Context, rawRef string, _ authn.Authenticator) error {
+func (s *stubTagDeleter) DeleteTag(_ context.Context, rawRef string, _ authn.Authenticator, insecure bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.calledWith = append(s.calledWith, rawRef)
+	s.calledWith = append(s.calledWith, callRecord{rawRef: rawRef, insecure: insecure})
 
 	return s.failErr
 }
@@ -51,6 +57,18 @@ func (s *stubTagDeleter) calls() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]string, len(s.calledWith))
+	for i, c := range s.calledWith {
+		out[i] = c.rawRef
+	}
+
+	return out
+}
+
+// callsWithOpts returns a copy of all call records.
+func (s *stubTagDeleter) callsWithOpts() []callRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]callRecord, len(s.calledWith))
 	copy(out, s.calledWith)
 
 	return out
@@ -304,6 +322,61 @@ var _ = Describe("RenderArtifactController", Ordered, func() {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(art), &solarv1alpha1.RenderArtifact{})
 				return apierrors.IsNotFound(err)
 			}, eventuallyTimeout).Should(BeTrue(), "RenderArtifact should be GC'd even when DeleteTag returns 404")
+		})
+	})
+
+	Context("GC with PlainHTTP", Label("renderartifact"), func() {
+		It("should pass Insecure=true to DeleteTag when PlainHTTP is set on the artifact", func() {
+			art := &solarv1alpha1.RenderArtifact{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "art-plainhttp",
+					Namespace: ns.Name,
+				},
+				Spec: solarv1alpha1.RenderArtifactSpec{
+					BaseURL:       "registry.example.com",
+					Repository:    "ns/myapp",
+					Tag:           "v1.0.0",
+					RenderTaskRef: "rt-plainhttp",
+					PlainHTTP:     true,
+				},
+			}
+			Expect(k8sClient.Create(ctx, art)).To(Succeed())
+
+			// No bindings → GC should delete the artifact and call DeleteTag.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(art), &solarv1alpha1.RenderArtifact{})
+				return apierrors.IsNotFound(err)
+			}, eventuallyTimeout).Should(BeTrue())
+
+			records := fakeTagDeleter.callsWithOpts()
+			Expect(records).NotTo(BeEmpty())
+			for _, rec := range records {
+				if rec.rawRef == "registry.example.com/ns/myapp:v1.0.0" {
+					Expect(rec.insecure).To(BeTrue(), "PlainHTTP artifact should delete with Insecure=true")
+					return
+				}
+			}
+			Fail("expected DeleteTag call for registry.example.com/ns/myapp:v1.0.0")
+		})
+
+		It("should pass Insecure=false to DeleteTag when PlainHTTP is not set", func() {
+			art := newArtifact("art-secure-default")
+			Expect(k8sClient.Create(ctx, art)).To(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(art), &solarv1alpha1.RenderArtifact{})
+				return apierrors.IsNotFound(err)
+			}, eventuallyTimeout).Should(BeTrue())
+
+			records := fakeTagDeleter.callsWithOpts()
+			Expect(records).NotTo(BeEmpty())
+			for _, rec := range records {
+				if rec.rawRef == "registry.example.com/ns/myapp:v1.0.0" {
+					Expect(rec.insecure).To(BeFalse(), "default artifact should delete with Insecure=false")
+					return
+				}
+			}
+			Fail("expected DeleteTag call for registry.example.com/ns/myapp:v1.0.0")
 		})
 	})
 })

--- a/pkg/controller/rendertask_controller.go
+++ b/pkg/controller/rendertask_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -345,6 +346,12 @@ func (r *RenderTaskReconciler) createRenderJob(ctx context.Context, res *solarv1
 
 	pushURL := r.reference(res.Spec.BaseURL, res.Spec.Repository, res.Spec.Tag)
 
+	args := slices.Clone(r.RendererArgs)
+	args = append(args, "/etc/renderer/config.json", fmt.Sprintf("--url=%s", pushURL))
+	if res.Spec.PlainHTTP {
+		args = append(args, "--plain-http=true")
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -361,13 +368,10 @@ func (r *RenderTaskReconciler) createRenderJob(ctx context.Context, res *solarv1
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{
-							Name:    "renderer",
-							Image:   r.RendererImage,
-							Command: []string{r.RendererCommand},
-							Args: append(r.RendererArgs,
-								"/etc/renderer/config.json",
-								fmt.Sprintf("--url=%s", pushURL),
-							),
+							Name:         "renderer",
+							Image:        r.RendererImage,
+							Command:      []string{r.RendererCommand},
+							Args:         args,
 							Env:          envVars,
 							VolumeMounts: volumeMounts,
 						},

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -919,6 +919,7 @@ func (r *TargetReconciler) ensureRenderArtifact(ctx context.Context, name string
 			PushSecretRef:       rt.Spec.PushSecretRef,
 			PushSecretNamespace: pushSecretNamespace,
 			RegistryFlavor:      flavor,
+			PlainHTTP:           rt.Spec.PlainHTTP,
 		},
 	}
 
@@ -1001,6 +1002,7 @@ func (r *TargetReconciler) computeReleaseRenderTaskSpec(rel *solarv1alpha1.Relea
 		Repository:     repo,
 		Tag:            tag,
 		BaseURL:        registry.Spec.Hostname,
+		PlainHTTP:      registry.Spec.PlainHTTP,
 		PushSecretRef:  registry.Spec.SolarSecretRef,
 		FailedJobTTL:   rel.Spec.FailedJobTTL,
 		OwnerName:      target.Name,
@@ -1075,6 +1077,7 @@ func (r *TargetReconciler) computeBootstrapRenderTaskSpec(target *solarv1alpha1.
 		Repository:     repo,
 		Tag:            tag,
 		BaseURL:        registry.Spec.Hostname,
+		PlainHTTP:      registry.Spec.PlainHTTP,
 		PushSecretRef:  registry.Spec.SolarSecretRef,
 		OwnerName:      target.Name,
 		OwnerNamespace: target.Namespace,

--- a/pkg/ociregistry/deleter.go
+++ b/pkg/ociregistry/deleter.go
@@ -13,6 +13,6 @@ import (
 // DeleteTag deletes the OCI tag identified by rawRef (e.g. "registry.example.com/ns/repo:v1").
 // auth provides credentials for the request.
 // A non-nil error means the deletion failed and should be surfaced to the caller.
-func DeleteTag(ctx context.Context, rawRef string, auth authn.Authenticator) error {
-	return (&standardDeleter{}).DeleteTag(ctx, rawRef, auth)
+func DeleteTag(ctx context.Context, rawRef string, auth authn.Authenticator, insecure bool) error {
+	return (&standardDeleter{}).DeleteTag(ctx, rawRef, auth, insecure)
 }

--- a/pkg/ociregistry/ociregistry_test.go
+++ b/pkg/ociregistry/ociregistry_test.go
@@ -23,7 +23,7 @@ import (
 // TestDeleteTag_InvalidReference ensures DeleteTag returns an error
 // immediately when the reference cannot be parsed, without making any network calls.
 func TestDeleteTag_InvalidReference(t *testing.T) {
-	err := ociregistry.DeleteTag(context.Background(), "not a valid::ref", authn.Anonymous)
+	err := ociregistry.DeleteTag(context.Background(), "not a valid::ref", authn.Anonymous, false)
 	if err == nil {
 		t.Fatal("expected error for invalid reference, got nil")
 	}
@@ -53,8 +53,33 @@ func TestDeleteTag_DeleteSucceeds(t *testing.T) {
 		t.Fatalf("failed to push test manifest: %v", err)
 	}
 
-	if err := ociregistry.DeleteTag(context.Background(), rawRef, authn.Anonymous); err != nil {
+	if err := ociregistry.DeleteTag(context.Background(), rawRef, authn.Anonymous, false); err != nil {
 		t.Fatalf("DeleteTag returned unexpected error: %v", err)
+	}
+}
+
+// TestDeleteTag_DeleteSucceedsPlainHTTP pushes a manifest to an in-process
+// plain HTTP OCI registry and verifies DeleteTag removes it when the
+// Insecure option is set.
+func TestDeleteTag_DeleteSucceedsPlainHTTP(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	repo := "testns/plainhttp"
+	tag := "v1.0.0"
+
+	rawRef := fmt.Sprintf("%s/%s:%s", host, repo, tag)
+	ref, err := name.ParseReference(rawRef, name.Insecure)
+	if err != nil {
+		t.Fatalf("parse reference: %v", err)
+	}
+	if err := remote.Write(ref, empty.Image, remote.WithContext(context.Background())); err != nil {
+		t.Fatalf("failed to push test manifest: %v", err)
+	}
+
+	if err := ociregistry.DeleteTag(context.Background(), rawRef, authn.Anonymous, true); err != nil {
+		t.Fatalf("DeleteTag with Insecure option returned unexpected error: %v", err)
 	}
 }
 
@@ -69,7 +94,7 @@ func TestDeleteTag_DeleteReturnsErrorOnRegistryFailure(t *testing.T) {
 
 	host := strings.TrimPrefix(srv.URL, "http://")
 	ref := fmt.Sprintf("%s/ns/repo:v1", host)
-	err := ociregistry.DeleteTag(context.Background(), ref, authn.Anonymous)
+	err := ociregistry.DeleteTag(context.Background(), ref, authn.Anonymous, false)
 	if err == nil {
 		t.Fatal("expected error on registry failure, got nil")
 	}

--- a/pkg/ociregistry/standard.go
+++ b/pkg/ociregistry/standard.go
@@ -19,8 +19,13 @@ import (
 // This works with any OCI Distribution Spec-compliant registry
 type standardDeleter struct{}
 
-func (d *standardDeleter) DeleteTag(ctx context.Context, rawRef string, auth authn.Authenticator) error {
-	ref, err := ociname.ParseReference(rawRef)
+func (d *standardDeleter) DeleteTag(ctx context.Context, rawRef string, auth authn.Authenticator, insecure bool) error {
+	parseOpts := []ociname.Option{}
+	if insecure {
+		parseOpts = append(parseOpts, ociname.Insecure)
+	}
+
+	ref, err := ociname.ParseReference(rawRef, parseOpts...)
 	if err != nil {
 		return fmt.Errorf("invalid OCI reference %q: %w", rawRef, err)
 	}


### PR DESCRIPTION
## What
Closes #618, Closes #629 

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `plainHTTP` configuration for render tasks and render artifacts to enable insecure (HTTP) OCI registry connections instead of HTTPS.
* **Documentation**
  * Updated the API reference to document the new `plainHTTP` field for render specifications.
* **Bug Fixes**
  * Ensured OCI tag deletion and render task creation honor `plainHTTP` consistently, including updates to related OpenAPI schema and automated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->