### PR TITLE
feat(dev): make demo / demo-app / demo-clean for a one-command demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,23 @@ dev-cluster-rebuild: ## Rebuild images from source and load them into the local 
 		--set image.tag=$(DEV_TAG) \
 		--set namespace=solar-system
 
+.PHONY: demo-app
+demo-app: ## Seed the ocm-demo app end to end on an existing dev cluster (transfer -> discover -> release -> render -> bootstrap)
+	OCM=$(OCM) KUBECTL=$(KUBECTL) YQ=$(YQ) KIND_CLUSTER_DEV=$(KIND_CLUSTER_DEV) $(HACK_DIR)/demo/demo-app.sh
+
+.PHONY: demo
+demo: ## From zero to a running demo app: create the dev cluster if needed, then seed it
+	@if $(KIND) get clusters 2>/dev/null | grep -Fqx -- "$(KIND_CLUSTER_DEV)"; then \
+		echo "Reusing existing $(KIND_CLUSTER_DEV) cluster."; \
+	else \
+		$(MAKE) dev-cluster; \
+	fi
+	$(MAKE) demo-app
+
+.PHONY: demo-clean
+demo-clean: ## Remove the demo app resources and namespace, keep the cluster
+	OCM=$(OCM) KUBECTL=$(KUBECTL) KIND_CLUSTER_DEV=$(KIND_CLUSTER_DEV) $(HACK_DIR)/demo/demo-clean.sh
+
 .PHONY: cleanup-dev-cluster
 cleanup-dev-cluster: ## Tear down the Kind cluster used for local tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER_DEV)

--- a/hack/demo/demo-app.sh
+++ b/hack/demo/demo-app.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Seed the ocm-demo application end to end on an existing dev cluster:
+#
+#   transfer -> discover -> release -> render -> bootstrap -> running workload
+#
+# It mirrors the happy path the e2e suite exercises (test/e2e/e2e_test.go) and
+# reuses the same fixtures under test/fixtures/e2e, so the demo and the e2e tests
+# cannot drift. It is idempotent: re-running applies the same resources and waits
+# on the same conditions.
+#
+# Assumes `make dev-cluster` has already run (SolAr + discovery + both Zots up).
+set -euo pipefail
+
+YQ="${YQ:-yq}"
+
+# SolAr resources and the render pipeline live in NS. It defaults to
+# solar-system: that is where dev-cluster's discovery writes the
+# ComponentVersion and where the discovery Registry (zot-scan) and the
+# zot-deploy pull secret already live, so every reference resolves in-namespace
+# without ReferenceGrants. The application itself is deployed into APP_NS (the
+# Release's targetNamespace).
+NS="${NS:-solar-system}"
+APP_NS="${APP_NS:-demo}"
+
+FIXTURES="test/fixtures/e2e"
+DEPLOY_REGISTRY_HOST="zot-deploy.zot.svc.cluster.local"
+
+COMPONENT_VERSION="opendefense-cloud-ocm-demo-v26-4-2"
+TARGET="cluster-1"
+RELEASE="test-opendefense-cloud-ocm-demo-v26-4-2-release"
+
+POLL_ATTEMPTS="${POLL_ATTEMPTS:-60}"
+POLL_DELAY="${POLL_DELAY:-5}"
+
+# kubectl pinned to the dev cluster context, so call sites read as plain
+# `kubectl ...`. Honors a KUBECTL override (e.g. from the Makefile) for the binary.
+KIND_CLUSTER_DEV="${KIND_CLUSTER_DEV:-solar-dev}"
+kubectl() { command "${KUBECTL:-kubectl}" --context "kind-${KIND_CLUSTER_DEV}" "$@"; }
+
+step() { printf '\n>>> %s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# Poll a command until it succeeds. Usage: wait_until "<description>" <cmd> [args...]
+wait_until() {
+    local description="$1"
+    shift
+    local attempt
+    for (( attempt = 1; attempt <= POLL_ATTEMPTS; attempt++ )); do
+        "$@" && return 0
+        sleep "$POLL_DELAY"
+    done
+    die "timed out after $(( POLL_ATTEMPTS * POLL_DELAY ))s waiting for ${description}"
+}
+
+# --- conditions we wait on ---------------------------------------------------
+
+component_version_exists() {
+    kubectl get componentversion "$COMPONENT_VERSION" -n "$NS" >/dev/null 2>&1
+}
+
+registry_bindings_exist() {
+    kubectl get registrybinding cluster-1-deploy-registry cluster-1-discovery-registry \
+        -n "$NS" >/dev/null 2>&1
+}
+
+target_exists() {
+    kubectl get target "$TARGET" -n "$NS" >/dev/null 2>&1
+}
+
+release_resolved() {
+    local status
+    status="$(kubectl get release "$RELEASE" -n "$NS" \
+        -o jsonpath='{.status.conditions[?(@.type=="ComponentVersionResolved")].status}' 2>/dev/null)"
+    [ "$status" = "True" ]
+}
+
+render_artifact_exists() {
+    [ -n "$(kubectl get renderartifacts -n "$NS" -o name 2>/dev/null)" ]
+}
+
+# --- phases ------------------------------------------------------------------
+
+ensure_catalog() {
+    if component_version_exists; then
+        step "ComponentVersion already in the catalog, skipping the transfer."
+        return
+    fi
+    step "Transferring the ocm-demo component into the discovery registry..."
+    bash test/fixtures/setup-discovery.sh
+    step "Waiting for discovery to add the ComponentVersion to the catalog..."
+    wait_until "ComponentVersion $COMPONENT_VERSION" component_version_exists
+}
+
+prepare_app_namespace() {
+    step "Ensuring the application namespace '$APP_NS' exists..."
+    kubectl get namespace "$APP_NS" >/dev/null 2>&1 || kubectl create namespace "$APP_NS"
+    kubectl label namespace "$APP_NS" trust=enabled --overwrite
+}
+
+deploy_credentials() {
+    step "Deploying registry pull credentials..."
+    kubectl apply -n "$NS" -f "$FIXTURES/regcred.yaml"
+    kubectl apply -n "$APP_NS" -f "$FIXTURES/regcred.yaml"
+}
+
+create_registry_and_bindings() {
+    step "Creating the deploy Registry and RegistryBindings..."
+    kubectl apply -n "$NS" -f "$FIXTURES/registry.yaml"
+    kubectl apply -n "$NS" -f "$FIXTURES/registrybinding.yaml"
+    wait_until "the RegistryBindings" registry_bindings_exist
+    # Give the controller's informer cache a moment to see the RegistryBindings
+    # before the ReleaseBinding triggers rendering (mirrors the e2e ordering).
+    sleep 5
+}
+
+register_target() {
+    step "Registering the Target..."
+    kubectl apply -n "$NS" -f "$FIXTURES/target.yaml"
+    wait_until "the Target $TARGET" target_exists
+}
+
+create_release() {
+    step "Creating the Release and waiting for it to resolve the ComponentVersion..."
+    kubectl apply -n "$NS" -f "$FIXTURES/release.yaml"
+    wait_until "the Release to resolve its ComponentVersion" release_resolved
+}
+
+trigger_render() {
+    step "Binding the Release to the Target to trigger the render pipeline..."
+    kubectl apply -n "$NS" -f "$FIXTURES/releasebinding.yaml"
+    step "Waiting for the render pipeline to produce a RenderArtifact..."
+    wait_until "a RenderArtifact" render_artifact_exists
+}
+
+bootstrap() {
+    step "Bootstrapping the cluster so Flux pulls the rendered chart and deploys it..."
+    # The bootstrap OCIRepository fixture is namespaced to 'default'; point it at
+    # the namespace we actually rendered into.
+    local url="oci://${DEPLOY_REGISTRY_HOST}/${NS}/bootstrap-${TARGET}"
+    "$YQ" ".spec.url = \"$url\"" "$FIXTURES/bootstrap-ocirepository.yaml" \
+        | kubectl apply -n "$NS" -f -
+    kubectl apply -n "$NS" -f "$FIXTURES/bootstrap-helmrelease.yaml"
+
+    step "Waiting for the bootstrap OCIRepository and HelmRelease to become ready..."
+    kubectl wait --for=condition=Ready -n "$NS" ocirepository/solar-bootstrap --timeout=300s
+    kubectl wait --for=condition=Ready -n "$NS" helmrelease/solar-bootstrap --timeout=300s
+}
+
+print_summary() {
+    cat <<EOF
+
+Demo app seeded. What to look at next:
+
+  # catalog, release and render state
+  kubectl -n $NS get components,componentversions,releases,rendertasks,renderartifacts
+
+  # bootstrap and the deployed workload
+  kubectl -n $NS get ocirepository,helmrelease
+  kubectl -n $APP_NS get helmrelease,pods
+EOF
+}
+
+main() {
+    ensure_catalog
+    prepare_app_namespace
+    deploy_credentials
+    create_registry_and_bindings
+    register_target
+    create_release
+    trigger_render
+    bootstrap
+    print_summary
+}
+
+main "$@"

--- a/hack/demo/demo-clean.sh
+++ b/hack/demo/demo-clean.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Remove the resources seeded by demo-app.sh and the demo application namespace,
+# while leaving the cluster, the discovery setup and the populated catalog in
+# place. Re-run demo-app.sh afterwards to seed again.
+set -euo pipefail
+
+NS="${NS:-solar-system}"
+APP_NS="${APP_NS:-demo}"
+FIXTURES="test/fixtures/e2e"
+
+# kubectl pinned to the dev cluster context, so call sites read as plain
+# `kubectl ...`. Honors a KUBECTL override (e.g. from the Makefile) for the binary.
+KIND_CLUSTER_DEV="${KIND_CLUSTER_DEV:-solar-dev}"
+kubectl() { command "${KUBECTL:-kubectl}" --context "kind-${KIND_CLUSTER_DEV}" "$@"; }
+
+step() { printf '\n>>> %s\n' "$*"; }
+
+remove_bootstrap() {
+    # Delete the Flux resources first so the workload is uninstalled before the
+    # SolAr resources that produced its chart go away.
+    step "Removing the bootstrap Flux resources..."
+    kubectl delete -n "$NS" helmrelease/solar-bootstrap ocirepository/solar-bootstrap \
+        --ignore-not-found --timeout=2m
+}
+
+remove_solar_resources() {
+    # Deleting the ReleaseBinding first lets the render GC controller clean up the
+    # RenderBinding and RenderArtifact.
+    step "Removing the demo SolAr resources..."
+    local fixture
+    for fixture in releasebinding release registrybinding target registry; do
+        kubectl delete -n "$NS" -f "$FIXTURES/$fixture.yaml" --ignore-not-found
+    done
+    kubectl delete -n "$NS" secret regcred --ignore-not-found
+}
+
+remove_app_namespace() {
+    step "Removing the application namespace '$APP_NS'..."
+    kubectl delete namespace "$APP_NS" --ignore-not-found --timeout=2m
+}
+
+main() {
+    remove_bootstrap
+    remove_solar_resources
+    remove_app_namespace
+    echo
+    echo "Demo resources removed. The cluster, discovery and catalog are kept."
+}
+
+main "$@"


### PR DESCRIPTION
## Background

Part of #644, the arc is one command to spin up SolAr locally with the demo app deployed -> `make demo`

1. ✅ make `make dev-cluster` reliably populate the catalog (#731)
2. ✅ single source of truth for the OCM transfer step (#733)
3. **(this PR)** `make demo-app` / `make demo` / `make demo-clean` for the full render -> bootstrap flow
4. a CI smoke test that runs the demo so it cant silently rot

## What

Three make targets, backed by two scripts under `hack/demo`:

- `make demo-app` -> seeds the ocm-demo app end to end on an existing dev cluster: transfer -> discover -> release -> render -> bootstrap -> running workload. Idempotent.
- `make demo` -> from zero: create the dev cluster if its missing, then `demo-app`.
- `make demo-clean` -> remove the demo resources and the app namespace, keep the cluster and the catalog.

## Why

After `make dev-cluster` we had an empty SolAr and getting the demo app actually deployed was a manual, order-sensitive dance across a few scripts. `demo-app` walks that whole path in one go.

The important bit for not drifting: `demo-app` mirrors the exact happy path the e2e suite exercises and reuses the **same** `test/fixtures/e2e` manifests (release, target, registry, bindings, regcred, bootstrap). So the demo and the e2e tests share their inputs and cant diverge. CI will guard the ordering in step 4 (pr follows after this one :)).

Topology -> everything runs in `solar-system`, because thats where dev-cluster's discovery writes the ComponentVersion and where the discovery Registry (`zot-scan`) and the `zot-deploy` pull secret already live. So every reference resolves in-namespace, no ReferenceGrants needed. This matches how the e2e suite runs the whole flow in a single namespace. The app itself lands in the Release's `targetNamespace` (`demo`).

Re-runs are cheap -> `demo-app` skips the transfer when the ComponentVersion is already in the catalog.

## Testing

Full loop against a local kind cluster (`make dev-cluster` first):

```
$ make demo-app
>>> Transferring the ocm-demo component and waiting for discovery...
>>> ...
ocirepository.../solar-bootstrap condition met
helmrelease.../solar-bootstrap condition met

$ kubectl -n solar-system get releases,rendertasks,renderartifacts
release/...-release      ...   Resolved
rendertask/render-rel-...   Target   cluster-1   JobSucceeded
rendertask/render-tgt-cluster-1-0   Target   cluster-1   JobSucceeded
renderartifact/...  solar-system/bootstrap-cluster-1  v0.0.0

$ kubectl -n demo get pods
solar-bootstrap-opendefense-cloud-ocm-demo-...-demo...   1/1   Running     # the demo app is deployed
```

For the person who reviews this, try to run the following locally:
- fresh `make demo-app` -> workload Running
- `make demo-clean` -> demo resources + `demo` namespace gone, catalog + cluster kept
- re-seed from clean -> workload Running again
- idempotent re-run with catalog present -> skips the transfer, still reaches Ready
- `make shellcheck` clean

e2e suite is untouched 

## Checklist

- [x] Tests added/updated (n/a, dev tooling, verified manually end to end against a live kind cluster; reuses the e2e fixtures; CI smoke test lands in the follow-up PR)
- [x] No breaking changes (new targets only, e2e untouched)
- [x] Readable commit history (one focused commit)
- [ ] AI code review considered and comments resolved

Part of #644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to launch a complete demo environment, either using an existing development cluster or creating one as needed.
  * Added automated demo setup covering namespaces, credentials, registries, releases, rendering, and readiness checks.
  * Added cleanup support to remove demo resources while preserving the development cluster and shared setup.
  * Added configurable options, progress reporting, timeout handling, and re-seeding guidance for demo workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->