### PR TITLE
ci: increase e2e timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test-e2e: manifests ## Run the e2e tests. Expected an isolated environment using
 	IMAGE_TAG=$(TAG) \
 	OCM=$(OCM) \
 	REGISTRY=$(REGISTRY) \
-	$(GO) test -count=1 -tags=e2e -timeout 15m ./test/e2e/ -v -ginkgo.v
+	$(GO) test -count=1 -tags=e2e -timeout 30m ./test/e2e/ -v -ginkgo.v
 
 
 .PHONY: manifests


### PR DESCRIPTION
## What
Increase E2E test timeout budget.

## Why
We have [failing e2e tests](https://github.com/opendefensecloud/solution-arsenal/actions/runs/29509152324/job/87692327691) due to a small timeout budget.

## Checklist
- [X] Tests added/updated
- [X] No breaking changes (or upgrade path documented above)
- [X] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended the end-to-end test timeout from 15 minutes to 30 minutes, allowing longer test runs to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->