### PR TITLE
fix: parse registries with host and port

### DIFF
--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -1019,18 +1018,14 @@ func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, r
 			return solarv1alpha1.BootstrapInput{}, fmt.Errorf("release %q has empty uniqueName; resolveReleaseConflicts must run before buildBootstrapInput", ri.name)
 		}
 
-		ref, err := ociname.ParseReference(ri.chartURL)
+		trimmedRef := strings.TrimPrefix(ri.chartURL, "oci://")
+		ref, err := ociname.ParseReference(trimmedRef)
 		if err != nil {
 			return solarv1alpha1.BootstrapInput{}, fmt.Errorf("failed to parse chartURL %s: %w", ri.chartURL, err)
 		}
 
-		repo, err := url.JoinPath(ref.Context().RegistryStr(), ref.Context().RepositoryStr())
-		if err != nil {
-			return solarv1alpha1.BootstrapInput{}, err
-		}
-
 		resolvedReleases[ri.uniqueName] = solarv1alpha1.ResolvedResourceAccess{
-			Repository:     strings.TrimPrefix(repo, "oci://"),
+			Repository:     ref.Context().String(),
 			Tag:            ref.Identifier(),
 			PullSecretName: renderRegistryPullSecret,
 		}

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -1776,4 +1776,18 @@ var _ = Describe("buildBootstrapInput", func() {
 		Expect(input.Releases).To(HaveKey("component-a"))
 		Expect(input.Releases).To(HaveKey("component-b"))
 	})
+
+	It("gracefully handles chartURL with oci:// prefix and explicit port", func() {
+		releases := []releaseInfo{{
+			name:       "my-release",
+			uniqueName: "uniq-release",
+			chartURL:   "oci://zot.zot.svc.cluster.local:5000/solar-system/solar-system/release-ocm-demo-release:v0.0.2-ec0e3b98",
+		}}
+		input, err := buildBootstrapInput(target, releases, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(input.Releases).To(HaveLen(1))
+		Expect(input.Releases).To(HaveKey("uniq-release"))
+		Expect(input.Releases["uniq-release"].Tag).To(Equal("v0.0.2-ec0e3b98"))
+		Expect(input.Releases["uniq-release"].Repository).To(Equal("zot.zot.svc.cluster.local:5000/solar-system/solar-system/release-ocm-demo-release"))
+	})
 })

--- a/pkg/renderer/push_chart.go
+++ b/pkg/renderer/push_chart.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	ociname "github.com/google/go-containerregistry/pkg/name"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/registry"
 	"sigs.k8s.io/yaml"
@@ -108,13 +109,14 @@ func ChartExists(opts PushOptions) (bool, error) {
 	}
 
 	// Parse "oci://host/repo:tag" into repo ref and tag
-	parts := strings.Split(opts.Reference, ":")
-	if len(parts) < 2 {
-		return false, fmt.Errorf("invalid reference, no tag found: %s", opts.Reference)
+	trimmedRef := strings.TrimPrefix(opts.Reference, "oci://")
+	ref, err := ociname.ParseReference(trimmedRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse reference %s: %w", opts.Reference, err)
 	}
 
-	tag := parts[len(parts)-1]
-	repoRef := strings.TrimSuffix(opts.Reference, ":"+tag)
+	tag := ref.Identifier()
+	repoRef := ref.Context().String()
 
 	client, err := registry.NewClient(opts.ClientOptions...)
 	if err != nil {

--- a/pkg/renderer/push_chart_test.go
+++ b/pkg/renderer/push_chart_test.go
@@ -4,6 +4,7 @@
 package renderer
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,9 @@ import (
 	"net/http/httptest"
 	"os"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"helm.sh/helm/v4/pkg/registry"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -289,5 +293,75 @@ var _ = Describe("PushChart", func() {
 			Expect(result).NotTo(BeNil())
 			Expect(result.Ref).NotTo(BeEmpty())
 		})
+	})
+})
+
+var _ = Describe("ChartExists", func() {
+	It("should return an error for empty reference", func() {
+		opts := PushOptions{Reference: ""}
+		exists, err := ChartExists(opts)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("registry reference is required"))
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should return an error for reference with an empty tag", func() {
+		opts := PushOptions{
+			Reference: "oci://registry.example.com/charts/test-chart:",
+		}
+		exists, err := ChartExists(opts)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse reference"))
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should return false when chart does not exist in registry", func() {
+		reg := testregistry.New()
+		srv := httptest.NewServer(reg.HandleFunc())
+		defer srv.Close()
+
+		listener := srv.Listener.Addr().(*net.TCPAddr)
+		referenceURL := fmt.Sprintf("oci://localhost:%d/nonexistent-chart:1.0.0", listener.Port)
+
+		opts := PushOptions{
+			Reference: referenceURL,
+			ClientOptions: []registry.ClientOption{
+				registry.ClientOptPlainHTTP(),
+			},
+		}
+
+		exists, err := ChartExists(opts)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should return true when chart exists in registry", func() {
+		reg := testregistry.New()
+		srv := httptest.NewServer(reg.HandleFunc())
+		defer srv.Close()
+
+		listener := srv.Listener.Addr().(*net.TCPAddr)
+		chartName := "existing-chart"
+		tag := "1.0.0"
+		referenceURL := fmt.Sprintf("oci://localhost:%d/%s:%s", listener.Port, chartName, tag)
+
+		// Push a minimal OCI manifest so the repository+tag exists in the registry
+		host := fmt.Sprintf("localhost:%d", listener.Port)
+		rawRef := fmt.Sprintf("%s/%s:%s", host, chartName, tag)
+		imgRef, err := name.ParseReference(rawRef, name.Insecure)
+		Expect(err).NotTo(HaveOccurred())
+		err = remote.Write(imgRef, empty.Image, remote.WithContext(context.Background()))
+		Expect(err).NotTo(HaveOccurred())
+
+		opts := PushOptions{
+			Reference: referenceURL,
+			ClientOptions: []registry.ClientOption{
+				registry.ClientOptPlainHTTP(),
+			},
+		}
+
+		exists, err := ChartExists(opts)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
 	})
 })


### PR DESCRIPTION
## What

Closes #628 

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCI chart reference parsing for `oci://` inputs, including explicit ports, to correctly derive repository and tag.
  * Updated chart existence checks to use OCI-aware parsing and return clearer errors when references can’t be interpreted.

* **Tests**
  * Added unit coverage for `oci://` chart URL parsing with explicit ports.
  * Expanded `ChartExists` test scenarios, including empty/missing references, invalid formats, non-existent charts, and confirmed existence after pushing an OCI manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->