### PR TITLE
fix: e2e test regression introduced with discovery api watch

### DIFF
--- a/charts/solar-discovery/files/role.yaml
+++ b/charts/solar-discovery/files/role.yaml
@@ -20,9 +20,3 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get

--- a/charts/solar-discovery/templates/role.yaml
+++ b/charts/solar-discovery/templates/role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "solar-discovery.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
+  labels:
+    {{- include "solar-discovery.labels" . | nindent 4 }}
+rules:
+  # Credential Secrets referenced by Registry.spec.solarSecretRef. list/watch are
+  # required by the Secret informer in RegistryProvider.WatchAPI, which reloads
+  # credentials on rotation; they are confined to the discovery namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/charts/solar-discovery/templates/rolebinding.yaml
+++ b/charts/solar-discovery/templates/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "solar-discovery.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
+  labels:
+    {{- include "solar-discovery.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "solar-discovery.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "solar-discovery.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -761,7 +761,10 @@ var _ = Describe("solar", Ordered, func() {
 			By("creating a ReferenceGrant in the registry namespace to allow Targets from testns")
 			grantFile := patchYAMLFile(
 				filepath.Join(dir, "test", "fixtures", "e2e", "cross-ns-registry-grant.yaml"),
-				fmt.Sprintf(`[{"op": "replace", "path": "/spec/from/0/namespace", "value": %q}]`, testns),
+				fmt.Sprintf(`[
+					{"op": "replace", "path": "/spec/from/0/namespace", "value": %q},
+					{"op": "replace", "path": "/spec/from/1/namespace", "value": %q}
+				]`, testns, testns),
 			)
 			defer func() { _ = os.Remove(grantFile) }()
 			applyResource(registryns, grantFile)

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -21,7 +21,7 @@ const queryClient = new QueryClient({
 
 declare global {
   interface Window {
-    __TANSTACK_QUERY_CLIENT__: import('@tanstack/query-core').QueryClient
+    __TANSTACK_QUERY_CLIENT__: QueryClient
   }
 }
 

--- a/web/src/pages/targets/edit-target-dialog.tsx
+++ b/web/src/pages/targets/edit-target-dialog.tsx
@@ -35,7 +35,7 @@ export function EditTargetDialog({
     for (const b of bindingsQ.data?.items ?? []) {
       if (
         b.spec.targetRef.name === name &&
-        (b.spec.targetNamespace ?? b.metadata.namespace) === ns
+        (b.spec.targetRef.namespace ?? b.metadata.namespace) === ns
       ) {
         m.set(b.spec.releaseRef.name, b.metadata.name)
       }


### PR DESCRIPTION
## What
Fixes e2e test

## Why
e2e tests were missing permissions on secrets for solar-discovery required after the api watch changes made previously.

## Testing
make test-e2e

## Notes for reviewers
Other minor changes included

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Target release bindings now resolve namespaces correctly, improving reliability when editing targets across namespaces.
  - Cross-namespace registry reference validation now correctly recognizes permitted sources.
  - Updated application typing improves compatibility and prevents potential build-time type inconsistencies.

- **Permissions**
  - Enhanced access for core secrets to support listing and monitoring where authorized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->