### PR TITLE
ci: pin dependencies for docs generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,14 @@
-mkdocs-material
-pymdown-extensions >= 10.16.1
-mkdocs-glightbox
-mkdocs-include-markdown-plugin
-mkdocs-panzoom-plugin
-mkdocs-awesome-nav
+mkdocs-material == 9.7.6
+pymdown-extensions ==11.0
+mkdocs-glightbox == 0.5.2
+mkdocs-include-markdown-plugin == 7.3.0
+mkdocs-panzoom-plugin == 0.5.2
+mkdocs-awesome-nav == 3.3.0
 
-pillow >= 10.3.0
-cairosvg
-mike
+pillow == 12.2.0
+cairosvg == 2.9.0
+mike == 2.2.0
+
+# Pinned transitive dependency; introduced to patch GHSA-65pc-fj4g-8rjx
+# (CVE-2026-45409). Kept current by Renovate.
+idna == 3.18


### PR DESCRIPTION
# What
Pins dependencies for dependencies used for docs generation.

## Why
osv sanning failed https://github.com/opendefensecloud/solution-arsenal/actions/runs/28087886593/job/83158256773 with (among other):

```
 | https://osv.dev/PYSEC-2026-215      | 6.9  | PyPI      | idna                                | 3.9.0               | 3.15          | docs/requirements.txt |
```

Pinned the dependencies so that we control the tooling that we use in CI and pinned a vulnerable, transitive dependency to make the osv scanning happy.

## Testing
none, beside checks in this PR


## Checklist
- [x] ~Tests added/updated~ n/a
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Operator Manual section with a reference architecture guide for the SolAr deployment workflow.

* **Documentation**
  * Expanded operator documentation with setup guidance, namespace layout, access relationships, and end-to-end deployment flow.
  * Added example manifests and navigation entries to make the new content easier to find.

* **Chores**
  * Updated documentation dependencies to fixed versions for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->