### PR TITLE
ci: demo smoke test that runs make demo end to end

### DIFF
--- a/.github/workflows/test-demo.yaml
+++ b/.github/workflows/test-demo.yaml
@@ -1,0 +1,70 @@
+name: Demo Smoke Test
+
+# Runs the one-command demo (make demo -> dev-cluster + demo-app) end to end and
+# asserts the demo application actually comes up. This is the backstop that keeps
+# the demo flow from silently drifting away from what the e2e suite covers.
+#
+# It builds SolAr from source and reuses the same test/fixtures/e2e manifests the
+# demo scripts apply, so it exercises the real render -> bootstrap pipeline. It
+# only runs when demo-relevant files change, to keep CI time down.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'hack/demo/**'
+      - 'hack/dev-cluster.sh'
+      - 'hack/ensure-kind-cluster.sh'
+      - 'test/fixtures/**'
+      - 'charts/**'
+      - 'Makefile'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/test-demo.yaml'
+  pull_request:
+    paths:
+      - 'hack/demo/**'
+      - 'hack/dev-cluster.sh'
+      - 'hack/ensure-kind-cluster.sh'
+      - 'test/fixtures/**'
+      - 'charts/**'
+      - 'Makefile'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/test-demo.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  demo-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # Tools (go, kind, kubectl, helm, yq, flux) come from the flake via dev-kit.
+    defaults:
+      run:
+        shell: nix develop --command bash -e {0}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          determinate: false
+          diagnostic-endpoint: ''
+      - name: Use opendefensecloud Cachix cache
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: opendefensecloud
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+      - name: Run the demo end to end
+        # `make demo` creates the dev cluster then seeds the app. demo-app waits
+        # for the bootstrap HelmRelease to become Ready and fails otherwise, so a
+        # successful run already proves the app deployed.
+        run: make demo
+      - name: Assert the demo workload is running
+        run: |
+          kubectl --context kind-solar-dev -n demo wait --for=condition=Ready pod --all --timeout=2m
+          kubectl --context kind-solar-dev -n demo get pods


### PR DESCRIPTION
## Background

Part of #644, the context is one command to spin up SolAr locally with the demo app deployed -> `make demo`. Small PRs:

1. ✅ make `make dev-cluster` reliably populate the catalog (#731)
2. ✅ single source of truth for the OCM transfer step (#733)
3. ✅ `make demo-app` / `make demo` / `make demo-clean` (#734)
4. **(this PR)** a CI smoke test so the demo flow cant silently rot

This is the last one, it closes out the story

## What

A `Demo Smoke Test` workflow that runs `make demo` (dev-cluster + demo-app) end to end and asserts the demo application actually comes up.

## Why

The demo shares its inputs with the e2e suite (same `test/fixtures/e2e` manifests), but the ordering and the make targets live outside the e2e Go test. Without a check they can drift and nobody notices until someone tries the demo. This job is the backstop: it walks the real transfer -> discover -> release -> render -> bootstrap pipeline and fails if the workload doesnt come up.

`demo-app` already waits for the bootstrap HelmRelease to become Ready and exits non-zero otherwise, so a green `make demo` is the assertion. The assert step then polls for the demo pod and waits for it to be Ready.

It builds SolAr from source rather than reusing the ghcr images, because `dev-cluster.sh` is wired for local images and adding a ghcr values + pull-secret path just for a smoke test wasnt worth it.

## Gating

The demo is heavy (builds the images + full cluster), so it follows the same opt-in pattern as docker/helm/e2e:

- on PRs -> only runs when the `ok-to-demo` label is set
- on `main` -> runs automatically, but only when demo-relevant files change

## Testing

- `actionlint` clean on the workflow.
- The full flow (`make demo` -> running workload) is verified locally end to end in #734.
- Self-validating: this PR carries `ok-to-demo`, so the smoke job runs on it (an earlier revision without the label gating already passed green in CI).

## Checklist

- [x] Tests added/updated (this *is* the test, a CI smoke check)
- [x] No breaking changes (new workflow only)
- [x] Readable commit history (one focused commit)
- [x] AI code review considered and comments resolved

Part of #644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated demo validation for relevant changes.
  * Demo checks verify that required demo pods reach a ready state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->