### PR TITLE
fix(ci): make Makefile the source of truth for e2e K8s version (v1.36.1)

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -33,7 +33,8 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: solar-test-e2e
-          node_image: kindest/node:v1.33.1
+          # Keep in sync with ENVTEST_K8S_VERSION in the Makefile (KIND_NODE_IMAGE derives from it).
+          node_image: kindest/node:v1.36.0
       - name: Install Tools
         run: |
           # Install kubectl

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -29,14 +29,18 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ steps.go-version.outputs.version }}
-      - name: Create Kubernetes (Kind) Cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          cluster_name: solar-test-e2e
-          # Keep in sync with ENVTEST_K8S_VERSION in the Makefile (KIND_NODE_IMAGE derives from it).
-          node_image: kindest/node:v1.36.0
       - name: Install Tools
         run: |
+          # Install kind. The e2e suite creates the cluster itself via
+          # `make e2e-cluster`, pinned to KIND_NODE_IMAGE (derived from
+          # ENVTEST_K8S_VERSION) — the Makefile is the single source of truth
+          # for the K8s version, so we only need the binary here.
+          KIND_VERSION="v0.31.0"
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
           # Install kubectl
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           chmod +x ./kubectl

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SOLAR_CHART_DIR ?= $(BUILD_PATH)/charts/solar
 OCM_DEMO_DIR ?= $(BUILD_PATH)/test/fixtures/ocm-demo-ctf
 OCM_DEMO_VERSION ?= v26.4.2
 
-ENVTEST_K8S_VERSION ?= 1.36.0
+ENVTEST_K8S_VERSION ?= 1.36.1
 
 # Kind node image for e2e — defaults to track ENVTEST_K8S_VERSION so envtest
 # (`make test`) and Kind-based e2e (`make test-e2e`) target the same K8s


### PR DESCRIPTION
## What
Fix the E2E workflow by making the Makefile the single source of truth for the K8s version: bump `ENVTEST_K8S_VERSION` to `1.36.1` and let `make e2e-cluster` own Kind cluster creation instead of the workflow.

## Why
The workflow pre-created the `solar-test-e2e` cluster via `helm/kind-action`, while `make test-e2e` (`make e2e-cluster` → `ensure-kind-cluster.sh`) created its own cluster pinned to `KIND_NODE_IMAGE` (derived from `ENVTEST_K8S_VERSION`). Two creators with two version values meant they could disagree — and they did, breaking E2E. The first attempted bump also exposed that `kindest/node:v1.36.0` was never published; `v1.36.1` is the real tag. Now the version lives only in the Makefile, `kind` is just a binary the workflow installs, and `make e2e-cluster` is the sole creator (no-op reuse when the cluster already matches).

## Testing
CI E2E run on this branch.

## Notes for reviewers
- `ENVTEST_K8S_VERSION 1.36.0 → 1.36.1`; `KIND_NODE_IMAGE` auto-derives `kindest/node:v1.36.1`, and envtest fetches `1.36.1` via the sideload script (dl.k8s.io on Linux CI).
- Removed the `helm/kind-action` step; `kind v0.31.0` is now installed in the `Install Tools` step. Cluster creation is fully owned by `make e2e-cluster` in the suite's `BeforeSuite`.
- Follow-up (separate issue/PR, not here): migrate all CI workflows to run under nix so every tool version comes from the dev shell instead of hardcoded installs.

## Checklist
- [x] ~~Tests added/updated~~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved
