### PR TITLE
ci(release): create the GitHub release as a draft for immutable releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,5 +113,8 @@ jobs:
           files: |
             bin/*
           generate_release_notes: true
-          draft: false
+          # Immutable releases forbid uploading assets to an already-published
+          # release, so create a draft with the signed artefacts attached and
+          # publish it separately (UI, or `gh release edit <tag> --draft=false`).
+          draft: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}


### PR DESCRIPTION
## What
Create the GitHub release as a draft so the signed assets attach before publish, in preparation for enabling immutable releases on this repository.

## Why
We're enabling immutable releases here (matching `artifact-conduit`) for supply-chain integrity. Immutable releases forbid uploading assets to an already-published release, so `action-gh-release`'s current `draft: false` create-then-upload flow would fail the moment immutability is on — exactly as it did on `artifact-conduit` (`v0.3.0-rc0` published with zero assets). Switching to `draft: true` attaches the signed `.sigstore.json` bundles to a draft; publishing the draft then locks it immutably with the assets already in place. Landing this before flipping the immutable toggle avoids breaking releases.

## Testing
CI-only change; `release.yaml` runs only on `v*` tags, so it is not exercised by PR CI. Asset production and signing are unchanged (verified on `v0.3.0-rc2`), and the draft→publish flow is already proven on `artifact-conduit`. After merge and enabling immutable releases, the next tag produces a draft release carrying the bundles, published with `gh release edit <tag> --draft=false`.

## Notes for reviewers
Behavior change: releases now land as drafts and must be published explicitly (`gh release edit <tag> --draft=false`, or the Releases UI). This is required by immutable releases — assets cannot be added after publish. Ordering matters: merge this before enabling immutable releases on the repo. Can be automated later with a downstream publish job if desired.

## Checklist
- [x] Tests added/updated — n/a (workflow-only; release.yaml runs on tags)
- [x] No breaking changes (release flow now needs an explicit publish step — documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved
