### PR TITLE
fix: improve handling of terminating renderartifacts

### DIFF
--- a/pkg/controller/renderartifact_controller.go
+++ b/pkg/controller/renderartifact_controller.go
@@ -87,14 +87,34 @@ func (r *RenderArtifactReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Handle deletion: attempt OCI tag cleanup, surface errors explicitly, then remove finalizer.
 	if !artifact.DeletionTimestamp.IsZero() {
 		if slices.Contains(artifact.Finalizers, renderArtifactFinalizer) {
-			if err := r.cleanupOCIArtifact(ctx, artifact); err != nil {
-				// Failure is already logged + event fired inside cleanupOCIArtifact.
-				// Keep the finalizer by returning the error so the object stays visible
-				// with the OCICleanup=False condition set.
-				return ctrl.Result{}, err
+			bound, err := r.renderArtifactBound(ctx, artifact)
+			if err != nil {
+				return ctrl.Result{}, errLogAndWrap(log, err, "failed to re-check RenderBindings for terminating RenderArtifact")
 			}
 
-			// OCI cleanup succeeded — remove finalizer to allow K8s deletion.
+			if bound {
+				// A binding still references this artifact: someone still needs the OCI tag,
+				// so keep it. The finalizer is retained on purpose: as long as the binding
+				// exists the object must not be deleted, or the tag would be orphaned in the
+				// registry (e.g. during namespace teardown nothing would recreate it). Once
+				// the binding is gone (Target deletion removes its bindings), a follow-up
+				// reconcile takes the not-bound path below and cleans up the tag.
+				log.V(1).Info("RenderArtifact is terminating but still referenced by a RenderBinding; keeping OCI tag",
+					"artifact", artifact.Name)
+				r.Recorder.Eventf(artifact, nil, corev1.EventTypeNormal, "OCICleanupSkipped", "Delete",
+					"RenderArtifact is terminating but still referenced by a RenderBinding; keeping OCI tag")
+
+				return ctrl.Result{}, nil
+			} else {
+				if err := r.cleanupOCIArtifact(ctx, artifact); err != nil {
+					// Failure is already logged + event fired inside cleanupOCIArtifact.
+					// Keep the finalizer by returning the error so the object stays visible
+					// with the OCICleanup=False condition set.
+					return ctrl.Result{}, err
+				}
+			}
+
+			// Remove finalizer to allow K8s deletion.
 			latest := artifact.DeepCopy()
 			latest.Finalizers = slices.DeleteFunc(latest.Finalizers, func(s string) bool {
 				return s == renderArtifactFinalizer
@@ -165,6 +185,34 @@ func (r *RenderArtifactReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// renderArtifactBound reports whether any RenderBinding still references the artifact.
+// Used during deletion so the OCI tag is not deleted while a Target still needs it.
+// Confirms via APIReader because the cache may lag on concurrent binding creates.
+func (r *RenderArtifactReconciler) renderArtifactBound(ctx context.Context, artifact *solarv1alpha1.RenderArtifact) (bool, error) {
+	bindingList := &solarv1alpha1.RenderBindingList{}
+	if err := r.List(ctx, bindingList,
+		client.InNamespace(artifact.Namespace),
+		client.MatchingFields{indexRenderBindingArtifactName: artifact.Name},
+	); err != nil {
+		return false, err
+	}
+	if len(bindingList.Items) > 0 {
+		return true, nil
+	}
+
+	confirmed := &solarv1alpha1.RenderBindingList{}
+	if err := r.APIReader.List(ctx, confirmed, client.InNamespace(artifact.Namespace)); err != nil {
+		return false, err
+	}
+	for i := range confirmed.Items {
+		if confirmed.Items[i].Spec.RenderArtifactRef.Name == artifact.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // cleanupOCIArtifact attempts to delete the OCI tag from the registry.

--- a/pkg/controller/renderartifact_controller.go
+++ b/pkg/controller/renderartifact_controller.go
@@ -105,13 +105,13 @@ func (r *RenderArtifactReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 					"RenderArtifact is terminating but still referenced by a RenderBinding; keeping OCI tag")
 
 				return ctrl.Result{}, nil
-			} else {
-				if err := r.cleanupOCIArtifact(ctx, artifact); err != nil {
-					// Failure is already logged + event fired inside cleanupOCIArtifact.
-					// Keep the finalizer by returning the error so the object stays visible
-					// with the OCICleanup=False condition set.
-					return ctrl.Result{}, err
-				}
+			}
+
+			if err := r.cleanupOCIArtifact(ctx, artifact); err != nil {
+				// Failure is already logged + event fired inside cleanupOCIArtifact.
+				// Keep the finalizer by returning the error so the object stays visible
+				// with the OCICleanup=False condition set.
+				return ctrl.Result{}, err
 			}
 
 			// Remove finalizer to allow K8s deletion.
@@ -206,10 +206,10 @@ func (r *RenderArtifactReconciler) renderArtifactBound(ctx context.Context, arti
 	if err := r.APIReader.List(ctx, confirmed, client.InNamespace(artifact.Namespace)); err != nil {
 		return false, err
 	}
-	for i := range confirmed.Items {
-		if confirmed.Items[i].Spec.RenderArtifactRef.Name == artifact.Name {
-			return true, nil
-		}
+	if slices.ContainsFunc(confirmed.Items, func(b solarv1alpha1.RenderBinding) bool {
+		return b.Spec.RenderArtifactRef.Name == artifact.Name
+	}) {
+		return true, nil
 	}
 
 	return false, nil

--- a/pkg/controller/renderartifact_finalizer_test.go
+++ b/pkg/controller/renderartifact_finalizer_test.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"context"
 	"errors"
 	"slices"
 	"testing"
@@ -88,7 +87,7 @@ func TestRenderArtifactDeletion(t *testing.T) {
 			Recorder:  recorder,
 		}
 
-		return r.Reconcile(context.Background(), ctrl.Request{
+		return r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: "art", Namespace: "ns"},
 		})
 	}
@@ -96,7 +95,7 @@ func TestRenderArtifactDeletion(t *testing.T) {
 	assertArtifactDeleted := func(t *testing.T, c client.Client) {
 		t.Helper()
 
-		err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, &solarv1alpha1.RenderArtifact{})
+		err := c.Get(t.Context(), client.ObjectKey{Name: "art", Namespace: "ns"}, &solarv1alpha1.RenderArtifact{})
 		if !apierrors.IsNotFound(err) {
 			t.Fatalf("expected the artifact to be deleted after finalizer removal, got %v", err)
 		}
@@ -106,11 +105,10 @@ func TestRenderArtifactDeletion(t *testing.T) {
 		t.Helper()
 
 		got := &solarv1alpha1.RenderArtifact{}
-		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+		if err := c.Get(t.Context(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
 			t.Fatalf("artifact should still exist: %v", err)
 		}
-		has := slices.Contains(got.Finalizers, renderArtifactFinalizer)
-		if !has {
+		if !slices.Contains(got.Finalizers, renderArtifactFinalizer) {
 			t.Error("expected the finalizer to still be present")
 		}
 		if got.DeletionTimestamp.IsZero() {

--- a/pkg/controller/renderartifact_finalizer_test.go
+++ b/pkg/controller/renderartifact_finalizer_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+func TestRenderArtifactDeletion(t *testing.T) {
+	t.Parallel()
+
+	newTerminatingArtifact := func() *solarv1alpha1.RenderArtifact {
+		now := metav1.NewTime(time.Now())
+		return &solarv1alpha1.RenderArtifact{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "art",
+				Namespace:         "ns",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{renderArtifactFinalizer},
+			},
+			Spec: solarv1alpha1.RenderArtifactSpec{
+				BaseURL:       "registry.example.com",
+				Repository:    "ns/repo",
+				Tag:           "v1",
+				RenderTaskRef: "rt",
+			},
+		}
+	}
+
+	newBinding := func() *solarv1alpha1.RenderBinding {
+		return &solarv1alpha1.RenderBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bind",
+				Namespace: "ns",
+			},
+			Spec: solarv1alpha1.RenderBindingSpec{
+				RenderArtifactRef: corev1.LocalObjectReference{Name: "art"},
+			},
+		}
+	}
+
+	newClient := func(t *testing.T, objs ...client.Object) client.Client {
+		t.Helper()
+
+		return fake.NewClientBuilder().
+			WithScheme(newEnsureRenderArtifactScheme(t)).
+			WithObjects(objs...).
+			WithIndex(&solarv1alpha1.RenderBinding{}, indexRenderBindingArtifactName, func(obj client.Object) []string {
+				rb := obj.(*solarv1alpha1.RenderBinding)
+				if rb.Spec.RenderArtifactRef.Name == "" {
+					return nil
+				}
+
+				return []string{rb.Spec.RenderArtifactRef.Name}
+			}).
+			Build()
+	}
+
+	reconcile := func(t *testing.T, c client.Client, apiReader client.Reader, td *stubTagDeleter) (ctrl.Result, error) {
+		t.Helper()
+
+		recorder := events.NewFakeRecorder(10)
+		go func() {
+			for range recorder.Events {
+			}
+		}()
+
+		r := &RenderArtifactReconciler{
+			Client:    c,
+			APIReader: apiReader,
+			DeleteTag: td.DeleteTag,
+			Recorder:  recorder,
+		}
+
+		return r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "art", Namespace: "ns"},
+		})
+	}
+
+	assertArtifactDeleted := func(t *testing.T, c client.Client) {
+		t.Helper()
+
+		err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, &solarv1alpha1.RenderArtifact{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected the artifact to be deleted after finalizer removal, got %v", err)
+		}
+	}
+
+	assertArtifactStillTerminating := func(t *testing.T, c client.Client) {
+		t.Helper()
+
+		got := &solarv1alpha1.RenderArtifact{}
+		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+			t.Fatalf("artifact should still exist: %v", err)
+		}
+		has := slices.Contains(got.Finalizers, renderArtifactFinalizer)
+		if !has {
+			t.Error("expected the finalizer to still be present")
+		}
+		if got.DeletionTimestamp.IsZero() {
+			t.Error("artifact should still be terminating")
+		}
+	}
+
+	t.Run("keeps the OCI tag and retains the finalizer when a binding still references the artifact", func(t *testing.T) {
+		t.Parallel()
+
+		td := &stubTagDeleter{}
+		c := newClient(t, newTerminatingArtifact(), newBinding())
+
+		if _, err := reconcile(t, c, c, td); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if calls := td.calls(); len(calls) != 0 {
+			t.Errorf("expected no DeleteTag call while the artifact is still bound, got %v", calls)
+		}
+		assertArtifactStillTerminating(t, c)
+	})
+
+	t.Run("deletes the OCI tag and removes the finalizer when no binding references the artifact", func(t *testing.T) {
+		t.Parallel()
+
+		td := &stubTagDeleter{}
+		c := newClient(t, newTerminatingArtifact())
+
+		if _, err := reconcile(t, c, c, td); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if calls := td.calls(); len(calls) != 1 {
+			t.Errorf("expected exactly one DeleteTag call, got %v", calls)
+		}
+		assertArtifactDeleted(t, c)
+	})
+
+	t.Run("keeps the finalizer when OCI cleanup fails", func(t *testing.T) {
+		t.Parallel()
+
+		td := &stubTagDeleter{}
+		td.failWith(errors.New("registry temporarily unavailable"))
+		c := newClient(t, newTerminatingArtifact())
+
+		if _, err := reconcile(t, c, c, td); err == nil {
+			t.Fatal("expected an error from OCI cleanup")
+		}
+		assertArtifactStillTerminating(t, c)
+	})
+
+	t.Run("keeps the OCI tag when the cache misses a binding the API server has", func(t *testing.T) {
+		t.Parallel()
+
+		td := &stubTagDeleter{}
+		// The cached client has not seen the binding yet; the APIReader has.
+		cache := newClient(t, newTerminatingArtifact())
+		apiReader := newClient(t, newTerminatingArtifact(), newBinding())
+
+		if _, err := reconcile(t, cache, apiReader, td); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if calls := td.calls(); len(calls) != 0 {
+			t.Errorf("expected no DeleteTag call when the API server still has a binding, got %v", calls)
+		}
+		assertArtifactStillTerminating(t, cache)
+	})
+}

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -482,6 +482,13 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			bName := renderBindingName(aName, target.Name)
 			// Create the RenderBinding before the RenderArtifact to avoid a race
 			if err := r.ensureRenderBinding(ctx, target, aName, bName, target.Spec.RenderRegistryRef); err != nil {
+				if errors.Is(err, errArtifactTerminating) {
+					log.V(1).Info("RenderArtifact is terminating; deferring RenderBinding until it is gone",
+						"renderArtifact", aName)
+
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				}
+
 				return ctrl.Result{}, errLogAndWrap(log, err, "failed to ensure RenderBinding for release")
 			}
 			if err := r.ensureRenderArtifact(ctx, aName, rt, target.Spec.RenderRegistryRef); err != nil {
@@ -608,6 +615,13 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		bootstrapBindingName := renderBindingName(bootstrapArtifactName, target.Name)
 		// Create the RenderBinding before the RenderArtifact to avoid a race
 		if err := r.ensureRenderBinding(ctx, target, bootstrapArtifactName, bootstrapBindingName, target.Spec.RenderRegistryRef); err != nil {
+			if errors.Is(err, errArtifactTerminating) {
+				log.V(1).Info("RenderArtifact is terminating; deferring RenderBinding until it is gone",
+					"renderArtifact", bootstrapArtifactName)
+
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to ensure RenderBinding for bootstrap")
 		}
 		if err := r.ensureRenderArtifact(ctx, bootstrapArtifactName, bootstrapRT, target.Spec.RenderRegistryRef); err != nil {
@@ -931,6 +945,13 @@ func (r *TargetReconciler) ensureRenderArtifact(ctx context.Context, name string
 	return nil
 }
 
+// errArtifactTerminating is returned by ensureRenderBinding when the RenderArtifact a
+// Target wants to bind to is being deleted. Callers translate it into a clean requeue so no
+// new RenderBinding can reference a terminating RenderArtifact, which would otherwise race
+// with RenderArtifactReconciler's OCI tag cleanup (a binding created in the window between
+// its bound-check and the tag delete could lose its tag).
+var errArtifactTerminating = errors.New("renderartifact is terminating")
+
 // ensureRenderBinding creates a RenderBinding linking this Target to the named
 // RenderArtifact if one does not already exist, and keeps an existing binding's Registry
 // snapshot in sync with the Target's current reference. Idempotent.
@@ -953,6 +974,19 @@ func (r *TargetReconciler) ensureRenderBinding(ctx context.Context, target *sola
 		latest.Spec.RegistryRef = &registryRef
 
 		return r.Patch(ctx, latest, client.MergeFrom(binding))
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Refuse to create a binding that references a terminating RenderArtifact. The deletion
+	// path only removes the OCI tag while no binding exists; creating one in that window
+	// could lose the tag. The artifact normally does not exist yet (the binding is created
+	// first), so this only fires when a shared artifact is mid-deletion.
+	artifact := &solarv1alpha1.RenderArtifact{}
+	if err := r.Get(ctx, client.ObjectKey{Name: artifactName, Namespace: target.Namespace}, artifact); err == nil {
+		if !artifact.DeletionTimestamp.IsZero() {
+			return errArtifactTerminating
+		}
 	} else if !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -890,12 +890,19 @@ func (r *TargetReconciler) deleteOwnedRenderBindings(ctx context.Context, target
 // RegistryRef for an existing artifact is kept in sync separately, by RenderArtifactReconciler
 // re-pinning from RenderBinding snapshots (see ensureRenderBinding below).
 func (r *TargetReconciler) ensureRenderArtifact(ctx context.Context, name string, rt *solarv1alpha1.RenderTask, registryRef solarv1alpha1.ObjectReference) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	artifact := &solarv1alpha1.RenderArtifact{}
-	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: rt.Namespace}, artifact); err == nil {
+	key := client.ObjectKey{Name: name, Namespace: rt.Namespace}
+	if err := r.Get(ctx, key, artifact); err == nil {
 		if !artifact.DeletionTimestamp.IsZero() {
-			// The artifact is terminating (OCI cleanup in progress). Creating a binding
-			// against it would race with the finalizer. Requeue and wait for full deletion.
-			return fmt.Errorf("RenderArtifact %s/%s is terminating; requeuing", rt.Namespace, name)
+			// The artifact is terminating (stuck in OCI cleanup). The RenderBinding pointing
+			// at it has already been ensured, and a fresh artifact is created on a later
+			// reconcile once deletion completes. Ignore it so a stuck finalizer cannot block
+			// this Target from reconciling successfully.
+			log.V(1).Info("RenderArtifact is terminating; ignoring", "renderArtifact", key)
+
+			return nil
 		}
 
 		return nil

--- a/pkg/controller/target_controller.go
+++ b/pkg/controller/target_controller.go
@@ -38,6 +38,8 @@ const (
 	ConditionTypeReleasesResolved = "ReleasesResolved"
 	ConditionTypeReleasesRendered = "ReleasesRendered"
 	ConditionTypeBootstrapReady   = "BootstrapReady"
+
+	defaultRequeueTime = 30 * time.Second
 )
 
 var ErrReleaseNotRenderedYet = errors.New("release is not rendered yet")
@@ -486,7 +488,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 					log.V(1).Info("RenderArtifact is terminating; deferring RenderBinding until it is gone",
 						"renderArtifact", aName)
 
-					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+					return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 				}
 
 				return ctrl.Result{}, errLogAndWrap(log, err, "failed to ensure RenderBinding for release")
@@ -619,7 +621,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				log.V(1).Info("RenderArtifact is terminating; deferring RenderBinding until it is gone",
 					"renderArtifact", bootstrapArtifactName)
 
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 			}
 
 			return ctrl.Result{}, errLogAndWrap(log, err, "failed to ensure RenderBinding for bootstrap")
@@ -652,11 +654,11 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "failed to clean up stale RenderBindings")
 		}
 
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 	}
 
 	// Still running
-	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: defaultRequeueTime}, nil
 }
 
 func (r *TargetReconciler) setCondition(ctx context.Context, target *solarv1alpha1.Target, condType string, status metav1.ConditionStatus, reason, message string) error {

--- a/pkg/controller/target_controller_ensurerenderartifact_test.go
+++ b/pkg/controller/target_controller_ensurerenderartifact_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+func newEnsureRenderArtifactScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	sch := runtime.NewScheme()
+	if err := scheme.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := solarv1alpha1.AddToScheme(sch); err != nil {
+		t.Fatalf("failed to add solar scheme: %v", err)
+	}
+
+	return sch
+}
+
+func TestEnsureRenderArtifact(t *testing.T) {
+	t.Parallel()
+
+	registryRef := solarv1alpha1.ObjectReference{Name: "reg"}
+	rt := &solarv1alpha1.RenderTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "rt", Namespace: "ns"},
+		Spec: solarv1alpha1.RenderTaskSpec{
+			BaseURL:    "registry.example.com",
+			Repository: "ns/repo",
+			Tag:        "v1",
+		},
+	}
+
+	t.Run("ignores a terminating artifact and does not recreate it", func(t *testing.T) {
+		t.Parallel()
+
+		now := metav1.NewTime(time.Now())
+		terminating := &solarv1alpha1.RenderArtifact{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "art",
+				Namespace:         "ns",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{renderArtifactFinalizer},
+			},
+			Spec: solarv1alpha1.RenderArtifactSpec{
+				BaseURL:       "registry.example.com",
+				Repository:    "ns/repo",
+				Tag:           "v1",
+				RenderTaskRef: "rt",
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(newEnsureRenderArtifactScheme(t)).
+			WithObjects(terminating).
+			Build()
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+			t.Fatalf("expected nil error for a terminating RenderArtifact, got %v", err)
+		}
+
+		got := &solarv1alpha1.RenderArtifact{}
+		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+			t.Fatalf("terminating artifact should still exist: %v", err)
+		}
+		if got.DeletionTimestamp.IsZero() {
+			t.Error("artifact should still be terminating")
+		}
+	})
+
+	t.Run("is a no-op for an existing non-terminating artifact", func(t *testing.T) {
+		t.Parallel()
+
+		existing := &solarv1alpha1.RenderArtifact{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "art",
+				Namespace: "ns",
+			},
+			Spec: solarv1alpha1.RenderArtifactSpec{
+				BaseURL:       "registry.example.com",
+				Repository:    "ns/repo",
+				Tag:           "v1",
+				RenderTaskRef: "rt",
+				RegistryRef:   &registryRef,
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(newEnsureRenderArtifactScheme(t)).
+			WithObjects(existing).
+			Build()
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+			t.Fatalf("expected nil error for an existing artifact, got %v", err)
+		}
+
+		got := &solarv1alpha1.RenderArtifact{}
+		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+			t.Fatalf("artifact should still exist: %v", err)
+		}
+		if !registryRefEqual(got.Spec.RegistryRef, &registryRef) {
+			t.Errorf("artifact RegistryRef should be unchanged, got %v", got.Spec.RegistryRef)
+		}
+	})
+
+	t.Run("creates the artifact when it does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		c := fake.NewClientBuilder().
+			WithScheme(newEnsureRenderArtifactScheme(t)).
+			Build()
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+
+		got := &solarv1alpha1.RenderArtifact{}
+		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+			t.Fatalf("created artifact should exist: %v", err)
+		}
+		if got.Spec.BaseURL != rt.Spec.BaseURL || got.Spec.Repository != rt.Spec.Repository || got.Spec.Tag != rt.Spec.Tag {
+			t.Errorf("artifact should carry the RenderTask coordinates, got %s/%s:%s", got.Spec.BaseURL, got.Spec.Repository, got.Spec.Tag)
+		}
+		if got.Spec.RenderTaskRef != rt.Name {
+			t.Errorf("artifact should reference the RenderTask %q, got %q", rt.Name, got.Spec.RenderTaskRef)
+		}
+		if !registryRefEqual(got.Spec.RegistryRef, &registryRef) {
+			t.Errorf("artifact should carry the RegistryRef %v, got %v", registryRef, got.Spec.RegistryRef)
+		}
+	})
+}

--- a/pkg/controller/target_controller_ensurerenderartifact_test.go
+++ b/pkg/controller/target_controller_ensurerenderartifact_test.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -68,12 +67,12 @@ func TestEnsureRenderArtifact(t *testing.T) {
 			Build()
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+		if err := r.ensureRenderArtifact(t.Context(), "art", rt, registryRef); err != nil {
 			t.Fatalf("expected nil error for a terminating RenderArtifact, got %v", err)
 		}
 
 		got := &solarv1alpha1.RenderArtifact{}
-		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+		if err := c.Get(t.Context(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
 			t.Fatalf("terminating artifact should still exist: %v", err)
 		}
 		if got.DeletionTimestamp.IsZero() {
@@ -103,12 +102,12 @@ func TestEnsureRenderArtifact(t *testing.T) {
 			Build()
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+		if err := r.ensureRenderArtifact(t.Context(), "art", rt, registryRef); err != nil {
 			t.Fatalf("expected nil error for an existing artifact, got %v", err)
 		}
 
 		got := &solarv1alpha1.RenderArtifact{}
-		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+		if err := c.Get(t.Context(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
 			t.Fatalf("artifact should still exist: %v", err)
 		}
 		if got.Spec.BaseURL != existing.Spec.BaseURL {
@@ -136,12 +135,12 @@ func TestEnsureRenderArtifact(t *testing.T) {
 			Build()
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderArtifact(context.Background(), "art", rt, registryRef); err != nil {
+		if err := r.ensureRenderArtifact(t.Context(), "art", rt, registryRef); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 
 		got := &solarv1alpha1.RenderArtifact{}
-		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
+		if err := c.Get(t.Context(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
 			t.Fatalf("created artifact should exist: %v", err)
 		}
 		if got.Spec.BaseURL != rt.Spec.BaseURL || got.Spec.Repository != rt.Spec.Repository || got.Spec.Tag != rt.Spec.Tag {

--- a/pkg/controller/target_controller_ensurerenderartifact_test.go
+++ b/pkg/controller/target_controller_ensurerenderartifact_test.go
@@ -90,10 +90,10 @@ func TestEnsureRenderArtifact(t *testing.T) {
 				Namespace: "ns",
 			},
 			Spec: solarv1alpha1.RenderArtifactSpec{
-				BaseURL:       "registry.example.com",
-				Repository:    "ns/repo",
-				Tag:           "v1",
-				RenderTaskRef: "rt",
+				BaseURL:       "stale.example.com",
+				Repository:    "ns/stale-repo",
+				Tag:           "v0",
+				RenderTaskRef: "stale-rt",
 				RegistryRef:   &registryRef,
 			},
 		}
@@ -110,6 +110,18 @@ func TestEnsureRenderArtifact(t *testing.T) {
 		got := &solarv1alpha1.RenderArtifact{}
 		if err := c.Get(context.Background(), client.ObjectKey{Name: "art", Namespace: "ns"}, got); err != nil {
 			t.Fatalf("artifact should still exist: %v", err)
+		}
+		if got.Spec.BaseURL != existing.Spec.BaseURL {
+			t.Errorf("artifact BaseURL should be unchanged, got %q", got.Spec.BaseURL)
+		}
+		if got.Spec.Repository != existing.Spec.Repository {
+			t.Errorf("artifact Repository should be unchanged, got %q", got.Spec.Repository)
+		}
+		if got.Spec.Tag != existing.Spec.Tag {
+			t.Errorf("artifact Tag should be unchanged, got %q", got.Spec.Tag)
+		}
+		if got.Spec.RenderTaskRef != existing.Spec.RenderTaskRef {
+			t.Errorf("artifact RenderTaskRef should be unchanged, got %q", got.Spec.RenderTaskRef)
 		}
 		if !registryRefEqual(got.Spec.RegistryRef, &registryRef) {
 			t.Errorf("artifact RegistryRef should be unchanged, got %v", got.Spec.RegistryRef)

--- a/pkg/controller/target_controller_ensurerenderbinding_test.go
+++ b/pkg/controller/target_controller_ensurerenderbinding_test.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -74,7 +73,7 @@ func TestEnsureRenderBinding(t *testing.T) {
 		t.Helper()
 
 		binding := &solarv1alpha1.RenderBinding{}
-		err := c.Get(context.Background(), client.ObjectKey{Name: "bind", Namespace: "ns"}, binding)
+		err := c.Get(t.Context(), client.ObjectKey{Name: "bind", Namespace: "ns"}, binding)
 
 		return binding, err
 	}
@@ -85,7 +84,7 @@ func TestEnsureRenderBinding(t *testing.T) {
 		c := newClient(t)
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+		if err := r.ensureRenderBinding(t.Context(), target, "art", "bind", registryRef); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 
@@ -107,7 +106,7 @@ func TestEnsureRenderBinding(t *testing.T) {
 		c := newClient(t, newLiveArtifact())
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+		if err := r.ensureRenderBinding(t.Context(), target, "art", "bind", registryRef); err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 
@@ -122,7 +121,7 @@ func TestEnsureRenderBinding(t *testing.T) {
 		c := newClient(t, newTerminatingArtifact())
 		r := &TargetReconciler{Client: c}
 
-		err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef)
+		err := r.ensureRenderBinding(t.Context(), target, "art", "bind", registryRef)
 		if !errors.Is(err, errArtifactTerminating) {
 			t.Fatalf("expected errArtifactTerminating, got %v", err)
 		}
@@ -152,7 +151,7 @@ func TestEnsureRenderBinding(t *testing.T) {
 		c := newClient(t, newTerminatingArtifact(), existing)
 		r := &TargetReconciler{Client: c}
 
-		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+		if err := r.ensureRenderBinding(t.Context(), target, "art", "bind", registryRef); err != nil {
 			t.Fatalf("expected nil error for an existing binding, got %v", err)
 		}
 

--- a/pkg/controller/target_controller_ensurerenderbinding_test.go
+++ b/pkg/controller/target_controller_ensurerenderbinding_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 BWI GmbH and Solution Arsenal contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	solarv1alpha1 "go.opendefense.cloud/solar/api/solar/v1alpha1"
+)
+
+func TestEnsureRenderBinding(t *testing.T) {
+	t.Parallel()
+
+	registryRef := solarv1alpha1.ObjectReference{Name: "reg"}
+	target := &solarv1alpha1.Target{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "ns"},
+	}
+
+	newLiveArtifact := func() *solarv1alpha1.RenderArtifact {
+		return &solarv1alpha1.RenderArtifact{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "art",
+				Namespace: "ns",
+			},
+			Spec: solarv1alpha1.RenderArtifactSpec{
+				BaseURL:       "registry.example.com",
+				Repository:    "ns/repo",
+				Tag:           "v1",
+				RenderTaskRef: "rt",
+				RegistryRef:   &registryRef,
+			},
+		}
+	}
+
+	newTerminatingArtifact := func() *solarv1alpha1.RenderArtifact {
+		now := metav1.NewTime(time.Now())
+		return &solarv1alpha1.RenderArtifact{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "art",
+				Namespace:         "ns",
+				DeletionTimestamp: &now,
+				Finalizers:        []string{renderArtifactFinalizer},
+			},
+			Spec: solarv1alpha1.RenderArtifactSpec{
+				BaseURL:       "registry.example.com",
+				Repository:    "ns/repo",
+				Tag:           "v1",
+				RenderTaskRef: "rt",
+				RegistryRef:   &registryRef,
+			},
+		}
+	}
+
+	newClient := func(t *testing.T, objs ...client.Object) client.Client {
+		t.Helper()
+
+		return fake.NewClientBuilder().
+			WithScheme(newEnsureRenderArtifactScheme(t)).
+			WithObjects(objs...).
+			Build()
+	}
+
+	getBinding := func(t *testing.T, c client.Client) (*solarv1alpha1.RenderBinding, error) {
+		t.Helper()
+
+		binding := &solarv1alpha1.RenderBinding{}
+		err := c.Get(context.Background(), client.ObjectKey{Name: "bind", Namespace: "ns"}, binding)
+
+		return binding, err
+	}
+
+	t.Run("creates the binding when the artifact does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		c := newClient(t)
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+
+		got, err := getBinding(t, c)
+		if err != nil {
+			t.Fatalf("created binding should exist: %v", err)
+		}
+		if got.Spec.RenderArtifactRef.Name != "art" {
+			t.Errorf("binding should reference artifact %q, got %q", "art", got.Spec.RenderArtifactRef.Name)
+		}
+		if got.Spec.OwnerName != target.Name {
+			t.Errorf("binding owner should be %q, got %q", target.Name, got.Spec.OwnerName)
+		}
+	})
+
+	t.Run("creates the binding when the artifact exists and is not terminating", func(t *testing.T) {
+		t.Parallel()
+
+		c := newClient(t, newLiveArtifact())
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+
+		if _, err := getBinding(t, c); err != nil {
+			t.Fatalf("created binding should exist: %v", err)
+		}
+	})
+
+	t.Run("does not create a binding when the artifact is terminating", func(t *testing.T) {
+		t.Parallel()
+
+		c := newClient(t, newTerminatingArtifact())
+		r := &TargetReconciler{Client: c}
+
+		err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef)
+		if !errors.Is(err, errArtifactTerminating) {
+			t.Fatalf("expected errArtifactTerminating, got %v", err)
+		}
+
+		_, err = getBinding(t, c)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("no binding should have been created, got %v", err)
+		}
+	})
+
+	t.Run("is a no-op for an existing binding even when the artifact is terminating", func(t *testing.T) {
+		t.Parallel()
+
+		existing := &solarv1alpha1.RenderBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bind",
+				Namespace: "ns",
+			},
+			Spec: solarv1alpha1.RenderBindingSpec{
+				RenderArtifactRef: corev1.LocalObjectReference{Name: "art"},
+				OwnerKind:         "Target",
+				OwnerName:         target.Name,
+				OwnerNamespace:    target.Namespace,
+				RegistryRef:       &registryRef,
+			},
+		}
+		c := newClient(t, newTerminatingArtifact(), existing)
+		r := &TargetReconciler{Client: c}
+
+		if err := r.ensureRenderBinding(context.Background(), target, "art", "bind", registryRef); err != nil {
+			t.Fatalf("expected nil error for an existing binding, got %v", err)
+		}
+
+		got, err := getBinding(t, c)
+		if err != nil {
+			t.Fatalf("existing binding should still exist: %v", err)
+		}
+		if !registryRefEqual(got.Spec.RegistryRef, &registryRef) {
+			t.Errorf("binding RegistryRef should be unchanged, got %v", got.Spec.RegistryRef)
+		}
+	})
+}

--- a/pkg/controller/target_controller_ensurerenderbinding_test.go
+++ b/pkg/controller/target_controller_ensurerenderbinding_test.go
@@ -142,10 +142,10 @@ func TestEnsureRenderBinding(t *testing.T) {
 				Namespace: "ns",
 			},
 			Spec: solarv1alpha1.RenderBindingSpec{
-				RenderArtifactRef: corev1.LocalObjectReference{Name: "art"},
-				OwnerKind:         "Target",
-				OwnerName:         target.Name,
-				OwnerNamespace:    target.Namespace,
+				RenderArtifactRef: corev1.LocalObjectReference{Name: "stale-art"},
+				OwnerKind:         "StaleKind",
+				OwnerName:         "stale-target",
+				OwnerNamespace:    "stale-ns",
 				RegistryRef:       &registryRef,
 			},
 		}
@@ -159,6 +159,18 @@ func TestEnsureRenderBinding(t *testing.T) {
 		got, err := getBinding(t, c)
 		if err != nil {
 			t.Fatalf("existing binding should still exist: %v", err)
+		}
+		if got.Spec.RenderArtifactRef.Name != existing.Spec.RenderArtifactRef.Name {
+			t.Errorf("binding RenderArtifactRef should be unchanged, got %q", got.Spec.RenderArtifactRef.Name)
+		}
+		if got.Spec.OwnerKind != existing.Spec.OwnerKind {
+			t.Errorf("binding OwnerKind should be unchanged, got %q", got.Spec.OwnerKind)
+		}
+		if got.Spec.OwnerName != existing.Spec.OwnerName {
+			t.Errorf("binding OwnerName should be unchanged, got %q", got.Spec.OwnerName)
+		}
+		if got.Spec.OwnerNamespace != existing.Spec.OwnerNamespace {
+			t.Errorf("binding OwnerNamespace should be unchanged, got %q", got.Spec.OwnerNamespace)
 		}
 		if !registryRefEqual(got.Spec.RegistryRef, &registryRef) {
 			t.Errorf("binding RegistryRef should be unchanged, got %v", got.Spec.RegistryRef)


### PR DESCRIPTION
## What
<!-- One sentence summary -->
Closes #619

## Checklist
- [x] Tests added/updated
- [x] No breaking changes (or upgrade path documented above)
- [x] Readable commit history (squashed and cleaned up as desired)
- [x] AI code review considered and comments resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cleanup of render artifacts that are still referenced by active bindings.
  * Improved deletion handling when artifact references are temporarily missing from the cache.
  * Deferred binding creation while an artifact is being deleted, avoiding unnecessary reconciliation errors.
  * Terminating artifacts are now preserved until dependent bindings are removed.

* **Tests**
  * Added coverage for artifact deletion, failed cleanup, retained references, deferred binding creation, and artifact creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->