### PR TITLE
ci: add renovate auto-approve caller workflow

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,14 @@
+# Auto-approve Renovate digest/patch/minor PRs so they can automerge.
+# Calls the reusable workflow in opendefensecloud/dev-kit. The automerge policy
+# (which update types are eligible) comes from the renovate-config presets.
+name: renovate-auto-approve
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+permissions:
+  pull-requests: write
+jobs:
+  approve:
+    uses: opendefensecloud/dev-kit/.github/workflows/renovate-auto-approve.yml@8cb6197cd7a2f93bc5cf12c689e48df615f1dbde # post-v1.0.13, pin to next release tag once cut
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
## What

- adds the renovate auto-approve caller workflow -> calls dev-kit's reusable `renovate-auto-approve.yml` (opendefensecloud/dev-kit#25), pinned to `8cb6197` (post-v1.0.13 re-pin to the next release tag once cut, noted in the file)
- created the missing `automerge` label

## Why

The renovate-config presets set `automerge: true` + the `automerge` label on digest/patch/minor PRs, but Renovate cant approve its own PRs, so the required-review gate never clears. This workflow provides that approval for labeled PRs; anything labeled `security` is skipped and an earlier approval revoked

Everything else was already in place, verified via API: "Allow GitHub Actions to approve PRs" enabled, `protect-main` requires 1 approval + `check`/`lint`/`test`/`CodeQL`, `allow_auto_merge` on -> merges stay gated on CI, majors and security updates stay human-gated.

Related: automerge policy (labels, update types, stability window) -> opendefensecloud/renovate-config#14, reusable workflow -> opendefensecloud/dev-kit#25.

## Testing

CI config only, no runnable behavior change
YAML parses clean, `uses:` ref resolves to the merged dev-kit workflow.

## Checklist

- [x] Tests added/updated (not applicable, CI config only)
- [x] No breaking changes
- [x] Readable commit history (squashed and cleaned up as desired)
- [ ] AI code review considered and comments resolved
