### PR TITLE
chore: add macOS support for envtest sideloading and UI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,13 @@ ui-test-e2e: ui-build ## Run Playwright UI e2e tests (auto-creates cluster if ne
 	done; \
 	cd web && DEX_LOCAL_PORT=5556 $(PNPM) exec playwright test; \
 	exit $$?
+ifeq ($(OS),darwin)
+ui-test-e2e: ui-playwright-browser
+
+.PHONY: ui-playwright-browser
+ui-playwright-browser: ui-install ## Install Playwright's Chromium browser (macOS; Linux uses the Nix-provided chromium)
+	cd web && $(PNPM) exec playwright install chromium
+endif
 
 ##@ Docs
 

--- a/Makefile
+++ b/Makefile
@@ -244,10 +244,11 @@ ui-dev: ui-install ## Start Go backend + Vite dev server against the UI dev clus
 	cd web && $(PNPM) exec concurrently --kill-others --names "dex,vite,bff" --prefix-colors "magenta,cyan,yellow" \
 		"KUBECONFIG=/tmp/solar-ui-dev-kubeconfig $(KUBECTL) port-forward -n dex service/dex 5556:5556" \
 		"$(PNPM) dev --port 5173" \
-		"sleep 2 && cd $(BUILD_PATH) && SSL_CERT_FILE=$(BUILD_PATH)/test/fixtures/dex-ca.crt $(GO) run ./cmd/solar-ui \
+		"sleep 2 && cd $(BUILD_PATH) && $(GO) run ./cmd/solar-ui \
 			--listen=0.0.0.0:8090 \
 			--kubeconfig=/tmp/solar-ui-dev-kubeconfig \
 			--oidc-issuer=https://localhost:5556 \
+			--oidc-ca-cert=$(BUILD_PATH)/test/fixtures/dex-ca.crt \
 			--oidc-client-id=solar-ui \
 			--oidc-client-secret=solar-ui-secret \
 			--oidc-redirect-url=http://localhost:8090/api/auth/callback \
@@ -288,11 +289,11 @@ ui-test-e2e: ui-build ## Run Playwright UI e2e tests (auto-creates cluster if ne
 		sleep 1; \
 	done; \
 	echo "Starting solar-ui backend..."; \
-	SSL_CERT_FILE=$(BUILD_PATH)/test/fixtures/dex-ca.crt \
 	$(LOCALBIN)/solar-ui \
 		--listen=0.0.0.0:8090 \
 		--kubeconfig=/tmp/solar-e2e-ui-kubeconfig \
 		--oidc-issuer=https://localhost:5556 \
+		--oidc-ca-cert=$(BUILD_PATH)/test/fixtures/dex-ca.crt \
 		--oidc-client-id=solar-ui \
 		--oidc-client-secret=solar-ui-secret \
 		--oidc-redirect-url=http://localhost:8090/api/auth/callback \

--- a/cmd/solar-ui/main.go
+++ b/cmd/solar-ui/main.go
@@ -29,6 +29,7 @@ func init() {
 	cmd.Flags().String("oidc-client-id", "solar-ui", "OIDC client ID")
 	cmd.Flags().String("oidc-client-secret", "", "OIDC client secret")
 	cmd.Flags().String("oidc-redirect-url", "http://localhost:8090/api/auth/callback", "OIDC redirect URL")
+	cmd.Flags().String("oidc-ca-cert", "", "Path to a PEM CA file trusted for TLS to the OIDC issuer (e.g. a dev Dex with a private CA)")
 	cmd.Flags().String("session-key", "", "Session encryption key (32 bytes, hex-encoded). Generated if empty.")
 	cmd.Flags().String("kubeconfig", "", "Path to kubeconfig (defaults to in-cluster config)")
 	cmd.Flags().String("auth-mode", "token", "How to convey OIDC identity to K8s: 'token' (forward id_token) or 'impersonate'")
@@ -52,6 +53,7 @@ func runE(cmd *cobra.Command, _ []string) error {
 	oidcClientID, _ := cmd.Flags().GetString("oidc-client-id")
 	oidcClientSecret, _ := cmd.Flags().GetString("oidc-client-secret")
 	oidcRedirectURL, _ := cmd.Flags().GetString("oidc-redirect-url")
+	oidcCACert, _ := cmd.Flags().GetString("oidc-ca-cert")
 	sessionKey, _ := cmd.Flags().GetString("session-key")
 	kubeconfig, _ := cmd.Flags().GetString("kubeconfig")
 	authMode, _ := cmd.Flags().GetString("auth-mode")
@@ -63,6 +65,7 @@ func runE(cmd *cobra.Command, _ []string) error {
 		OIDCClientID:     oidcClientID,
 		OIDCClientSecret: oidcClientSecret,
 		OIDCRedirectURL:  oidcRedirectURL,
+		OIDCCACertFile:   oidcCACert,
 		SessionKey:       sessionKey,
 		Kubeconfig:       kubeconfig,
 		AuthMode:         authMode,

--- a/flake.lock
+++ b/flake.lock
@@ -15,11 +15,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781095231,
-        "narHash": "sha256-f1s7iZEvvgUsKSrfIYnm85cWtuvZVstlHJEK407yZDI=",
+        "lastModified": 1781814153,
+        "narHash": "sha256-jbx068xJf5OwC6lR/JM33myb/+KnATU8HCK6AHJTVY8=",
         "owner": "opendefensecloud",
         "repo": "dev-kit",
-        "rev": "5107b50be074d483888a332c008d6bd27beb93e0",
+        "rev": "41370fd52f6889401ef79388e54e7e38bfbf112e",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781239934,
-        "narHash": "sha256-bK84gDc7MgPdoQfr4k1oSIsdA9pSXVjEc3QPpVFGRPs=",
+        "lastModified": 1782106363,
+        "narHash": "sha256-G83I05Qk2IiSmTbbokvwxcyOKYsSAGAnj+ZwCVGXp5k=",
         "owner": "purpleclay",
         "repo": "go-overlay",
-        "rev": "efc8ba6788ff0736cc2098d7c588d58819a927e7",
+        "rev": "1ab2d7b1da14962bc0beb5f2f0f535cc482a6f31",
         "type": "github"
       },
       "original": {
@@ -219,11 +219,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,11 +32,11 @@
             fluxcd
             nodejs_22
             pnpm
-            chromium
-          ];
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.chromium ];
 
           env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-          env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = "${pkgs.chromium}/bin/chromium";
+          env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH =
+            pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.chromium}/bin/chromium";
 
           preCommitHooks = {
             commitlint.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,8 @@
             pnpm
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.chromium ];
 
-          env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+          env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD =
+            pkgs.lib.optionalString pkgs.stdenv.isLinux "1";
           env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH =
             pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.chromium}/bin/chromium";
 

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -39,34 +39,44 @@ if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -i -p path >/dev/nul
   exit 0
 fi
 
-# Detect host. dl.k8s.io publishes kube-apiserver only for linux server
-# platforms (darwin/windows return 404). controller-tools cross-compiles its
-# own darwin/windows envtest archives from K8s source — we can't replicate
-# that from a shell script, so on non-linux hosts we defer to vanilla
-# `setup-envtest use` (which downloads from controller-tools' index). It
-# succeeds whenever the requested version is in the index; only when the
-# index has no entry do we have to give up and ask the dev to pin.
-# 
+# Detect host platform up front — both the sideload paths and the messages
+# below need it.
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
-if [ "$os" != "linux" ]; then
-  if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then
-    exit 0
-  fi
-  cat >&2 <<EOF
-envtest-sideload: ${os} is supported via controller-tools' pre-packaged
-  archives, but '${K8S_VERSION}' is not in their index and dl.k8s.io has
-  no kube-apiserver binary for non-linux platforms.
-  List available versions:    ${SETUP_ENVTEST} list
-  Then pin ENVTEST_K8S_VERSION to one of those, or run on Linux where
-  this script can sideload the upstream K8s/etcd binaries directly.
-EOF
-  exit 1
-fi
 case "$(uname -m)" in
   x86_64)        arch=amd64 ;;
   aarch64|arm64) arch=arm64 ;;
   *) echo "envtest-sideload: unsupported arch $(uname -m)" >&2; exit 1 ;;
 esac
+
+# We can only assemble a sideload tarball from upstream sources on linux and
+# darwin. For anything else (e.g. windows) controller-tools cross-compiles its
+# own envtest archives that we can't replicate from a shell script, so defer to
+# vanilla `setup-envtest use` (the controller-tools index) and only fail when
+# the requested version isn't there.
+if [ "$os" != linux ] && [ "$os" != darwin ]; then
+  if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then
+    exit 0
+  fi
+  cat >&2 <<EOF
+envtest-sideload: ${os} is supported only via controller-tools' pre-packaged
+  archives, but '${K8S_VERSION}' is not in their index and this script can only
+  sideload upstream binaries on linux and darwin.
+  List available versions:    ${SETUP_ENVTEST} list
+  Then pin ENVTEST_K8S_VERSION to one of those.
+EOF
+  exit 1
+fi
+
+# On darwin, dl.k8s.io publishes no kube-apiserver (Kubernetes builds server
+# binaries only for linux/windows), so sideloading there means building
+# kube-apiserver from source — a slow, heavy first run. Prefer controller-tools'
+# pre-packaged darwin archive whenever the requested version is in their index;
+# only fall through to the source build when it isn't.
+if [ "$os" = darwin ]; then
+  if "$SETUP_ENVTEST" use "$K8S_VERSION" --bin-dir "$BIN_DIR" -p path >/dev/null 2>&1; then
+    exit 0
+  fi
+fi
 
 # Wrap curl with retries + timeouts so transient network blips don't fail
 # the whole sideload. --retry-all-errors covers HTTP 5xx (curl 7.71+, 2020).
@@ -76,6 +86,17 @@ fetch() {
   curl --fail --silent --show-error --location \
     --retry 3 --retry-delay 2 --retry-all-errors \
     --connect-timeout 10 --max-time 300 "$@"
+}
+
+# Portable SHA-256 verification: reads `<hash>  <file>` lines on stdin and
+# checks them. GNU coreutils ships `sha256sum`; stock macOS ships only
+# `shasum`. Both accept the same check format on stdin.
+sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -
+  else
+    shasum -a 256 -c -
+  fi
 }
 
 # Look up the etcd version K8s ships with from its build/dependencies.yaml.
@@ -92,41 +113,89 @@ echo "envtest-sideload: K8s ${K8S_VERSION} ships with etcd ${etcd_version} (${os
 
 stage=$(mktemp -d)
 trap 'rm -rf "$stage"' EXIT
+mkdir -p "$stage/k8s-bin"
 
 # --- K8s binaries (kube-apiserver, kubectl) --------------------------------
 # Direct per-binary downloads avoid pulling the ~600 MB server tarball when we
-# only need two binaries (~150 MB + ~50 MB combined).
+# only need two binaries. kubectl is published for every platform (incl.
+# darwin); kube-apiserver only for linux/windows, so darwin builds it from
+# source below.
 #
 # NOTE: If a future K8s release ships a new server binary that envtest
 # expects (e.g. some hypothetical "super-controller-thing"), envtest will
 # fail to start the control plane and the test run will surface the missing
-# binary. Add the new name to the loop below — the server tarball at
-# dl.k8s.io/v${VER}/kubernetes-server-${os}-${arch}.tar.gz is the canonical
-# index of what's available per release if you need to discover the exact
-# filename. Same applies if envtest itself ever adds a required binary
-# beyond kube-apiserver/etcd/kubectl.
+# binary. Add the new name to the download/build steps below — the server
+# tarball at dl.k8s.io/v${VER}/kubernetes-server-${os}-${arch}.tar.gz is the
+# canonical index of what's available per release. Same applies if envtest
+# itself ever adds a required binary beyond kube-apiserver/etcd/kubectl.
 k8s_base="https://dl.k8s.io/release/v${K8S_VERSION}/bin/${os}/${arch}"
-mkdir -p "$stage/k8s-bin"
-for bin in kube-apiserver kubectl; do
+download_k8s_bin() {
+  local bin="$1"
   echo "envtest-sideload: downloading ${k8s_base}/${bin}"
   fetch -o "$stage/k8s-bin/$bin"        "$k8s_base/$bin"
   fetch -o "$stage/k8s-bin/$bin.sha256" "$k8s_base/$bin.sha256"
   # The .sha256 sibling is just the hex digest; pair with the filename ourselves.
-  ( cd "$stage/k8s-bin" && printf '%s  %s\n' "$(cat "$bin.sha256")" "$bin" | sha256sum -c - )
+  ( cd "$stage/k8s-bin" && printf '%s  %s\n' "$(cat "$bin.sha256")" "$bin" | sha256_check )
   chmod +x "$stage/k8s-bin/$bin"
-done
+}
 
-# --- etcd tarball (etcd binary) --------------------------------------------
+download_k8s_bin kubectl
+
+if [ "$os" = linux ]; then
+  download_k8s_bin kube-apiserver
+else
+  # darwin: no upstream kube-apiserver binary exists, so build it from the
+  # tagged Kubernetes source — exactly what controller-tools does to produce
+  # its darwin envtest archives. First run is slow (~hundreds of MB of source
+  # + a multi-minute compile); the result is cached by setup-envtest afterward.
+  command -v go >/dev/null 2>&1 || {
+    echo "envtest-sideload: building kube-apiserver for ${os} requires Go on PATH" >&2
+    exit 1
+  }
+  echo "envtest-sideload: no upstream ${os} kube-apiserver binary exists; building v${K8S_VERSION} from source (this can take several minutes; the result is cached)"
+  src="$stage/kubernetes"
+  git clone --quiet --depth 1 --branch "v${K8S_VERSION}" \
+    https://github.com/kubernetes/kubernetes "$src"
+  # Stamp version metadata the way upstream's hack/lib/version.sh does, so the
+  # apiserver reports the correct version over /version (some tests read it).
+  # `go build -X` silently ignores symbols a given release doesn't define, so
+  # listing both the component-base and client-go mirrors is safe across versions.
+  ver_major="${K8S_VERSION%%.*}"
+  ver_rest="${K8S_VERSION#*.}"
+  ver_minor="${ver_rest%%.*}"
+  build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  ldflags=""
+  for pkg in k8s.io/component-base/version k8s.io/client-go/pkg/version; do
+    ldflags+=" -X ${pkg}.gitVersion=v${K8S_VERSION}"
+    ldflags+=" -X ${pkg}.gitMajor=${ver_major}"
+    ldflags+=" -X ${pkg}.gitMinor=${ver_minor}"
+    ldflags+=" -X ${pkg}.gitCommit=v${K8S_VERSION}"
+    ldflags+=" -X ${pkg}.gitTreeState=clean"
+    ldflags+=" -X ${pkg}.buildDate=${build_date}"
+  done
+  ( cd "$src" && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+      go build -ldflags "$ldflags" -o "$stage/k8s-bin/kube-apiserver" ./cmd/kube-apiserver )
+  chmod +x "$stage/k8s-bin/kube-apiserver"
+fi
+
+# --- etcd archive (etcd binary) --------------------------------------------
+# etcd publishes a .tar.gz per linux platform and a .zip per darwin platform.
 etcd_dir="etcd-v${etcd_version}-${os}-${arch}"
-etcd_tar="${etcd_dir}.tar.gz"
 etcd_base="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}"
-echo "envtest-sideload: downloading ${etcd_base}/${etcd_tar}"
-fetch -o "$stage/$etcd_tar"    "$etcd_base/$etcd_tar"
-fetch -o "$stage/SHA256SUMS"   "$etcd_base/SHA256SUMS"
-# etcd's SHA256SUMS lists `<hash>  <filename>` for every platform tarball;
-# grep our specific filename and pass to sha256sum -c.
-( cd "$stage" && grep "  ${etcd_tar}\$" SHA256SUMS | sha256sum -c - )
-tar -C "$stage" -xzf "$stage/$etcd_tar" "$etcd_dir/etcd"
+if [ "$os" = linux ]; then
+  etcd_archive="${etcd_dir}.tar.gz"
+  extract_etcd() { tar -C "$stage" -xzf "$stage/$etcd_archive" "$etcd_dir/etcd"; }
+else
+  etcd_archive="${etcd_dir}.zip"
+  extract_etcd() { unzip -q -o -d "$stage" "$stage/$etcd_archive" "$etcd_dir/etcd"; }
+fi
+echo "envtest-sideload: downloading ${etcd_base}/${etcd_archive}"
+fetch -o "$stage/$etcd_archive" "$etcd_base/$etcd_archive"
+fetch -o "$stage/SHA256SUMS"    "$etcd_base/SHA256SUMS"
+# etcd's SHA256SUMS lists `<hash>  <filename>` for every platform archive;
+# select our exact filename (awk field match — no regex metachars) and verify.
+( cd "$stage" && awk -v f="$etcd_archive" '$2 == f' SHA256SUMS | sha256_check )
+extract_etcd
 
 # --- Assemble the sideload tarball with the three binaries at top level ---
 sideload_tar="$stage/sideload.tar.gz"

--- a/hack/envtest-sideload.sh
+++ b/hack/envtest-sideload.sh
@@ -103,7 +103,7 @@ sha256_check() {
 # Self-updating per K8s release.
 deps_url="https://raw.githubusercontent.com/kubernetes/kubernetes/v${K8S_VERSION}/build/dependencies.yaml"
 etcd_version=$(fetch "$deps_url" \
-  | "$YQ" '.dependencies[] | select(.name == "etcd") | .version')
+  | "$YQ" '.dependencies[] | select(.name == "etcd") | .version' | tr -d '"')
 if [[ -z "$etcd_version" ]]; then
   echo "envtest-sideload: could not resolve etcd version from $deps_url" >&2
   exit 1

--- a/pkg/ui/auth/oidc.go
+++ b/pkg/ui/auth/oidc.go
@@ -6,10 +6,13 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
@@ -38,19 +41,33 @@ type OIDCConfig struct {
 	ClientSecret string //nolint:gosec // config field, not a hardcoded credential
 	RedirectURL  string
 	AuthMode     AuthMode
+	// CACertFile, when set, is a PEM file whose certificates are used as the TLS
+	// roots for talking to the issuer. Needed when the issuer (e.g. a dev Dex)
+	// presents a private CA. (SSL_CERT_FILE is ignored on macOS).
+	CACertFile string
 }
 
 // OIDCProvider implements the Provider interface using OpenID Connect.
 type OIDCProvider struct {
-	provider *oidc.Provider
-	oauth    oauth2.Config
-	verifier *oidc.IDTokenVerifier
-	authMode AuthMode
+	provider   *oidc.Provider
+	oauth      oauth2.Config
+	verifier   *oidc.IDTokenVerifier
+	authMode   AuthMode
+	httpClient *http.Client
 }
 
 // NewOIDCProvider creates a new OIDC provider.
 func NewOIDCProvider(cfg OIDCConfig) (*OIDCProvider, error) {
-	provider, err := oidc.NewProvider(context.Background(), cfg.Issuer)
+	httpClient, err := newHTTPClient(cfg.CACertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Carry the HTTP client through the context so go-oidc uses it for discovery
+	// and (via the provider) for fetching the remote JWKS.
+	ctx := oidc.ClientContext(context.Background(), httpClient)
+
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC provider for issuer %q: %w", cfg.Issuer, err)
 	}
@@ -71,11 +88,42 @@ func NewOIDCProvider(cfg OIDCConfig) (*OIDCProvider, error) {
 	}
 
 	return &OIDCProvider{
-		provider: provider,
-		oauth:    oauthCfg,
-		verifier: verifier,
-		authMode: authMode,
+		provider:   provider,
+		oauth:      oauthCfg,
+		verifier:   verifier,
+		authMode:   authMode,
+		httpClient: httpClient,
 	}, nil
+}
+
+// newHTTPClient builds an HTTP client. When caCertFile is set, its PEM certificates
+// are added to the system root pool and used as the TLS roots.
+func newHTTPClient(caCertFile string) (*http.Client, error) {
+	if caCertFile == "" {
+		return &http.Client{}, nil
+	}
+
+	pem, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OIDC CA cert %q: %w", caCertFile, err)
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no certificates found in OIDC CA cert %q", caCertFile)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	return &http.Client{Transport: transport}, nil
 }
 
 // HandleLogin redirects the user to the OIDC provider.
@@ -106,7 +154,9 @@ func (p *OIDCProvider) HandleCallback(store *session.Store) http.HandlerFunc {
 		}
 		store.ClearState(w)
 
-		token, err := p.oauth.Exchange(r.Context(), code)
+		ctx := oidc.ClientContext(r.Context(), p.httpClient)
+
+		token, err := p.oauth.Exchange(ctx, code)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("token exchange failed: %v", err), http.StatusInternalServerError)
 
@@ -120,7 +170,7 @@ func (p *OIDCProvider) HandleCallback(store *session.Store) http.HandlerFunc {
 			return
 		}
 
-		idToken, err := p.verifier.Verify(r.Context(), rawIDToken)
+		idToken, err := p.verifier.Verify(ctx, rawIDToken)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("id_token verification failed: %v", err), http.StatusInternalServerError)
 

--- a/pkg/ui/config.go
+++ b/pkg/ui/config.go
@@ -10,8 +10,11 @@ type Config struct {
 	OIDCClientID     string
 	OIDCClientSecret string //nolint:gosec // config field, not a hardcoded credential
 	OIDCRedirectURL  string
-	SessionKey       string //nolint:gosec // config field, not a hardcoded credential
-	Kubeconfig       string
+	// OIDCCACertFile, when set, is a PEM file whose certificates are trusted for
+	// TLS to the OIDC issuer (e.g. a dev Dex using a private CA).
+	OIDCCACertFile string
+	SessionKey     string //nolint:gosec // config field, not a hardcoded credential
+	Kubeconfig     string
 	// AuthMode controls how OIDC identity is conveyed to K8s: "token" (default)
 	// forwards the id_token as a bearer token; "impersonate" uses K8s impersonation.
 	AuthMode string

--- a/pkg/ui/server.go
+++ b/pkg/ui/server.go
@@ -49,6 +49,7 @@ func NewServer(cfg Config, log logr.Logger) (*Server, error) {
 			ClientSecret: cfg.OIDCClientSecret,
 			RedirectURL:  cfg.OIDCRedirectURL,
 			AuthMode:     auth.AuthMode(cfg.AuthMode),
+			CACertFile:   cfg.OIDCCACertFile,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create OIDC provider: %w", err)


### PR DESCRIPTION
## What
Closes #650

## Why
- No pre-compiled binaries for kubeapi-server exist for darwin that are needed to envtest sideloading -> compile them when on macOS
- `SSL_CERT_FILE` is ignored on macOS -> pass it and attach it to the http Client used when calling the OIDC issuer in the context of UI dev
- No chromium nix package exist for darwin -> install them separately when on macOS

## Testing
`make test` and `make test-e2e-ui`

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing a custom PEM CA certificate to trust your OIDC issuer.
  * Exposed this via a new OIDC server option/CLI flag and corresponding UI configuration field.
* **Bug Fixes**
  * Improved local UI and UI test startup to apply the OIDC CA explicitly.
  * Enhanced cross-platform envtest sideloading with stronger checksum/archiving verification.
  * Made Playwright’s Chromium download configuration apply only on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->