### PR TITLE
docs: fix link to OCM Kubernetes Controllers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ application bundles provided as OCM packages from an OCI compliant registry.
 Additionally Kubernetes clusters can be registered with SolAr to turn them into
 deployment targets for the solutions from the catalog. The deployment itself
 then uses OCM Controllers with fluxCD as a deployer
-(<https://ocm.software/docs/concepts/ocm-controllers/>).
+(https://ocm.software/docs/concepts/kubernetes-controllers/).
 
 <br style="clear: left;"/>
 


### PR DESCRIPTION
## What
The link to the OCM Kubernetes controller docs in the top-level readme was broken

## Why
To make the link work again, pointing to the up to date documentation on the OCM website

## Testing
-

## Notes for reviewers
-

## Checklist
- [ ] Tests added/updated
- [ ] No breaking changes (or upgrade path documented above)
- [ ] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated the introduction’s external documentation link from the OCM Controllers concepts page to the Kubernetes Controllers concepts page.
  - Adjusted link formatting to match the new URL reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->