### PR TITLE
fix: handle insecure deploy registry for bootstrap chart

### DIFF
--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -537,7 +537,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	default:
 		// RenderTask exists — check if the desired bootstrap input changed
 		// (release set, resolved refs/tags, or userdata)
-		desiredInput, inputErr := buildBootstrapInput(target, releases, registry.Spec.TargetPullSecretName)
+		desiredInput, inputErr := buildBootstrapInput(target, releases, registry.Spec.TargetPullSecretName, registry.Spec.PlainHTTP)
 		if inputErr != nil {
 			return ctrl.Result{}, errLogAndWrap(log, inputErr, "failed to build desired bootstrap input for comparison")
 		}
@@ -1012,7 +1012,7 @@ func (r *TargetReconciler) computeReleaseRenderTaskSpec(rel *solarv1alpha1.Relea
 
 // buildBootstrapInput constructs the desired BootstrapInput from the current
 // target and resolved releases. Used for both comparison and spec construction.
-func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, renderRegistryPullSecret string) (solarv1alpha1.BootstrapInput, error) {
+func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, renderRegistryPullSecret string, insecure bool) (solarv1alpha1.BootstrapInput, error) {
 	resolvedReleases := map[string]solarv1alpha1.ResolvedResourceAccess{}
 
 	for _, ri := range releases {
@@ -1030,6 +1030,7 @@ func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, r
 			Repository:     ref.Context().String(),
 			Tag:            ref.Identifier(),
 			PullSecretName: renderRegistryPullSecret,
+			Insecure:       insecure,
 		}
 	}
 
@@ -1040,7 +1041,7 @@ func buildBootstrapInput(target *solarv1alpha1.Target, releases []releaseInfo, r
 }
 
 func (r *TargetReconciler) computeBootstrapRenderTaskSpec(target *solarv1alpha1.Target, releases []releaseInfo, registry *solarv1alpha1.Registry, bootstrapVersion int64) (solarv1alpha1.RenderTaskSpec, error) {
-	input, err := buildBootstrapInput(target, releases, registry.Spec.TargetPullSecretName)
+	input, err := buildBootstrapInput(target, releases, registry.Spec.TargetPullSecretName, registry.Spec.PlainHTTP)
 	if err != nil {
 		return solarv1alpha1.RenderTaskSpec{}, err
 	}

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -1739,7 +1739,7 @@ var _ = Describe("buildBootstrapInput", func() {
 
 	It("returns an error when uniqueName is empty (resolveReleaseConflicts was not called)", func() {
 		releases := []releaseInfo{{name: "my-release", chartURL: "registry.example.com/ns/my-release:v1.0.0"}}
-		_, err := buildBootstrapInput(target, releases, "")
+		_, err := buildBootstrapInput(target, releases, "", false)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("empty uniqueName"))
 	})
@@ -1770,7 +1770,7 @@ var _ = Describe("buildBootstrapInput", func() {
 		resolvedUniqueNames := []string{resolved[0].uniqueName, resolved[1].uniqueName}
 		Expect(resolvedUniqueNames).To(ConsistOf("component-a", "component-b"))
 
-		input, err := buildBootstrapInput(target, resolved, "")
+		input, err := buildBootstrapInput(target, resolved, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(input.Releases).To(HaveLen(2), "both releases must appear; same ri.name must not cause a collision")
 		Expect(input.Releases).To(HaveKey("component-a"))
@@ -1783,11 +1783,35 @@ var _ = Describe("buildBootstrapInput", func() {
 			uniqueName: "uniq-release",
 			chartURL:   "oci://zot.zot.svc.cluster.local:5000/solar-system/solar-system/release-ocm-demo-release:v0.0.2-ec0e3b98",
 		}}
-		input, err := buildBootstrapInput(target, releases, "")
+		input, err := buildBootstrapInput(target, releases, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(input.Releases).To(HaveLen(1))
 		Expect(input.Releases).To(HaveKey("uniq-release"))
 		Expect(input.Releases["uniq-release"].Tag).To(Equal("v0.0.2-ec0e3b98"))
 		Expect(input.Releases["uniq-release"].Repository).To(Equal("zot.zot.svc.cluster.local:5000/solar-system/solar-system/release-ocm-demo-release"))
+	})
+
+	It("sets insecure=true on all releases when insecure argument is true", func() {
+		releases := []releaseInfo{{
+			name:       "my-release",
+			uniqueName: "uniq-release",
+			chartURL:   "oci://registry.example.com/ns/my-release:v1.0.0",
+		}}
+		input, err := buildBootstrapInput(target, releases, "pull-secret", true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(input.Releases).To(HaveLen(1))
+		Expect(input.Releases["uniq-release"].Insecure).To(BeTrue())
+	})
+
+	It("sets insecure=false on all releases when insecure argument is false", func() {
+		releases := []releaseInfo{{
+			name:       "my-release",
+			uniqueName: "uniq-release",
+			chartURL:   "oci://registry.example.com/ns/my-release:v1.0.0",
+		}}
+		input, err := buildBootstrapInput(target, releases, "pull-secret", false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(input.Releases).To(HaveLen(1))
+		Expect(input.Releases["uniq-release"].Insecure).To(BeFalse())
 	})
 })


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #631

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bootstrap and registry handling now supports plain HTTP connections, improving compatibility with insecure registries.

* **Bug Fixes**
  * Updated bootstrap comparison logic so changes to registry connection mode correctly trigger a refresh when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->