### PR TITLE
chore(dev): drop the unused OCM vars from dev-cluster.sh

### DIFF
--- a/hack/dev-cluster.sh
+++ b/hack/dev-cluster.sh
@@ -8,9 +8,7 @@ TAG="${TAG:-latest}"
 
 FLUX="${FLUX:-flux}"
 HELM="${HELM:-helm}"
-OCM_DEMO_DIR="${OCM_DEMO_DIR:-$(pwd)/test/fixtures/ocm-demo-ctf}"
 KUBECTL="${KUBECTL:-kubectl}"
-OCM="${OCM:-ocm}"
 YQ="${YQ:-yq}"
 
 # Versions are exported by the Makefile; fail fast with a clear message when run standalone.


### PR DESCRIPTION
## What

Remove the now-unused `OCM_DEMO_DIR` and `OCM` variables from `hack/dev-cluster.sh`.

## Why

#733 moved the OCM transfer into `hack/demo/transfer-discovery.sh`, so `dev-cluster.sh` doesnt run `ocm` anymore. Both variables were left behind as dead declarations.@olzemal spotted `OCM_DEMO_DIR` in a review on #733 -> `OCM` is dead for the same reason, so go away :)

## Testing

```
$ grep -nE '\bOCM\b|OCM_DEMO_DIR' hack/dev-cluster.sh   # nothing left
$ make shellcheck                                        # clean
```

No behavior change, the Makefile never passed these to the script (the `ocm-transfer-demo` target owns `OCM` separately).

## Checklist

- [x] Tests added/updated (n/a, dead-code removal)
- [x] No breaking changes
- [x] Readable commit history (one commit)
- [x] AI code review considered and comments resolved
