### PR TITLE
fix(dev): make dev-cluster reliably populate the catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,9 @@ dev-cluster-rebuild: ## Rebuild images from source and load them into the local 
 		--set apiserver.image.tag=$(DEV_TAG) \
 		--set controller.image.tag=$(DEV_TAG) \
 		--set renderer.image.tag=$(DEV_TAG)
+	$(KUBECTL) apply --namespace solar-system -f test/fixtures/e2e/zot-discovery-registry-scan.yaml
 	$(HELM) upgrade --install --namespace solar-system solar-discovery charts/solar-discovery \
-		-f test/fixtures/solar-discovery-webhook.values.yaml \
+		-f test/fixtures/solar-discovery-scan.values.yaml \
 		--set image.tag=$(DEV_TAG) \
 		--set namespace=solar-system
 

--- a/docs/developer-guide/dev-cluster-with-kind.md
+++ b/docs/developer-guide/dev-cluster-with-kind.md
@@ -134,7 +134,7 @@ after the transfer the discovery worker scans the registry and creates the
 `Component` and `ComponentVersion` in the `solar-system` namespace:
 
 ```bash
-kubectl -n solar-system get components,componentversions
+kubectl --context kind-solar-dev -n solar-system get components,componentversions
 ```
 
 ### Environment Variables

--- a/docs/developer-guide/dev-cluster-with-kind.md
+++ b/docs/developer-guide/dev-cluster-with-kind.md
@@ -13,8 +13,10 @@ This guide describes how to set up a local development cluster using [Kind](http
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) installed
 - [Helm](https://helm.sh/docs/intro/install/) installed
 - [yq](https://github.com/mikefarah/yq#install) installed
+- [Flux CLI](https://fluxcd.io/flux/installation/#install-the-flux-cli) installed
 
-This should be take care of if you use the Makefile.
+This should be taken care of if you use the Makefile. The `ocm` CLI is not a
+manual prerequisite, the Makefile provisions it into `bin/` automatically.
 
 ## Quick Start
 
@@ -34,6 +36,9 @@ This will:
    - trust-manager
    - Zot registries (discovery and deploy)
    - SolAr with your local images
+   - solar-discovery in scan mode, with the local discovery Zot already
+     registered as a `Registry`, so the catalog populates automatically once an
+     OCM package is pushed
 
 ## What Gets Installed
 
@@ -118,8 +123,18 @@ This will:
 
 1. Wait for zot-discovery to be ready
 2. Start a port-forward to zot-discovery
-3. Transfer the ocm-demo component via OCM
-4. Clean up the port-forward
+3. Transfer the ocm-demo component via OCM (using `test/fixtures/e2e/ocmconfig`,
+   which trusts the cluster CA)
+4. Clean up the port-forward (always, via a trap)
+
+Since `make dev-cluster` deploys solar-discovery in scan mode with the discovery
+Zot already registered, you do not apply a `Registry` yourself. A few seconds
+after the transfer the discovery worker scans the registry and creates the
+`Component` and `ComponentVersion` in the `solar-system` namespace:
+
+```bash
+kubectl -n solar-system get components,componentversions
+```
 
 ### Environment Variables
 

--- a/docs/developer-guide/dev-cluster-with-kind.md
+++ b/docs/developer-guide/dev-cluster-with-kind.md
@@ -49,6 +49,7 @@ This will:
 | zot-discovery | zot          | OCI registry for discovery       |
 | zot-deploy    | zot          | OCI registry for deployment      |
 | solar         | solar-system | SolAr API server and controllers |
+| solar-discovery | solar-system | Scans the discovery registry (scan mode) and populates the catalog |
 
 ## Accessing Registries
 
@@ -142,13 +143,15 @@ kubectl -n solar-system get components,componentversions
 | --                 | --                           | --                      |
 | `KIND_CLUSTER_DEV` | `solar-dev`                  | Kind cluster name       |
 | `KUBECTL`          | `kubectl`                    | Kubernetes CLI          |
-| `OCM`              | `ocm`                        | OCM CLI path            |
+| `OCM`              | `ocm`                        | OCM CLI path. The Makefile provisions it into `bin/go/ocm`, which is not on `PATH`, so for standalone use pass `OCM=./bin/go/ocm` |
+| `OCM_CONFIG`       | `./test/fixtures/e2e/ocmconfig` | ocm config file (needs the rootcerts block that trusts the cluster CA) |
 | `OCM_DEMO_DIR`     | `test/fixtures/ocm-demo-ctf` | ocm-demo CTF location   |
+| `LOCAL_PORT`       | `4443`                       | local port for the zot-discovery port-forward |
 
 Example:
 
 ```bash
-KIND_CLUSTER_DEV=my-cluster ./test/fixtures/setup-discovery.sh
+OCM=./bin/go/ocm KIND_CLUSTER_DEV=my-cluster ./test/fixtures/setup-discovery.sh
 ```
 
 ## Setting Up Release for Testing

--- a/hack/dev-cluster.sh
+++ b/hack/dev-cluster.sh
@@ -224,14 +224,24 @@ setup_solar() {
         --timeout 5m
 }
 
-# setup_discovery installs the solar-discovery Helm chart into the solar-system namespace.
+# setup_discovery installs the solar-discovery Helm chart into the solar-system
+# namespace in scan mode, so the local catalog populates reproducibly.
+#
+# The scan Registry is applied BEFORE the worker is deployed on purpose: the
+# discovery pipeline builds one scanner per registry that is present when the
+# pod constructs its pipeline (see pkg/discovery/pipeline). A Registry created
+# after the worker is already running never gets a scanner, so the catalog would
+# stay empty. Scan mode (vs webhook) is used here because it reconciles on an
+# interval and is timing independent, which a one-command dev setup needs; the
+# webhook path is exercised by the e2e suite instead.
 setup_discovery() {
     echo -e "\nSETTING UP SOLAR-DISCOVERY:\n"
     $KUBECTL apply --namespace=solar-system -f test/fixtures/e2e/zot-discovery-auth.yaml
+    $KUBECTL apply --namespace=solar-system -f test/fixtures/e2e/zot-discovery-registry-scan.yaml
     $HELM upgrade --install \
         --namespace=solar-system \
         solar-discovery charts/solar-discovery \
-        -f test/fixtures/solar-discovery-webhook.values.yaml \
+        -f test/fixtures/solar-discovery-scan.values.yaml \
         --set image.tag="$TAG" \
         --set namespace=solar-system
     $KUBECTL wait deployment \
@@ -239,9 +249,6 @@ setup_discovery() {
         -l app.kubernetes.io/instance=solar-discovery \
         --for condition=Available \
         --timeout 5m
-    # Update discovery webhook pointer service to point to the discovery service
-    $KUBECTL apply --namespace zot \
-        -f test/fixtures/discovery-webhook-ptr-svc.yaml
 }
 
 # main orchestrates cluster setup by invoking cert-manager, trust-manager, Zot components, Flux, and (unless SKIP_SOLAR is "true") Solar, then prints DONE.

--- a/test/fixtures/setup-discovery.sh
+++ b/test/fixtures/setup-discovery.sh
@@ -25,12 +25,18 @@ pf_pid=$!
 trap 'kill "$pf_pid" 2>/dev/null || true' EXIT
 
 echo "Waiting for the port-forward to accept connections..."
+ready=false
 for _ in $(seq 1 30); do
     if (exec 3<>"/dev/tcp/localhost/${LOCAL_PORT}") 2>/dev/null; then
+        ready=true
         break
     fi
     sleep 1
 done
+if [ "$ready" != "true" ]; then
+    echo "port-forward to zot-discovery never became ready on localhost:${LOCAL_PORT}" >&2
+    exit 1
+fi
 
 echo "Transferring ocm-demo component via OCM..."
 $OCM --config "$OCM_CONFIG" \

--- a/test/fixtures/setup-discovery.sh
+++ b/test/fixtures/setup-discovery.sh
@@ -5,18 +5,36 @@ KIND_CLUSTER_DEV="${KIND_CLUSTER_DEV:-solar-dev}"
 KUBECTL="${KUBECTL:-kubectl} --context kind-${KIND_CLUSTER_DEV}"
 OCM="${OCM:-ocm}"
 OCM_DEMO_DIR="${OCM_DEMO_DIR:-$(pwd)/test/fixtures/ocm-demo-ctf}"
+# ocmconfig with the rootcerts block that trusts the cluster CA. The
+# credentials-only test/fixtures/ocmconfig fails TLS against the self-signed
+# zot cert, so use the same config the e2e suite uses.
+OCM_CONFIG="${OCM_CONFIG:-./test/fixtures/e2e/ocmconfig}"
+LOCAL_PORT="${LOCAL_PORT:-4443}"
 
 echo -e "\nSETTING UP DISCOVERY:\n"
 echo "Waiting for zot-discovery rollout (timeout: 5m)..."
 $KUBECTL rollout status statefulset/zot-discovery \
     -n zot \
     --timeout 5m
+
 echo "Starting port-forward for zot-discovery service..."
-$KUBECTL -n zot port-forward svc/zot-discovery 4443:443 &
-echo "Waiting for port-forward to establish..."
-sleep 2
+$KUBECTL -n zot port-forward "svc/zot-discovery" "${LOCAL_PORT}:443" &
+pf_pid=$!
+# Always tear the port-forward down, including when the transfer fails. The
+# previous version left it running on any non-zero exit.
+trap 'kill "$pf_pid" 2>/dev/null || true' EXIT
+
+echo "Waiting for the port-forward to accept connections..."
+for _ in $(seq 1 30); do
+    if (exec 3<>"/dev/tcp/localhost/${LOCAL_PORT}") 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
 echo "Transferring ocm-demo component via OCM..."
-$OCM --config ./test/fixtures/ocmconfig \
-    transfer ctf "$OCM_DEMO_DIR" https://localhost:4443/test
-echo "Cleaning up port-forward..."
-pkill -f "port-forward.*4443:443" || true
+$OCM --config "$OCM_CONFIG" \
+    transfer ctf "$OCM_DEMO_DIR" "https://localhost:${LOCAL_PORT}/test"
+
+echo "Transfer done. Discovery scans the registry on its interval and creates"
+echo "the Component/ComponentVersion in the solar-system namespace shortly after."


### PR DESCRIPTION
## Background

The final goal (part of #644) is one command to spin up SolAr locally with the demo app actually deployed -> `make demo`, so onboarding is easy and reproducible. Today `make dev-cluster` gives you an empty SolAr and getting the demo running is a broken, order-sensitive manual dance. We get there in a few small PRs:

1. **(this PR)** make `make dev-cluster` reliably populate the catalog
2. extract a shared OCM transfer step so the dev path and the e2e suite cant drift
3. `make demo-app` / `make demo` / `make demo-clean` to seed the full render -> bootstrap flow
4. Optional but I think worth it: a smoke test which runs in CI that runs the demo so it cant silently rot

Each ships and gets reviewed on its own. This PR is step 1 basically

## What

Make `make dev-cluster` actually populate the catalog out of the box, and fix the discovery transfer helper.

- deploy solar-discovery in scan mode and register the local discovery Zot as a `Registry` before the worker starts (both `dev-cluster.sh` and `dev-cluster-rebuild`). @olzemal  had the idea to include that also in the solar helm chart but I would probably like to do it this way for now and then later we can refactor it if we really agree to extend the helm chart in the future. But this is out of scope for now I would say
- `setup-discovery.sh` now uses the ca-trusting ocmconfig and always cleans up its port-forward

## Why

On a fresh dev-cluster the catalog was always empty. Dug into it -> discovery was deployed with no registries, and the pipeline builds its scanners from the registries present at startup (`pkg/discovery/pipeline`). A `Registry` added after the worker is already running never gets a scanner, so nothing ever gets discovered. Webhook mode doesnt save us either, its push events are one-shot with no retry and race the listener readiness (i watched zot get `connection refused` on `:8080` and just drop the events).

Scan mode is the reproducible choice for a one command dev setup -> it reconciles on an interval, so timing doesnt matter. Applying the scan `Registry` before the worker starts means the scanner exists from the first reconcile. e2e is untouched, it manages its own discovery and still covers webhook mode, so no drift there.

Separately, `setup-discovery.sh` pointed at `test/fixtures/ocmconfig`, which only carries credentials and has no rootcerts block -> `ocm transfer` failed TLS against the self-signed zot cert. It now uses `test/fixtures/e2e/ocmconfig` (the same one e2e uses) and tears the port-forward down via a trap, so a failed transfer doesnt leak it.

## Testing

Full clean run from teardown against a local kind cluster:

```
$ make cleanup-dev-cluster && make dev-cluster
...
DONE

$ kubectl -n solar-system get registry          # auto-wired by dev-cluster, no manual step
NAME       HOSTNAME           PLAIN HTTP   AGE
zot-scan   10.96.200.10:443   false        7s

$ kubectl get comp,cv -A                          # before pushing anything
(empty - correct)

$ OCM=./bin/go/ocm bash test/fixtures/setup-discovery.sh
...
Transferring ocm-demo component via OCM...
Transfer done. ...

$ kubectl -n solar-system get comp,cv             # ~10s later, via scan
NAME                                                            REGISTRY           REPOSITORY
component.../opendefense-cloud-ocm-demo                         10.96.200.10:443   test/opendefense.cloud/ocm-demo
NAME                                                            COMPONENT REF                TAG
componentversion.../opendefense-cloud-ocm-demo-v26-4-2          opendefense-cloud-ocm-demo   v26.4.2
```

No leaked port-forward afterwards. `make shellcheck` clean, e2e suite untouched.

## Checklist

- [x] Tests added/updated (n/a, dev tooling + docs, verified manually against a live kind cluster, e2e unchanged)
- [x] No breaking changes (e2e manages its own discovery, only the dev/demo path changes)
- [x] Readable commit history (two focused commits)
- [x] AI code review considered and comments resolved

Part of #644
