### PR TITLE
fix(hooks): improve pre-commit hook performance (#669)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -27,8 +27,29 @@
     text = ''
         #!/usr/bin/env bash
         set -e
+
+        BINDIR="$(cd "$(dirname "$0")" && pwd)"
+        GOLANGCI_LINT="$BINDIR/golangci-lint"
+
+        if [ ! -x "$GOLANGCI_LINT" ]; then
+          if command -v go &>/dev/null && [ -f "$BINDIR/../tools.lock" ]; then
+            TOOLSPEC=$(grep '^golangci-lint ' "$BINDIR/../tools.lock" | head -1)
+            if [ -n "$TOOLSPEC" ]; then
+              PKG="${TOOLSPEC#golangci-lint }"
+              echo "pre-commit: installing golangci-lint ($PKG)..." >&2
+              GOBIN="$BINDIR" go install "$PKG"
+            fi
+          fi
+        fi
+
+        if [ ! -x "$GOLANGCI_LINT" ]; then
+          echo "error: golangci-lint not found at $GOLANGCI_LINT" >&2
+          echo "Run 'make lint' or 'make fmt' to install it, or install it manually." >&2
+          exit 1
+        fi
+
         for dir in $(echo "$@" | xargs -n1 dirname | sort -u); do
-          ./bin/golangci-lint run ./"$dir"
+          "$GOLANGCI_LINT" run ./"$dir"
         done
       '';
     executable = true;

--- a/devenv.nix
+++ b/devenv.nix
@@ -27,7 +27,6 @@
     text = ''
         #!/usr/bin/env bash
         set -e
-        make golangci-lint
         for dir in $(echo "$@" | xargs -n1 dirname | sort -u); do
           ./bin/golangci-lint run ./"$dir"
         done
@@ -36,7 +35,6 @@
   };
 
   git-hooks.hooks = {
-    gofmt.enable = true;
     golangci-lint = {
       enable = true;
       entry = "./bin/pre-commit-golangci-lint";


### PR DESCRIPTION
## What
Improve performance of pre-commit hooks by eliminating redundant lint and format runs.

Closes #669

## Why
The fmt and lint pre-commit hooks were slow because:
1. The `golangci-lint` hook ran `make golangci-lint` (full-project scan) before also linting each changed directory individually — a redundant double scan.
2. The `gofmt` hook was redundant since `golangci-lint` already invokes `gofmt` as a formatter.

## Testing
Pre-commit hook invocation can be verified via `devenv shell` by staging Go files and attempting a commit.

## Notes for reviewers
Configuration change only — no code changes.

## Checklist
- [ ] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Go lint hook so it runs directly on the affected directories, making checks faster and more targeted.
  * Updated development configuration to rely on the existing Git hook setup and removed automatic Go formatting enablement from language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->