### PR TITLE
fix(discovery): exclude terminating CVs from parent Component cleanup

### DIFF
--- a/pkg/discovery/apiwriter/apiwriter.go
+++ b/pkg/discovery/apiwriter/apiwriter.go
@@ -239,7 +239,19 @@ func (rs *APIWriter) deleteComponentVersion(ctx context.Context, ev discovery.Wr
 			if err != nil {
 				return err
 			}
-			if len(remaining.Items) == 0 {
+			// The CV we just deleted still appears here in Terminating state (it carries
+			// a finalizer), so exclude it and any other terminating CVs; otherwise the
+			// parent Component delete is skipped and the Component is orphaned forever.
+			// FIXME: replace this inferred cleanup with a Component reconciler that
+			// owns deletion serialized per-Component (re-creation-safe follow-up).
+			active := 0
+			for _, r := range remaining.Items {
+				if r.Name == cv.Name || !r.DeletionTimestamp.IsZero() {
+					continue
+				}
+				active++
+			}
+			if active == 0 {
 				if err := client.IgnoreNotFound(rs.client.Components(rs.namespace).Delete(ctx, parent, metav1.DeleteOptions{})); err != nil {
 					return err
 				}

--- a/pkg/discovery/apiwriter/apiwriter_test.go
+++ b/pkg/discovery/apiwriter/apiwriter_test.go
@@ -504,5 +504,48 @@ var _ = Describe("APIWriter", Ordered, func() {
 			_, err := solarClient.Components("default").Get(ctx, "opendefense-cloud-ocm-demo", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should delete the parent Component when the only sibling ComponentVersion is already terminating", func() {
+			Expect(writer.Start(ctx)).To(Succeed())
+
+			// Create the CV + Component via a normal create event.
+			inputChan <- createEvent(discovery.EventCreated)
+			Eventually(func() error {
+				_, err := solarClient.ComponentVersions("default").Get(ctx, "opendefense-cloud-ocm-demo-v26-4-2", metav1.GetOptions{})
+				return err
+			}).ShouldNot(HaveOccurred())
+
+			// Seed a sibling CV for the same Component that is already terminating
+			// (deletionTimestamp + finalizer set). The real apiserver leaves such a
+			// CV listable until its finalizer clears, so it must NOT count as an
+			// active reference keeping the parent Component alive — otherwise the
+			// Component is orphaned forever (the e2e webhook GC failure).
+			now := metav1.Now()
+			terminating := &solarv1alpha1.ComponentVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "opendefense-cloud-ocm-demo-v26-5-0",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"solar.opendefense.cloud/componentversion-finalizer"},
+					Labels:            map[string]string{componentLabel: "opendefense-cloud-ocm-demo"},
+				},
+			}
+			_, err := solarClient.ComponentVersions("default").Create(ctx, terminating, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Delete the active CV; its only sibling is terminating, so the parent
+			// Component must be garbage-collected.
+			inputChan <- createEvent(discovery.EventDeleted)
+			Eventually(func() bool {
+				select {
+				case errEvent := <-errChan:
+					Expect(errEvent.Error).NotTo(HaveOccurred())
+				default:
+				}
+				_, err := solarClient.Components("default").Get(ctx, "opendefense-cloud-ocm-demo", metav1.GetOptions{})
+
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue(), "parent Component should be deleted when its only sibling CV is terminating")
+		})
 	})
 })

--- a/pkg/discovery/apiwriter/apiwriter_test.go
+++ b/pkg/discovery/apiwriter/apiwriter_test.go
@@ -508,10 +508,16 @@ var _ = Describe("APIWriter", Ordered, func() {
 		It("should delete the parent Component when the only sibling ComponentVersion is already terminating", func() {
 			Expect(writer.Start(ctx)).To(Succeed())
 
-			// Create the CV + Component via a normal create event.
+			// Create the CV + Component via a normal create event. Wait for both so
+			// the later NotFound assertion can't pass merely because the Component
+			// was never created.
 			inputChan <- createEvent(discovery.EventCreated)
 			Eventually(func() error {
-				_, err := solarClient.ComponentVersions("default").Get(ctx, "opendefense-cloud-ocm-demo-v26-4-2", metav1.GetOptions{})
+				if _, err := solarClient.ComponentVersions("default").Get(ctx, "opendefense-cloud-ocm-demo-v26-4-2", metav1.GetOptions{}); err != nil {
+					return err
+				}
+				_, err := solarClient.Components("default").Get(ctx, "opendefense-cloud-ocm-demo", metav1.GetOptions{})
+
 				return err
 			}).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
## What
When a `ComponentVersion` is deleted, the discovery apiwriter only deletes the parent `Component` if no active CVs remain — terminating siblings no longer keep it alive.

## Why
On a CV delete the apiwriter checks whether any sibling CVs still reference the parent `Component` before deleting it. The just-deleted CV carries a finalizer, so it lingers in `Terminating` state and was still counted by the `len(remaining.Items) == 0` check; the parent delete was skipped and the `Component` orphaned forever. This surfaced as the e2e webhook discovery spec timing out for 600s waiting for the `Component` to be garbage-collected. The fix counts only active CVs, excluding the CV being deleted and any already in `Terminating` state.

## Testing
- New unit test (`pkg/discovery/apiwriter`) seeds a terminating sibling CV — the state the fake clientset never reproduces on its own, which is why this slipped past unit tests while failing e2e — and asserts the parent `Component` is deleted; verified it fails on the pre-fix logic and passes on the fix.
- `go test ./pkg/discovery/apiwriter/...` green; `go vet` clean.

## Notes for reviewers
This is the minimal fix to unblock the release. A follow-up will move `Component` lifecycle into a dedicated reconciler that owns deletion serialized per-`Component`, making it re-creation-safe and removing the inferred-cleanup + finalizer machinery entirely (tracked by the `FIXME` added in this PR).

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component cleanup behavior so parent components are deleted once all child component versions are removed, including cases where remaining siblings are in a terminating state—preventing orphaned parent components.

* **Tests**
  * Added coverage to verify parent component garbage-collection when deleting a component version that leaves only one terminating sibling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->