### PR TITLE
fix(release): sign release artefacts as Sigstore bundles

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,10 +95,15 @@ jobs:
           cd bin
           for f in *; do
             [ -f "$f" ] || continue
-            case "$f" in *.sig|*.pem) continue ;; esac
+            case "$f" in *.sigstore.json) continue ;; esac
+            # Emit a Sigstore bundle (signature + cert + Rekor proof), named
+            # *.sigstore.json so OpenSSF Scorecard's Signed-Releases check
+            # detects it. Don't revert to --output-signature/--output-certificate:
+            # those are deprecated and silently ignored by newer cosign, which
+            # defaults to the bundle format and requires --bundle.
             cosign sign-blob --yes \
-              --output-signature "${f}.sig" \
-              --output-certificate "${f}.pem" \
+              --new-bundle-format=true \
+              --bundle "${f}.sigstore.json" \
               "$f"
           done
 

--- a/docs/operator-manual/releases.md
+++ b/docs/operator-manual/releases.md
@@ -8,14 +8,13 @@ Versions are expressed as `x.y.z`, where `x` is the major version, `y` is the mi
 
 ## Verifying release artefacts
 
-Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching `<file>.sig` (signature) and `<file>.pem` (certificate) is published next to it on the GitHub Release page.
+Every release artefact (each binary and `checksums.txt`) is keylessly signed with [cosign](https://docs.sigstore.dev/) during the release workflow. For each artefact `<file>`, a matching Sigstore bundle `<file>.sigstore.json` (containing the signature, certificate, and transparency-log proof) is published next to it on the GitHub Release page.
 
-To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.pem` and `.sig`:
+To verify a downloaded binary, install [cosign](https://docs.sigstore.dev/system_config/installation/) and run `cosign verify-blob`, pointing it at the artefact's `.sigstore.json` bundle:
 
 ```bash
 cosign verify-blob \
-  --certificate solar-apiserver-linux-amd64.pem \
-  --signature  solar-apiserver-linux-amd64.sig \
+  --bundle solar-apiserver-linux-amd64.sigstore.json \
   --certificate-identity-regexp 'https://github.com/opendefensecloud/solution-arsenal/\.github/workflows/release\.yaml@.*' \
   --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
   solar-apiserver-linux-amd64


### PR DESCRIPTION
## What
Sign release artefacts as Sigstore bundles (`<file>.sigstore.json`) instead of separate `.sig`/`.pem` files, fixing the release signing step.

## Why
cosign's `--output-signature`/`--output-certificate` flags are deprecated and are silently ignored by newer cosign, which defaults to the bundle format and requires `--bundle`. With no `--bundle` set the step fails (`create bundle file: open : no such file or directory`) — this is what made the `v0.3.0-rc1` Release job die at the signing step, so no binaries or signatures were ever attached. Rather than pin the deprecated path, emit a modern Sigstore bundle per artefact; OpenSSF Scorecard's `Signed-Releases` check recognises `.sigstore.json` bundles, so the score still lifts.

## Testing
Reproduced the failure (Release for `v0.3.0-rc1`, job `28007736169`) stopping at `Sign release artefacts (keyless)` with the empty-`--bundle` error. Verified a local `sign-blob --new-bundle-format=true --bundle x.sigstore.json` → `verify-blob --bundle x.sigstore.json` round-trip prints `Verified OK` with cosign `v2.6.3`. Container-image signing on `main` independently verifies OK via `cosign verify ghcr.io/opendefensecloud/solar-apiserver:main`, confirming the keyless OIDC→Fulcio→Rekor path is healthy. The binary path only runs on a `v*` tag, so it is first exercised for real by the next release tag.

## Notes for reviewers
CI + docs only (`.github/workflows/release.yaml`, `docs/operator-manual/releases.md`); no code, API, RBAC, or generated artefacts touched, so codegen was not run. Artefact naming changes from `<file>.sig` + `<file>.pem` to a single `<file>.sigstore.json` bundle; the documented `cosign verify-blob` command is updated to match.

## Checklist
- [x] Tests added/updated — n/a (workflow-only; first exercised on the next release tag)
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release downloads now include Sigstore bundle files for verification.
  * Release artefacts are signed using the updated keyless signing flow.

* **Documentation**
  * Updated release-verification instructions to match the new bundle-based signing format.
  * Clarified how to verify downloaded binaries with the revised cosign workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->