### PR TITLE
fix(tests): separate unit and integration tests with make test-fast (#667)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,15 +75,25 @@ envtest-binaries-sideload: $(SETUP_ENVTEST)  ## Populate the envtest cache for E
 		bash hack/envtest-sideload.sh $(ENVTEST_K8S_VERSION)
 
 .PHONY: test
-test: $(SETUP_ENVTEST) $(GINKGO) envtest-binaries-sideload ocm-transfer-demo ## Run all tests
+test: $(SETUP_ENVTEST) $(GINKGO) envtest-binaries-sideload ocm-transfer-demo ## Run all tests (including integration tests tagged with 'integration' build tag)
 	mkdir -p $(BUILD_PATH)/coverdata
 	OCM=$(OCM) \
 	GOCOVERDIR=$(BUILD_PATH)/coverdata \
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -i -p path)" \
-	$(GINKGO) -r -cover --fail-fast --require-suite -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile --keep-separate-coverprofiles $(testargs)
+	$(GINKGO) -r -cover --fail-fast --require-suite --tags=integration -covermode count --output-dir=$(BUILD_PATH) -coverprofile=solar.full.coverprofile --keep-separate-coverprofiles $(testargs)
 	@echo 'mode: count' > $(BUILD_PATH)/solar.full.coverprofile && \
 	 cat $(BUILD_PATH)/*_solar.full.coverprofile 2>/dev/null | grep -v '^mode:' >> $(BUILD_PATH)/solar.full.coverprofile || true
 	@grep -v 'zz_generated' $(BUILD_PATH)/solar.full.coverprofile > solar.coverprofile || true
+
+.PHONY: test-fast
+test-fast: $(GINKGO) ## Run unit tests only — skips envtest-based integration tests for fast local feedback
+	$(GINKGO) -r --fail-fast \
+		./api/... \
+		./cmd/solar-renderer/... \
+		./pkg/controller/ \
+		./pkg/discovery/... \
+		./pkg/ociregistry/... \
+		./pkg/renderer/...
 
 .PHONY: test-e2e
 test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/cmd/solar-apiserver/apiserver_test.go
+++ b/cmd/solar-apiserver/apiserver_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package main_test
 
 import (

--- a/cmd/solar-apiserver/suite_test.go
+++ b/cmd/solar-apiserver/suite_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package main_test
 
 import (

--- a/pkg/controller/componentversion_controller_test.go
+++ b/pkg/controller/componentversion_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/profile_controller_test.go
+++ b/pkg/controller/profile_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/registrybinding_controller_test.go
+++ b/pkg/controller/registrybinding_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/release_controller_test.go
+++ b/pkg/controller/release_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/releasebinding_controller_test.go
+++ b/pkg/controller/releasebinding_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/renderartifact_controller_test.go
+++ b/pkg/controller/renderartifact_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/rendertask_controller_test.go
+++ b/pkg/controller/rendertask_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (

--- a/pkg/controller/target_controller_test.go
+++ b/pkg/controller/target_controller_test.go
@@ -1,6 +1,8 @@
 // Copyright 2026 BWI GmbH and Solution Arsenal contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package controller
 
 import (


### PR DESCRIPTION
## What
Separate unit and integration tests using Go build tags and add `make test-fast` for rapid local feedback.

Closes #667

## Why
Unit and integration tests were coupled, forcing developers to run the full envtest-backed suite even for minor local changes. This creates long feedback loops and discourages thorough testing of edge cases.

## Testing
- `make test` continues to run all tests (now passes `--tags=integration` to include tagged integration suites)
- `make test-fast` runs only unit-test packages, targeting execution under 5 seconds
- CI workflows (`golang.yaml`, `release.yaml`) remain unchanged — they use `make test`

## Notes for reviewers
Integration test files in `pkg/controller/` and `cmd/solar-apiserver/` are tagged with `//go:build integration`, following the existing `//go:build e2e` pattern. Three standalone unit test files in `pkg/controller/` (`backoff_test.go`, `backoff_wiring_test.go`, `rendertask_pullsecrets_test.go`) remain untagged and are included in `make test-fast`.

## Checklist
- [ ] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved