### PR TITLE
ci: hide non-changelog commit types from release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,15 @@
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
-        { "type": "chore", "section": "Miscellaneous Chores" }
+        { "type": "chore", "section": "Miscellaneous Chores" },
+        { "type": "docs", "hidden": true },
+        { "type": "ci", "hidden": true },
+        { "type": "build", "hidden": true },
+        { "type": "test", "hidden": true },
+        { "type": "refactor", "hidden": true },
+        { "type": "style", "hidden": true },
+        { "type": "perf", "hidden": true },
+        { "type": "revert", "hidden": true }
       ]
     }
   }


### PR DESCRIPTION
## What
Adds `hidden: true` entries for `docs`, `ci`, `build`, `test`, `refactor`, `style`, `perf`, `revert` to the release-please `changelog-sections`.

## Why
We only want `feat` / `fix` / `chore` in the changelog. But when `changelog-sections` lists only those three, release-please does not hide the other types, it renders them under a raw header instead (e.g. the `0.3.0` changelog picked up a stray `### ci` section). Marking the rest `hidden: true` keeps the changelog to the three sections we want. This is generation-only, no version/release impact.

## Notes
This is the config half of the changelog cleanup. The other half (each change showing up twice) is not a release-please setting, its the merge strategy: with merge commits, a PR's feature-branch commits land on `main` next to the merge commit, so release-please lists both. The fix there is to switch the repo to squash-merge only (Settings -> General -> Pull Requests), which needs admin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved changelog organization by explicitly categorizing maintenance updates.
  * Keeps internal build, testing, refactoring, styling, performance, and revert changes out of the published changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->